### PR TITLE
test deploying master to $web

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 stages:
   - stage: build
     jobs:
-      - job: services-master
+      - job: services_master
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         dependsOn: []
         pool:
@@ -31,7 +31,7 @@ stages:
               cargo test -v --release
             workingDirectory: $(Build.SourcesDirectory)/medicines
             displayName: Run tests
-      - job: services-branch
+      - job: services_branch
         condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
         dependsOn: []
         pool:


### PR DESCRIPTION
If the branch is `master` we want to deploy to the container `$web` as that is the root of the static website on the blob storage. Other branches get deployed to a container named after the branch.