### PR TITLE
Change clickable area of search results

### DIFF
--- a/medicines/web/components/mip/index.tsx
+++ b/medicines/web/components/mip/index.tsx
@@ -63,6 +63,9 @@ const Mip: React.FC = () => {
 
   const handleSearchSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    setSearch(e.currentTarget.value);
+
     if (search.length > 0) {
       const searchResults = await azureSearch(search);
       const results = searchResults.map((doc: IAzureSearchResult) => {

--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -26,12 +26,14 @@ const StyledDrugList = styled.section`
     margin: 0;
   }
 
-  ul {
+  dl,
+  dt,
+  dd {
     list-style: none;
     padding: 0;
   }
 
-  li {
+  article {
     display: flex;
     background-color: ${mhraBlue10};
     padding: ${baseSpace};
@@ -40,21 +42,25 @@ const StyledDrugList = styled.section`
     word-wrap: break-word;
   }
 
-  li p {
+  dl p {
     margin: 0;
     padding: 0;
   }
 
-  li a {
+  dd h3 {
+    margin: 0;
+  }
+
+  dd a {
     color: ${black};
     text-decoration: none;
   }
 
-  li .left {
+  dt.left {
     flex: 0;
   }
 
-  li .left .icon {
+  dt.left .icon {
     background-color: ${mhraBlue80};
     color: ${white};
     font-size: ${h2FontSize};
@@ -64,31 +70,32 @@ const StyledDrugList = styled.section`
     width: 70px;
   }
 
-  li .right {
+  dd.right {
     flex: 1;
-    padding: 0 ${baseFontSize};
+    margin-left: 0;
     min-width: 1%;
+    padding: 0 ${baseFontSize};
     word-wrap: break-word;
   }
 
-  li .right .drug-name {
+  dd.right .drug-name {
     font-size: ${h2FontSize};
     font-weight: bold;
-    padding-bottom: ${tinyPaddingSizeCss};
     min-width: 1%;
+    padding-bottom: ${tinyPaddingSizeCss};
     word-wrap: break-word;
   }
 
-  li .right .metadata {
+  dd.right .metadata {
     font-size: ${baseFontSize};
     min-width: 1%;
     word-wrap: break-word;
   }
 
-  li .right .context {
+  dd.right .context {
     font-size: ${h2FontSize};
-    padding-top: ${largePaddingSizeCss};
     min-width: 1%;
+    padding-top: ${largePaddingSizeCss};
     word-wrap: break-word;
   }
 
@@ -157,19 +164,19 @@ const SearchResults = (props: { drugs: IDocument[]; lastSearch: string }) => (
         information may be available at the {emaWebsiteLink()} website.
       </p>
     </div>
-    <ul>
+    <dl>
       {props.drugs.length > 0 &&
         props.drugs.map((drug, i) => (
-          <li key={i}>
-            <div className="left">
+          <article key={i}>
+            <dt className="left">
               <p className="icon">{drug.docType.toUpperCase()}</p>
-            </div>
-            <div className="right">
-              <p className="drug-name">
+            </dt>
+            <dd className="right">
+              <h3 className="drug-name">
                 <a href={drug.url}>
                   {drug.name} ({drug.fileSize} KB)
                 </a>
-              </p>
+              </h3>
               <p className="metadata">Last updated: {drug.lastUpdated}</p>
               {drug.docType !== 'Par' && (
                 <p className="metadata">
@@ -185,10 +192,10 @@ const SearchResults = (props: { drugs: IDocument[]; lastSearch: string }) => (
                   __html: normalizeDescription(drug.context),
                 }}
               />
-            </div>
-          </li>
+            </dd>
+          </article>
         ))}
-    </ul>
+    </dl>
   </StyledDrugList>
 );
 

--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -165,26 +165,26 @@ const SearchResults = (props: { drugs: IDocument[]; lastSearch: string }) => (
               <p className="icon">{drug.docType.toUpperCase()}</p>
             </div>
             <div className="right">
-              <a href={drug.url}>
-                <p className="drug-name">
+              <p className="drug-name">
+                <a href={drug.url}>
                   {drug.name} ({drug.fileSize} KB)
+                </a>
+              </p>
+              <p className="metadata">Last updated: {drug.lastUpdated}</p>
+              {drug.docType !== 'Par' && (
+                <p className="metadata">
+                  Active substances:{' '}
+                  {drug.activeSubstances
+                    .map(substance => toSentenceCase(substance))
+                    .join(', ')}
                 </p>
-                <p className="metadata">Last updated: {drug.lastUpdated}</p>
-                {drug.docType !== 'Par' && (
-                  <p className="metadata">
-                    Active substances:{' '}
-                    {drug.activeSubstances
-                      .map(substance => toSentenceCase(substance))
-                      .join(', ')}
-                  </p>
-                )}
-                <p
-                  className="context"
-                  dangerouslySetInnerHTML={{
-                    __html: normalizeDescription(drug.context),
-                  }}
-                />
-              </a>
+              )}
+              <p
+                className="context"
+                dangerouslySetInnerHTML={{
+                  __html: normalizeDescription(drug.context),
+                }}
+              />
             </div>
           </li>
         ))}


### PR DESCRIPTION
### Link to Github issue

resolves #34 

![](https://i.gifer.com/PdvL.gif)

### Acceptance Criteria

- [x] Only the title of search results should take you to the document.

### Testing information

1. Navigate to the website.
2. Perform a valid search which returns results (`ibuprofen` for example).
3. Clicking on the title (or file size) should load the document, clicking anywhere else should not.

### Pre-merge Checklist

- [ ] Branch test approved