### PR TITLE
Modify format for Created dates in search results

### DIFF
--- a/medicines/web/components/mip/index.tsx
+++ b/medicines/web/components/mip/index.tsx
@@ -88,8 +88,8 @@ const Mip: React.FC = () => {
         fileSize: Math.ceil(
           doc.metadata_storage_size ? doc.metadata_storage_size : 0 / 1000,
         ).toLocaleString('en-GB'),
-        lastUpdated: doc.created
-          ? moment(doc.created).format('Do MMM YYYY')
+        created: doc.created
+          ? moment(doc.created).format('DD MMMM YYYY')
           : 'Unknown',
         name: sanitizeTitle(doc.title),
         url: doc.metadata_storage_path,

--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -110,7 +110,7 @@ export interface IDocument {
   context: string;
   docType: string;
   fileSize: string;
-  lastUpdated: string;
+  created: string;
   name: string;
   url: string;
 }
@@ -183,7 +183,7 @@ const SearchResults = (props: {
                   {drug.name} ({drug.fileSize} KB)
                 </a>
               </h3>
-              <p className="metadata">Last updated: {drug.lastUpdated}</p>
+              <p className="metadata">Created: {drug.created}</p>
               {drug.docType !== 'Par' && (
                 <p className="metadata">
                   Active substances:{' '}


### PR DESCRIPTION
### Ticket

Resolves #40 - Last updated dates in the search results should not contain "nth"

![](https://media.giphy.com/media/efc3KnJEVmox2/giphy.gif)

### Acceptance Criteria

- [x] The date should now show as 'Created', not 'Last Updated';
- [x] The date should no longer have 'th', 'nd', or 'st' after the day;
- [x] The date should now be formatted to show the full name of the month.

### Testing information

1. Perform a search on the site;
2. Check the date after each document result.

### Pre-merge Checklist

- [x] Branch test approved
