### PR TITLE
Escape AND, OR, and NOT in search (these are being treated as operands).

### DIFF
--- a/medicines/web/components/mip/azure-search.ts
+++ b/medicines/web/components/mip/azure-search.ts
@@ -32,7 +32,7 @@ export interface IAzureSearchResult {
 }
 
 const escapeSpecialCharacters = (word: string): string =>
-  word.replace(/([+\-!(){}\[\]^~*?:\/]|\|\||&&)/gi, `\\$1`);
+  word.replace(/([+\-!(){}\[\]^~*?:\/]|\|\||&&|AND|OR|NOT)/gi, `\\$1`);
 
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
   `${word}~${azureSearchWordFuzziness} ${word}^${azureSearchExactnessBoost}`;


### PR DESCRIPTION
### Ticket

Resolves #41 - Copy/pasting some search terms into the search box results in 400 Error

![](https://media1.giphy.com/media/M90fN81I1NyH6nwd8c/giphy.gif?cid=790b7611e8992cdb92bb5c8c7d02385b794978d63cfaa3be&rid=giphy.gif)

### Acceptance Criteria

- [x] Searching for a term including the word `AND`, `OR`, or `NOT` doesn't return a 400 error from Azure.

### Testing information

1. Navigate to the website;
2. Paste `HYDROCORTISONE 1 BITE AND STING RELIEF CREAM PL 00289/0599 UKPAR TABLE OF CONTENTS` into the Search box;
3. When performing a search, you should get results.

### Pre-merge Checklist

- [ ] Branch test approved
