### PR TITLE
trim search term

### DIFF
--- a/medicines/web/components/mip/index.tsx
+++ b/medicines/web/components/mip/index.tsx
@@ -127,7 +127,7 @@ const Mip: React.FC = () => {
   const rerouteSearchResults = (pageNo: number) => {
     router.push({
       pathname: router.route,
-      query: { search, page: pageNo },
+      query: { search: search.trim(), page: pageNo },
     });
   };
 

--- a/medicines/web/components/mip/index.tsx
+++ b/medicines/web/components/mip/index.tsx
@@ -134,13 +134,14 @@ const Mip: React.FC = () => {
   useEffect(() => {
     if (searchTerm && page) {
       if (typeof searchTerm === 'string') {
-        setSearch(searchTerm);
+        const trimmedTerm = searchTerm.trim();
+        setSearch(trimmedTerm);
         let parsedPage = Number(page);
         if (!parsedPage || parsedPage < 1) {
           parsedPage = 1;
         }
         setPageNumber(parsedPage);
-        fetchSearchResults(searchTerm, parsedPage);
+        fetchSearchResults(trimmedTerm, parsedPage);
       }
     } else if (substance) {
       if (typeof substance === 'string') {


### PR DESCRIPTION
Fixes a bug that could send an untrimmed string to the search engine, resulting in a bad request. If a user starts or ends their search with whitespace, it will now get trimmed.