### PR TITLE
Moving About copy into copy/about.md

### DIFF
--- a/medicines/web/copy/about.md
+++ b/medicines/web/copy/about.md
@@ -1,0 +1,70 @@
+## About this service
+
+### SPC-PILs
+
+Patient information leaflet (PILs) are found in every medicine pack,
+and provide information on how a medicine should be used safely.
+
+Summaries of Product Characteristics (SPCs) are a description of a
+medicinal product’s properties and the conditions attached to its use.
+A PIL will be based on an SPC.
+
+We publish the most up-to-date information for a medicine according to
+its licence history.
+
+PILs can be updated several times during the product’s lifecycle,so
+the leaflet a patient gets with their medicine could be different to
+the one found here.
+
+We hold data for medicines licensed at a national (UK) level. Some
+medicines are licensed centrally by the European Medicines Agency
+(EMA). For product information on these medicines, [use the EMA website][ema].
+
+Once a marketing authorisation has been cancelled, the product
+information will stay on the website for a year.
+
+Market authorisation holders have 6 months to exhaust stocks after
+they cancel their product. This means the PILs will still be available
+on the website during this period, with an extra 6 months for patients
+who still have the product at home.
+
+If you have any questions or comments on this list of product
+information, please [contact our Customer Services Team][customer services].
+
+### PARs
+
+We make scientific assessment reports called PARs (Public Assessment
+Reports) for new marketing authorisations granted after 30 October 2005.
+
+We also publish PARs for all marketing authorisation applications that
+were refused after 1 April 2019.
+
+PARs are published and edited in accordance with a specific EC
+Directive, 2004/27/EC.
+
+For some medicines licensed at a European level, the PARs are prepared
+by either the European Medicines Agency (EMA) or the responsible
+authority of another EU member state. The PARs for these medicines can
+be found on the following websites:
+
+- [European Medicines Agency (EMA)][ema medicine]
+- [Head of Medicines Agency][head of med]
+
+### Changes to PARs
+
+Subsequent non-safety changes (variations) of clinical significance
+for each marketing authorisation are provided at the end of each PAR
+as separate annexes.
+
+Minor changes to a marketing authorisation, for example, changes in
+pack sizes and minor updates to the product literature, may not be
+represented in the PAR.
+
+We also publish [Safety Public Assessment Reports][spar], which provide
+details of significant safety changes to a marketing authorisation.
+
+[ema]: https://www.ema.europa.eu/en/medicines
+[customer services]: https://www.gov.uk/guidance/contact-mhra#customer-services
+[ema medicine]: https://www.ema.europa.eu/en/medicines/field_ema_web_categories%253Aname_field/Human/ema_group_types/ema_medicine
+[head of med]: http://mri.medagencies.org/Human/
+[spar]: http://www.mhra.gov.uk/safety-public-assessment-reports/index.htm

--- a/medicines/web/pages/about.tsx
+++ b/medicines/web/pages/about.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Page from '../components/page';
 import { mhra70 } from '../styles/colors';

--- a/medicines/web/pages/about.tsx
+++ b/medicines/web/pages/about.tsx
@@ -4,6 +4,9 @@ import Page from '../components/page';
 import { mhra70 } from '../styles/colors';
 import { baseSpace } from '../styles/dimensions';
 
+// @ts-ignore
+import about from '../copy/about.md';
+
 const StyledMain = styled.main`
   padding: ${baseSpace};
   font-size: 19px;
@@ -21,106 +24,7 @@ const StyledMain = styled.main`
 const App: React.FC = () => {
   return (
     <Page title="Products">
-      <StyledMain>
-        <h2>About this service</h2>
-        <h3>SPC-PILs</h3>
-        <p>
-          Patient information leaflet (PILs) are found in every medicine pack,
-          and provide information on how a medicine should be used safely.
-        </p>
-        <p>
-          Summaries of Product Characteristics (SPCs) are a description of a
-          medicinal product’s properties and the conditions attached to its use.
-          A PIL will be based on an SPC.
-        </p>
-        <p>
-          We publish the most up-to-date information for a medicine according to
-          its licence history.
-        </p>
-        <p>
-          PILs can be updated several times during the product’s lifecycle,so
-          the leaflet a patient gets with their medicine could be different to
-          the one found here.
-        </p>
-        <p>
-          We hold data for medicines licensed at a national (UK) level. Some
-          medicines are licensed centrally by the European Medicines Agency
-          (EMA). For product information on these medicines,{' '}
-          <a href="https://www.ema.europa.eu/en/medicines">
-            use the EMA website
-          </a>
-          .
-        </p>
-        <p>
-          Once a marketing authorisation has been cancelled, the product
-          information will stay on the website for a year.
-        </p>
-        <p>
-          Market authorisation holders have 6 months to exhaust stocks after
-          they cancel their product. This means the PILs will still be available
-          on the website during this period, with an extra 6 months for patients
-          who still have the product at home.
-        </p>
-        <p>
-          If you have any questions or comments on this list of product
-          information, please{' '}
-          <a href="https://www.gov.uk/guidance/contact-mhra#customer-services">
-            contact our Customer Services Team
-          </a>
-          .
-        </p>
-        <h3>PARs</h3>
-        <p>
-          We make scientific assessment reports called PARs (Public Assessment
-          Reports) for new marketing authorisations granted after 30 October
-          2005.
-        </p>
-        <p>
-          We also publish PARs for all marketing authorisation applications that
-          were refused after 1 April 2019.
-        </p>
-        <p>
-          PARs are published and edited in accordance with a specific EC
-          Directive, 2004/27/EC.
-        </p>
-        <p>
-          For some medicines licensed at a European level, the PARs are prepared
-          by either the European Medicines Agency (EMA) or the responsible
-          authority of another EU member state. The PARs for these medicines can
-          be found on the following websites:
-        </p>
-        <ul>
-          <li>
-            <a href="https://www.ema.europa.eu/en/medicines/field_ema_web_categories%253Aname_field/Human/ema_group_types/ema_medicine">
-              European Medicines Agency (EMA)
-            </a>
-          </li>
-          <li>
-            <a href="http://mri.medagencies.org/Human/">
-              Head of Medicines Agency
-            </a>
-          </li>
-        </ul>
-        <h3>Changes to PARs</h3>
-        <p>
-          Subsequent non-safety changes (variations) of clinical significance
-          for each marketing authorisation are provided at the end of each PAR
-          as separate annexes.
-        </p>
-        <p>
-          Minor changes to a marketing authorisation, for example, changes in
-          pack sizes and minor updates to the product literature, may not be
-          represented in the PAR.
-        </p>
-        <p>
-          We also publish{' '}
-          <a href="http://www.mhra.gov.uk/safety-public-assessment-reports/index.htm">
-            Safety Public Assessment Reports
-          </a>
-          , which provide details of significant safety changes to a marketing
-          authorisation.
-        </p>
-      </StyledMain>
+      <StyledMain dangerouslySetInnerHTML={{ __html: about }} />
     </Page>
   );
 };


### PR DESCRIPTION
Pure refactor just to keep all the copy-heavy pages' copy as markdown in one place.

Relates to #68 

### Acceptance Criteria

- [ ] About page still available at /about
- [ ] About page copy and display unchanged
