### PR TITLE
Putting the yellowcard back in the main layout for mobile

### DIFF
--- a/medicines/web/components/mip/index.tsx
+++ b/medicines/web/components/mip/index.tsx
@@ -202,6 +202,9 @@ const Mip: React.FC = () => {
             searchTerm={search}
           />
         )}
+        <div className="yellow-card-wrapper">
+          <YellowCard />
+        </div>
       </Main>
     </>
   );


### PR DESCRIPTION
Fixes #87 

![](https://media.giphy.com/media/xl3gdscRgS7W4sEHTz/giphy.gif)

### Acceptance Criteria

- [ ] Yellow card appears at bottom of the page in mobile view
