### PR TITLE
Correcting small typo

### DIFF
--- a/medicines/web/copy/homepage.md
+++ b/medicines/web/copy/homepage.md
@@ -14,7 +14,7 @@ Every medicine pack includes a patient information leaflet (PIL), which provides
 
 PILs are based on the Summaries of Product Characteristics (SPCs) which are a description of a medicinal product’s properties and the conditions attached to its use.
 
-You can use the A-Z list to find an active substance, or search for amedicine.
+You can use the A-Z list to find an active substance, or search for a medicine.
 
 ## PARs
 


### PR DESCRIPTION
### Name of the story

[Airtable ticket](https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recdM8tQUvATrbXg4)


### Acceptance Criteria

- accessibility criteria to 'Use plain English'

### Testing information

There was a space missing between 'a' and 'medicine' on the homepage

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
