### PR TITLE
Making copy match the copy document for about us

### DIFF
--- a/medicines/web/copy/about.md
+++ b/medicines/web/copy/about.md
@@ -7,7 +7,7 @@ and provide information on how a medicine should be used safely.
 
 Summaries of Product Characteristics (SPCs) are a description of a
 medicinal product’s properties and the conditions attached to its use.
-A PIL will be based on a SPC.
+A PIL will be based on an SPC.
 
 We publish the most up-to-date information for a medicine according to
 its licence history. PILs can be updated several times during the product’s lifecycle, so

--- a/medicines/web/copy/about.md
+++ b/medicines/web/copy/about.md
@@ -7,12 +7,10 @@ and provide information on how a medicine should be used safely.
 
 Summaries of Product Characteristics (SPCs) are a description of a
 medicinal product’s properties and the conditions attached to its use.
-A PIL will be based on an SPC.
+A PIL will be based on a SPC.
 
 We publish the most up-to-date information for a medicine according to
-its licence history.
-
-PILs can be updated several times during the product’s lifecycle,so
+its licence history. PILs can be updated several times during the product’s lifecycle, so
 the leaflet a patient gets with their medicine could be different to
 the one found here.
 


### PR DESCRIPTION
2 changes: 
1) Adding a space after the comma for 'so'
2) The sentences 'We publish the most up-to-date...' and 'PILs can be updated several...' should be in the same paragraph

Point 1  addresses this ticket https://github.com/MHRA/products/issues/105

### Name of the story
https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recdM8tQUvATrbXg4


### Acceptance Criteria

- Copy on the website matches to the document

### Testing information

- Use diffchecker.com to compare old and new text quickly

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
