### PR TITLE
One character change for typo

### DIFF
--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -222,7 +222,7 @@ const SearchResults = (props: {
           )}
           <p className="ema-message">
             If the product information you are seeking does not appear below, it
-            is possible that the product holds a central European license and
+            is possible that the product holds a central European licence and
             its information may be available at the {emaWebsiteLink()} website.
           </p>
         </div>


### PR DESCRIPTION
### Name of the story

https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recglYW9k8GB5awI8

### Acceptance Criteria

- The word "licence" should be used across the site not "license". Doing a find all in the repo, this was the only instance.

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
