### PR TITLE
#111 Footer links are absolute

### DIFF
--- a/medicines/web/components/footer/index.tsx
+++ b/medicines/web/components/footer/index.tsx
@@ -57,7 +57,7 @@ const Footer: React.FC = () => (
         <ul>
           <li>
             <p>
-              <Link href="cookies">
+              <Link href="/cookies">
                 <a>Cookie Policy</a>
               </Link>
             </p>
@@ -71,14 +71,14 @@ const Footer: React.FC = () => (
           </li>
           <li>
             <p>
-              <Link href="accessibility">
+              <Link href="/accessibility">
                 <a>Accessibility Statement</a>
               </Link>
             </p>
           </li>
           <li>
             <p>
-              <Link href="about">
+              <Link href="/about">
                 <a>About this service</a>
               </Link>
             </p>


### PR DESCRIPTION
Fixes #111 

![Absolutes](https://media.giphy.com/media/uNgUzhakqXkyI/giphy.gif)

## To Reproduce

1. Go to https://mhraproductsdev.z33.web.core.windows.net
2. Click on the cookies policy in the footer
3. Scroll down to the footer again and click on the about page

### Bug behaviour

This leads to a 404 and the URL displaying is https://mhraproductsdev.z33.web.core.windows.net/cookies/about/

### Fix behaviour

The about page should load and the URL should be https://mhraproductsdev.z33.web.core.windows.net/about/

### Acceptance Criteria

- [ ] The about page should load and the URL should be https://mhraproductsdev.z33.web.core.windows.net/about/

### Testing information

<insert notes for testers that might be helpful>

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
