### PR TITLE
Removing the word central and centrally

### DIFF
--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -221,7 +221,7 @@ const SearchResults = (props: {
           )}
           <p className="ema-message">
             If the product information you are seeking does not appear below, it
-            is possible that the product holds a central European licence and
+            is possible that the product holds an European licence and
             its information may be available at the {emaWebsiteLink()} website.
           </p>
         </div>

--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -221,7 +221,7 @@ const SearchResults = (props: {
           )}
           <p className="ema-message">
             If the product information you are seeking does not appear below, it
-            is possible that the product holds an European licence and
+            is possible that the product holds a European licence and
             its information may be available at the {emaWebsiteLink()} website.
           </p>
         </div>

--- a/medicines/web/copy/about.md
+++ b/medicines/web/copy/about.md
@@ -15,7 +15,7 @@ the leaflet a patient gets with their medicine could be different to
 the one found here.
 
 We hold data for medicines licensed at a national (UK) level. Some
-medicines are licensed centrally by the European Medicines Agency
+medicines are licensed by the European Medicines Agency
 (EMA). For product information on these medicines, [use the EMA website][ema].
 
 Once a marketing authorisation has been cancelled, the product


### PR DESCRIPTION
### Name of the story

https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recglYW9k8GB5awI8

https://github.com/MHRA/products/issues/155 

### Acceptance Criteria
- Word 'license' isn't being used 
- central removed from 'central European agency'
- word 'centrally' removed from the about this service


### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
