### PR TITLE
Resolve Warning

### DIFF
--- a/learning/web/src/components/CookieBanner/index.js
+++ b/learning/web/src/components/CookieBanner/index.js
@@ -63,7 +63,7 @@ const CookieBanner = () => {
   useEffect(() => {
     const showBanner = window.localStorage.getItem(banner)
     showBanner === "false" ? setCookieBanner(false) : setCookieBanner(true)
-  })
+  }, [])
 
   return cookieBanner ? (
     <StyledCookieBanner>


### PR DESCRIPTION
Fix this

> ⚠️  warning  React Hook useEffect contains a call to 'setCookieBanner'. Without a list of
dependencies, this can lead to an infinite chain of updates. To fix this, pass [] as a second argument
to the useEffect Hook  react-hooks/exhaustive-deps