### PR TITLE
Fix display of search results in IE 11. Fixes issue #99.

### DIFF
--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -59,7 +59,7 @@ const StyledDrugList = styled.div`
   }
 
   dt.left {
-    flex: 0;
+    flex: 1;
   }
 
   dt.left .icon {
@@ -73,7 +73,7 @@ const StyledDrugList = styled.div`
   }
 
   dd.right {
-    flex: 1;
+    flex: 12;
     margin-left: 0;
     min-width: 1%;
     padding: 0 ${baseFontSize};
@@ -221,8 +221,8 @@ const SearchResults = (props: {
           )}
           <p className="ema-message">
             If the product information you are seeking does not appear below, it
-            is possible that the product holds a European licence and
-            its information may be available at the {emaWebsiteLink()} website.
+            is possible that the product holds a European licence and its
+            information may be available at the {emaWebsiteLink()} website.
           </p>
           <p>
             Before a medicine can be sold in the UK, a number of licenses are


### PR DESCRIPTION
### Fix display of search results in IE 11

Fixes https://github.com/MHRA/products/issues/99

![giphy-9](https://user-images.githubusercontent.com/76330/70989014-c5a2ad00-20ba-11ea-8603-1876b70ce430.gif)

### Acceptance Criteria

- [ ] Search results are laid out in IE 11 similarly to how they're laid out in other modern browsers.

### Testing information

<insert notes for testers that might be helpful>

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
