### PR TITLE
Resize Yellow Card image in IE 11

### DIFF
--- a/medicines/web/components/yellow-card/index.tsx
+++ b/medicines/web/components/yellow-card/index.tsx
@@ -25,6 +25,9 @@ const StyledYellowCard = styled.section`
   header {
     padding: 1rem;
     background-color: ${mhraYellow};
+    svg {
+      height: 31px;
+    }
   }
 
   div.action-bar {


### PR DESCRIPTION
### Resize Yellow Card image in IE 11

#### Before

![Screenshot 2019-12-17 at 16 45 56](https://user-images.githubusercontent.com/76330/71016339-ef74c780-20ec-11ea-8508-514bf2990d7d.png)

#### After

![Screenshot 2019-12-17 at 16 45 46](https://user-images.githubusercontent.com/76330/71016359-f7cd0280-20ec-11ea-8ee1-de534a54cdee.png)
