### PR TITLE
Fix link to Cookie Policy page in Medicines

### DIFF
--- a/medicines/web/components/cookie-policy/index.tsx
+++ b/medicines/web/components/cookie-policy/index.tsx
@@ -73,7 +73,7 @@ const CookieBanner: React.FC = () => {
           use Google Analytics cookies to help us improve our services. We do
           not collect any data that would identify you directly. To know more
           about our policies, please go to our&nbsp;
-          <Link href="cookies">
+          <Link href="/cookies">
             <a>cookie policy page</a>
           </Link>
           .&nbsp;By continuing to use this site, you agree to our use of


### PR DESCRIPTION
### Fix link to Cookie Policy page in Medicines

Fixes #240

![dog want cookie](https://media.giphy.com/media/l3nWl5bhBoim7glNu/giphy.gif)

This fixes a bug where clicking on 'cookie policy' in the cookie banner while already on the cookie policy page would send you to /cookies/cookies and 404.

### Acceptance Criteria

- [ ] clicking on 'cookie policy' in the cookie banner while on the cookie policy page should remain on the same page

### Testing information

This only affects Medicines. Learning already works as expected.

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
