### PR TITLE
Fix doc-type classes so they appear for PARs, not just PILs and SPCs.

### DIFF
--- a/medicines/web/components/search-results/index.tsx
+++ b/medicines/web/components/search-results/index.tsx
@@ -266,19 +266,19 @@ const SearchResults = (props: {
                     <p className="icon">{drug.docType.toUpperCase()}</p>
                   </dt>
                   <dd className="right">
-                    {drug.product != null ? (
-                      <a
-                        href={drug.url}
-                        className={'doc-type-' + drug.docType.toLowerCase()}
-                      >
-                        <p className="title">{drug.product}</p>
-                        <p className="subtitle">{drug.name}</p>
-                      </a>
-                    ) : (
-                      <a href={drug.url}>
+                    <a
+                      href={drug.url}
+                      className={'doc-type-' + drug.docType.toLowerCase()}
+                    >
+                      {drug.product != null ? (
+                        <>
+                          <p className="title">{drug.product}</p>
+                          <p className="subtitle">{drug.name}</p>
+                        </>
+                      ) : (
                         <p className="title">{drug.name}</p>
-                      </a>
-                    )}
+                      )}
+                    </a>
                     <p className="metadata">File size: {drug.fileSize} KB</p>
                     {drug.activeSubstances != null &&
                       drug.activeSubstances.length > 0 && (


### PR DESCRIPTION
### Fix doc-type classes so they appear for PARs, not just PILs and SPCs.

[Airtable ticket](https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recAuj9vaFtvF57ke?blocks=hide)

![giphy-13](https://user-images.githubusercontent.com/76330/71264383-e6c60080-233b-11ea-9915-37c992970741.gif)

### Acceptance Criteria

- [ ] A link to a PIL document should always have an HTML class to distinguish it.
- [ ] A link to a SPC document should always have an HTML class to distinguish it.
- [ ] A link to a PAR document should always have an HTML class to distinguish it.

### Testing information

<insert notes for testers that might be helpful>

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
