### PR TITLE
Convert sitemap-generator to TypeScript

### DIFF
--- a/medicines/web/package.json
+++ b/medicines/web/package.json
@@ -62,7 +62,7 @@
     "lint": "yarn tslint",
     "start": "next start",
     "export": "next export -o dist && yarn sitemap",
-    "sitemap": "node ./tools/sitemap-generator.js"
+    "sitemap": "ts-node --project tools/tsconfig.json tools/sitemap-generator.ts"
   },
   "version": "1.0.0"
 }

--- a/medicines/web/tools/sitemap-generator.ts
+++ b/medicines/web/tools/sitemap-generator.ts
@@ -74,4 +74,4 @@ if (!module.parent) {
   );
 }
 
-module.exports = start;
+export default start;

--- a/medicines/web/tools/sitemap-generator.ts
+++ b/medicines/web/tools/sitemap-generator.ts
@@ -1,7 +1,6 @@
-const fs = require('fs').promises;
-const { readdirSync } = require('fs');
-const path = require('path');
-const moment = require('moment');
+import fs, { promises, readdirSync } from 'fs';
+import moment from 'moment';
+import path from 'path';
 
 const pagesDir = path.resolve('./dist');
 const sitemapFile = path.resolve('./dist/sitemap.xml');
@@ -11,7 +10,7 @@ const BASE_URL = 'https://products.mhra.gov.uk';
 const YYY_MM_DD = 'YYYY-MM-DD';
 const CHANGE_FREQUENCY = 'daily';
 
-const createPathsObj = async () => {
+const createPathsObj = async (): Promise<{ [index: string]: any }> => {
   const pages = readdirSync(pagesDir, {
     withFileTypes: true,
   })
@@ -21,13 +20,13 @@ const createPathsObj = async () => {
     .map(dir => (dir === 'index' ? '/' : `/${dir}`));
 
   return pages.reduce(
-    (acc, pageRoute) =>
-      Object.assign(acc, {
-        [`${pageRoute}`]: {
-          page: pageRoute,
-          lastModified: new Date().toISOString(),
-        },
-      }),
+    (acc, pageRoute) => ({
+      ...acc,
+      [`${pageRoute}`]: {
+        page: pageRoute,
+        lastModified: new Date().toISOString(),
+      },
+    }),
     {},
   );
 };
@@ -65,12 +64,14 @@ Sitemap: ${BASE_URL}/sitemap.xml
 
 const start = async () => {
   const sitemapXml = await createSiteMapString();
-  await fs.writeFile(sitemapFile, sitemapXml);
-  await fs.writeFile(robotsFile, robotString);
+  await fs.writeFileSync(sitemapFile, sitemapXml);
+  await fs.writeFileSync(robotsFile, robotString);
 };
 
 if (!module.parent) {
-  start().then(() => console.log('Created sitemap.xml 🗺  & robots.txt 🤖'));
+  start().then(() =>
+    process.stdout.write('Created sitemap.xml 🗺  & robots.txt 🤖\n'),
+  );
 }
 
 module.exports = start;

--- a/medicines/web/tools/tsconfig.json
+++ b/medicines/web/tools/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
### Convert sitemap-generator to TypeScript

[Airtable ticket](https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/rec7a9scPFk8V1EYm)

![giphy-14](https://user-images.githubusercontent.com/76330/71893597-0cc51080-3144-11ea-89f9-91a333a3f1cd.gif)

Required change so that sitemap can be expanded to include product and substance pages.