### PR TITLE
API Pod - Create a Kubernetes Pod for the API

### DIFF
--- a/medicines/api/infrastructure/README.md
+++ b/medicines/api/infrastructure/README.md
@@ -1,0 +1,41 @@
+# Setting up the API
+
+Here's how to set up the API.
+
+## Setting up the Kubernetes pod
+
+Given you've followed the [instructions to connect to a kubernetes cluster](https://github.com/MHRA/products/blob/master/infrastructure/README.md#connecting-to-a-kubernetes-cluster), you can create a kubernetes pod for the API.
+
+1. Source your chosen environment, e.g. for _non-prod_:
+
+```sh
+source ../../../infrastructure/non-prod/.env
+```
+
+2. Deploy the kubernetes pod for your chosen environment, e.g. _non-prod_:
+
+```sh
+kubectl apply -f ./non-prod/deployment.yml
+```
+
+3. See the pods running
+
+```sh
+kubectl get pods
+```
+
+This should return something like:
+
+> ```sh
+> NAME                   READY   STATUS             RESTARTS   AGE
+> api-7f68d6cb99-lm262   0/1     ErrImagePull       0          12s
+> api-7f68d6cb99-vsqkj   0/1     ImagePullBackOff   0          12s
+> ```
+
+### Cleanup
+
+If you want to remove the API pod from the kubernetes cluster, you can do so easily by running the `kubectl delete` command.
+
+```sh
+kubectl delete deployment api
+```

--- a/medicines/api/infrastructure/non-prod/deployment.yml
+++ b/medicines/api/infrastructure/non-prod/deployment.yml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generation: 1
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - image: api
+          name: api
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "50m"
+            limits:
+              memory: "400Mi"
+              cpu: "100m"


### PR DESCRIPTION
#API Pod - Create a Kubernetes Pod for the API

[Airtable ticket](https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recnmqht8YQhVjOLF?blocks=hide)

![](https://media.giphy.com/media/GSxIsqgnfrEFW/giphy.gif)

## Acceptance Criteria

- [ ] Kubernetes cluster has an empty pod in it ready to be used for the API server
- [ ] Manifest is in repo as a .yml file

## Testing information

### Setting up the Kubernetes pod

Given you've followed the [instructions to connect to a kubernetes cluster](https://github.com/MHRA/products/blob/master/infrastructure/README.md#connecting-to-a-kubernetes-cluster), you can create a kubernetes pod for the API.

1. Source your chosen environment, e.g. for _non-prod_:

```sh
source ../../../infrastructure/non-prod/.env
```

2. Deploy the kubernetes pod for your chosen environment, e.g. _non-prod_:

```sh
kubectl apply -f ./non-prod/deployment.yml
```

3. See the pods running

```sh
kubectl get pods
```

This should return something like:

> ```sh
> NAME                   READY   STATUS             RESTARTS   AGE
> api-7f68d6cb99-lm262   0/1     ErrImagePull       0          12s
> api-7f68d6cb99-vsqkj   0/1     ImagePullBackOff   0          12s
> ```


### Pre-flight Checklist
~Tests~
~DUXD review approval~
~Accessibility Reviewed~
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
