### PR TITLE
Match all keywords in Search

### DIFF
--- a/medicines/web/cypress/integration/tests.js
+++ b/medicines/web/cypress/integration/tests.js
@@ -16,7 +16,7 @@ before(() => {
   });
 });
 
-Cypress.on('window:before:load', (win) => {
+Cypress.on('window:before:load', win => {
   delete win.fetch;
   // since the application code does not ship with a polyfill
   // load a polyfilled "fetch" from the test
@@ -25,19 +25,19 @@ Cypress.on('window:before:load', (win) => {
 
   // Clear out session storage so that the disclaimer is always presented.
   win.sessionStorage.clear();
-})
+});
 
 describe('Search', function() {
   it('Search for Paracetamol', function() {
     cy.server();
     // Mock out first page of search results.
     cy.route(
-      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=0&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords',
+      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=0&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords&searchMode=all',
       'fixture:search_results.json',
     );
     // Mock out second page of search results.
     cy.route(
-      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=10&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords',
+      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=10&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords&searchMode=all',
       'fixture:search_results.json',
     );
 
@@ -56,17 +56,17 @@ describe('A-Z Index', function() {
     cy.server();
     // Mock out list of substances and medcines.
     cy.route(
-      "https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&facet=facets,count:50000,sort:value&$filter=facets/any(f:+f+eq+'P')&$top=0",
+      "https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&facet=facets,count:50000,sort:value&$filter=facets/any(f:+f+eq+'P')&$top=0&searchMode=all",
       'fixture:facets.json',
     );
     // Mock out first page of search results.
     cy.route(
-      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=0&search=PARACETAMOL~1+PARACETAMOL^4+TABLETS~1+TABLETS^4&scoringProfile=preferKeywords',
+      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=0&search=PARACETAMOL~1+PARACETAMOL^4+TABLETS~1+TABLETS^4&scoringProfile=preferKeywords&searchMode=all',
       'fixture:search_results.json',
     );
     // Mock out second page of search results.
     cy.route(
-      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=10&search=PARACETAMOL~1+PARACETAMOL^4+TABLETS~1+TABLETS^4&scoringProfile=preferKeywords',
+      'https://mhraproductsdev.search.windows.net/indexes/products-index/docs?api-key=CFBCBE8AA11AA871C14001527533870C&api-version=2017-11-11&highlight=content&queryType=full&$count=true&$top=10&$skip=10&search=PARACETAMOL~1+PARACETAMOL^4+TABLETS~1+TABLETS^4&scoringProfile=preferKeywords&searchMode=all',
       'fixture:search_results.json',
     );
 

--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -42,8 +42,8 @@ const extractProductLicenseRegExp: RegExp = new RegExp(
   'ig',
 );
 
-const escapeSpecialCharacters = (word: string): string =>
-  word.replace(/([+\-!(){}\[\]^~*?:\/]|\|\||&&|AND|OR|NOT)/gi, `\\$1`);
+const escapeSpecialWords = (word: string): string =>
+  word.replace(/(\|\||&&|\bAND\b|\bOR\b|\bNOT\b)/gi, `\\$1`);
 
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
   `${word}~${searchWordFuzziness} ${word}^${searchExactnessBoost}`;
@@ -63,10 +63,12 @@ const addNormalizedProductLicenses = (q: string): string => {
   return `${q}`;
 };
 
+const splitByNonSearchableCharacters = (query: string) =>
+  query.split(/(?:[,+\-!(){}\[\]^~*?:\/]|\s+)/gi);
+
 const buildFuzzyQuery = (query: string): string => {
-  return addNormalizedProductLicenses(query)
-    .split(' ')
-    .map(word => escapeSpecialCharacters(word))
+  return splitByNonSearchableCharacters(addNormalizedProductLicenses(query))
+    .map(word => escapeSpecialWords(word))
     .map(word => preferExactMatchButSupportFuzzyMatch(word))
     .join(' ');
 };

--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -95,6 +95,7 @@ const buildSearchUrl = (
   );
   url.searchParams.append('search', query);
   url.searchParams.append('scoringProfile', searchScoringProfile as string);
+  url.searchParams.append('searchMode', 'all');
 
   return url.toString();
 };
@@ -113,6 +114,7 @@ const buildFacetUrl = (query: string): string => {
   url.searchParams.append('facet', 'facets,count:50000,sort:value');
   url.searchParams.append('$filter', `facets/any(f: f eq '${query}')`);
   url.searchParams.append('$top', '0');
+  url.searchParams.append('searchMode', 'all');
 
   return url.toString();
 };


### PR DESCRIPTION
### Match all keywords in Search

[Airtable ticket](https://airtable.com/tbl7CISHKkr8Kdeh2/viwlDIU6cp8cbQYhj/recpQdqgtr4yFlDOH)

![All or nothing](https://media.giphy.com/media/Vxb78fJCMYD16/giphy.gif)

### Acceptance Criteria

- [ ] Adding more keywords to the search refines the search, so fewer results are returned
- [ ] Results relate to all keywords given
- [ ] ~Partial word matches still bring back results, e.g  like `ibup` matches `ibuprofen`~. We thought that we wanted to preserve a behaviour where `ibup` matched results for `ibuprofren`, however this does not look like current behaviour. Currently, partial words bring back far fewer results than the full words.

### Testing information

<insert notes for testers that might be helpful>

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
