### PR TITLE
API runs on port 8000 by default

### DIFF
--- a/medicines/api/README.md
+++ b/medicines/api/README.md
@@ -25,10 +25,10 @@ You should also have installed:
 
 1. Navigate to this directory, `/medicines/api`
 2. Run `cargo run`
-3. Once compiled, open a browser tab and go to http://127.0.0.1:8080/healthz
+3. Once compiled, open a browser tab and go to http://127.0.0.1:8000/healthz
 4. You should see **OK** rendered on the page
 
-To see the graphql explorer, go to http://127.0.0.1:8080/graphiql.
+To see the graphql explorer, go to http://127.0.0.1:8000/graphiql.
 
 ## Running in Docker container 🐳
 


### PR DESCRIPTION
Quick correction—default port is 8000, not 8080.