### PR TITLE
#302 Fixing trailing character search error

### DIFF
--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -68,6 +68,7 @@ const splitByNonSearchableCharacters = (query: string) =>
 
 const buildFuzzyQuery = (query: string): string => {
   return splitByNonSearchableCharacters(addNormalizedProductLicenses(query))
+    .filter(x => x.length > 0)
     .map(word => escapeSpecialWords(word))
     .map(word => preferExactMatchButSupportFuzzyMatch(word))
     .join(' ');


### PR DESCRIPTION
### Fixing trailing character search error

Fixed #302

### Acceptance Criteria

- [ ] #302 is fixed
- [ ] Searching for `ibuprofen^` gets the same results as searching for `ibuprofen`

### Testing information

<insert notes for testers that might be helpful>

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
