### PR TITLE
Kubernetes deployments for stub api

### DIFF
--- a/medicines/document-manager/README.md
+++ b/medicines/document-manager/README.md
@@ -9,6 +9,7 @@ the Products website.
 ## To-Do
 
 - [x] Dockerize stub API;
+- [ ] Remove Helm dependencies;
 - [ ] Implement functioning API with XML support;
 - [ ] Implement functioning API with JSON support;
 - [ ] Connect APIs to pub/sub;

--- a/medicines/document-manager/stub-api/manifests/cert.yaml
+++ b/medicines/document-manager/stub-api/manifests/cert.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: tls
+spec:
+  secretName: tls
+  dnsNames:
+    - $PUBLIC_URL
+  acme:
+    config:
+      - http01:
+          ingressClass: nginx
+        domains:
+          - $PUBLIC_URL
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/medicines/document-manager/stub-api/manifests/cluster-issuer.yaml
+++ b/medicines/document-manager/stub-api/manifests/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: $SSL_EMAIL
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/medicines/document-manager/stub-api/manifests/deployment.yaml
+++ b/medicines/document-manager/stub-api/manifests/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: document
+  labels:
+    app: document
+spec:
+  replicas: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: document
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: document
+        tier: frontend
+    spec:
+      containers:
+        - image: $STUB_IMAGE
+          name: document
+          ports:
+            - containerPort: 8080
+              name: web

--- a/medicines/document-manager/stub-api/manifests/ingress.yaml
+++ b/medicines/document-manager/stub-api/manifests/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: stub-api-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+    - hosts:
+        - $PUBLIC_URL
+      secretName: tls
+  rules:
+    - host: $PUBLIC_URL
+      http:
+        paths:
+          - backend:
+              serviceName: document-stub
+              servicePort: 8080
+            path: /(.*)

--- a/medicines/document-manager/stub-api/manifests/svc.yaml
+++ b/medicines/document-manager/stub-api/manifests/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: document-stub
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  labels:
+    app: document
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: document
+    tier: frontend
+  type: LoadBalancer

--- a/medicines/document-manager/stub-api/stub.pl
+++ b/medicines/document-manager/stub-api/stub.pl
@@ -56,7 +56,7 @@ post '/documents' => sub {
         }
     );
 
-    my @expected_fields = ('id', 'name', 'type', 'author', 'product_name', 'keywords', 'pl_number', 'active_substances', 'file_source', 'file_path');
+    my @expected_fields = ('id', 'name', 'type', 'author', 'product_name', 'pl_number', 'active_substances', 'file_source', 'file_path');
 
     for my $expected_field (@expected_fields) {
         if (!defined($document->{$expected_field})) {


### PR DESCRIPTION
### Name of the story

These are changes from the morning automatic batch catch-up with Dilu.

### Acceptance Criteria

- [x] Can now deploy stub API to Kubernetes;
- [x] Ingress is set up for stub API;
- [x] LetsEncrypt is set up for stub API.

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved
