### PR TITLE
DataLayer: previousEvent and pageCategory

### DIFF
--- a/medicines/web/src/services/events.ts
+++ b/medicines/web/src/services/events.ts
@@ -4,6 +4,12 @@ const pushToDataLayer = (dataLayer: any) => {
   TagManager.dataLayer({
     dataLayer,
   });
+  TagManager.dataLayer({
+    dataLayer: {
+      previousEvent: dataLayer.event,
+      pageCategory: dataLayer.event,
+    },
+  });
 };
 
 export default {

--- a/medicines/web/src/services/events.ts
+++ b/medicines/web/src/services/events.ts
@@ -4,10 +4,14 @@ const pushToDataLayer = (dataLayer: any) => {
   TagManager.dataLayer({
     dataLayer,
   });
+  recordHistoryForNextEvent(dataLayer.event);
+};
+
+const recordHistoryForNextEvent = (event: string) => {
   TagManager.dataLayer({
     dataLayer: {
-      previousEvent: dataLayer.event,
-      pageCategory: dataLayer.event,
+      previousEvent: event,
+      pageCategory: event,
     },
   });
 };


### PR DESCRIPTION
### Missing data in dataLayer

Fixes #423.

![Data!](https://media.giphy.com/media/rIq6ASPIqo2k0/giphy.gif)

### Acceptance Criteria

- [ ] `pageCategory` is set to indicate page before event is triggered

### Testing information

By accessing [tagmangager.google.com][GTM], you can use the Preview/Debug mode to see what data is in the `dataLayer`.

### Pre-flight Checklist

- [ ] Tests
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[GTM]: https://tagmangager.google.com