### PR TITLE
Add basic auth to stub api

### DIFF
--- a/medicines/document-manager/stub-api/Dockerfile
+++ b/medicines/document-manager/stub-api/Dockerfile
@@ -7,4 +7,8 @@ RUN cpanm Carton
 run carton install
 
 EXPOSE 8080
+
+ENV STUB_USERNAME username
+ENV STUB_PASSWORD password
+
 CMD ["carton", "exec", "plackup", "-s", "Starman", "-p", "8080", "--workers", "1", "-a", "stub.pl"]

--- a/medicines/document-manager/stub-api/README.md
+++ b/medicines/document-manager/stub-api/README.md
@@ -97,8 +97,7 @@ Sample response:
 
 ### DELETE /documents/:document
 
-Sends a delete request for :document. Sample documents are con10101010,
-con20202020, con30303030, con40404040, and con50505050.
+Sends a delete request for :document.
 
 A 202 with a job_id will be returned on success, and a 404 if
 the requested document does not exist.

--- a/medicines/document-manager/stub-api/README.md
+++ b/medicines/document-manager/stub-api/README.md
@@ -11,7 +11,7 @@ The intended usage pattern is as follows:
 
 - Send a DELETE or POST request for a document;
 - Continue to poll the GET endpoint for that document until the status has
-updated.
+  updated.
 
 In the background, the real API will asynchronously process the request and
 update the status of the document as it progresses.
@@ -19,7 +19,7 @@ update the status of the document as it progresses.
 ## Running
 
 ```
-$ docker build -t stub-document-manager-api 
+$ docker build -t stub-document-manager-api
 $ docker run -p 8080:8080 -it --rm stub-document-manager-api
 ```
 
@@ -52,7 +52,7 @@ Then you need to build the Docker image and push it to your container registry:
 ```bash
 $ export STUB_IMAGE=container-registry.yourdomain.com/stub-api:1.0.1
 
-$ docker build -t $STUB_IMAGE
+$ docker build -t $STUB_IMAGE .
 $ docker push $STUB_IMAGE
 ```
 
@@ -61,6 +61,8 @@ There are Kubernetes manifests in the `manifests` directory. You can apply these
 ```bash
 $ export PUBLIC_URL=yourdomain.com
 $ export SSL_EMAIL=you@yourdomain.com
+$ export STUB_USERNAME=basic_auth_username
+$ export STUB_PASSWORD=basic_auth_password
 
 $ envsubst < manifests/cluster-issuer.yaml | kubectl apply -f -
 $ envsubst < manifests/cert.yaml | kubectl apply -f -
@@ -68,6 +70,12 @@ $ envsubst < manifests/ingress.yaml | kubectl apply -f -
 $ envsubst < manifests/deployment.yaml | kubectl apply -f -
 $ envsubst < manifests/svc.yaml | kubectl apply -f -
 ```
+
+## Authorization
+
+The stub API implements [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication),
+using the credentials set in the previous step. Any request without a valid `Authorization` header will receive
+a 401 response.
 
 ## Endpoints
 
@@ -89,10 +97,10 @@ Sample response:
 
 ### DELETE /documents/:document
 
-Sends a delete request for :document. Sample documents are con10101010, 
+Sends a delete request for :document. Sample documents are con10101010,
 con20202020, con30303030, con40404040, and con50505050.
 
-A 202 with a job_id will be returned on success, and a 404 if 
+A 202 with a job_id will be returned on success, and a 404 if
 the requested document does not exist.
 
 Sample response:
@@ -133,9 +141,9 @@ This expects an XML body shaped like the following:
 </document>
 ```
 
-It will return a 202 with job_id (and the document will have a 
-status) if the shape is correct, a 422 if there are missing 
-required fields, and a 409 if the ID already exists and is not 
+It will return a 202 with job_id (and the document will have a
+status) if the shape is correct, a 422 if there are missing
+required fields, and a 409 if the ID already exists and is not
 in the deleted state.
 
 Sample response:

--- a/medicines/document-manager/stub-api/cpanfile
+++ b/medicines/document-manager/stub-api/cpanfile
@@ -1,4 +1,5 @@
 requires 'Dancer2', '0.300000';
+requires 'Dancer2::Plugin::Auth::HTTP::Basic::DWIW', '0.07';
 requires 'Dancer2::Serializer::XML', '0.04';
 requires 'JSON', '4.02';
 requires 'Plack', '1.0047';

--- a/medicines/document-manager/stub-api/manifests/deployment.yaml
+++ b/medicines/document-manager/stub-api/manifests/deployment.yaml
@@ -21,6 +21,11 @@ spec:
       containers:
         - image: $STUB_IMAGE
           name: document
+          env:
+            - name: STUB_USERNAME
+              value: $STUB_USERNAME
+            - name: STUB_PASSWORD
+              value: $STUB_PASSWORD
           ports:
             - containerPort: 8080
               name: web

--- a/medicines/document-manager/stub-api/stub.pl
+++ b/medicines/document-manager/stub-api/stub.pl
@@ -19,11 +19,11 @@ http_basic_auth_handler check_login => sub {
 };
 
 get '/jobs/:job' => http_basic_auth required => sub {
+    my $self = shift;
+    $self->{'app'}->{'serializer_engine'}->{'xml_options'}->{'serialize'} = {RootName => 'job', NoAttr => 1};
+
     my $job_id = route_parameters->get('job');
     if (exists($jobs{$job_id})) {
-        my $self = shift;
-        $self->{serializer_engine}->{xml_options}->{serialize} = {RootName => 'job', NoAttr => 1};
-
         my $status = $jobs{$job_id};
         my $resp = dclone $status;
 
@@ -40,12 +40,12 @@ get '/jobs/:job' => http_basic_auth required => sub {
 };
 
 del '/documents/:document' => http_basic_auth required => sub {
+    my $self = shift;
+    $self->{'app'}->{'serializer_engine'}->{'xml_options'}->{'serialize'} = {RootName => 'job', NoAttr => 1};
+
     my $document_id = route_parameters->get('document');
 
     if (exists($documents{$document_id})) {
-        my $self = shift;
-        $self->{serializer_engine}->{xml_options}->{serialize} = {RootName => 'job', NoAttr => 1};
-
         delete($documents{$document_id});
 
         my $job_id = create_uuid_as_string(UUID_V4);
@@ -68,7 +68,7 @@ del '/documents/:document' => http_basic_auth required => sub {
 
 post '/documents' => http_basic_auth required => sub {
     my $self = shift;
-    $self->{serializer_engine}->{xml_options}->{serialize} = {RootName => 'job', NoAttr => 1};
+    $self->{'app'}->{'serializer_engine'}->{'xml_options'}->{'serialize'} = {RootName => 'job', NoAttr => 1};
 
     my $doc = XMLin(
         request->body,
@@ -77,7 +77,7 @@ post '/documents' => http_basic_auth required => sub {
         GroupTags  => {
             keywords          => 'keyword',
             active_substances => 'active_substance',
-            'products'        => 'product'
+            products          => 'product'
         }
     );
 

--- a/medicines/document-manager/stub-api/stub.pl
+++ b/medicines/document-manager/stub-api/stub.pl
@@ -1,13 +1,24 @@
 use Dancer2;
-use XML::Simple qw(:strict);
-use UUID::Tiny ':std';
+use Dancer2::Plugin::Auth::HTTP::Basic::DWIW;
 use Storable 'dclone';
+use UUID::Tiny ':std';
+use XML::Simple qw(:strict);
+
 set serializer => 'XML';
 
 my %documents;
 my %jobs;
 
-get '/jobs/:job' => sub {
+die "You need to set STUB_USERNAME & STUB_PASSWORD in your environment"
+    unless (defined $ENV{'STUB_USERNAME'} && defined $ENV{'STUB_PASSWORD'});
+
+http_basic_auth_handler check_login => sub {
+    my ($user, $pass) = @_;
+
+    return $user eq $ENV{'STUB_USERNAME'} && $pass eq $ENV{'STUB_PASSWORD'};
+};
+
+get '/jobs/:job' => http_basic_auth required => sub {
     my $job_id = route_parameters->get('job');
     if (exists($jobs{$job_id})) {
         my $self = shift;
@@ -28,7 +39,7 @@ get '/jobs/:job' => sub {
     }
 };
 
-del '/documents/:document' => sub {
+del '/documents/:document' => http_basic_auth required => sub {
     my $document_id = route_parameters->get('document');
 
     if (exists($documents{$document_id})) {
@@ -55,7 +66,7 @@ del '/documents/:document' => sub {
     }
 };
 
-post '/documents' => sub {
+post '/documents' => http_basic_auth required => sub {
     my $self = shift;
     $self->{serializer_engine}->{xml_options}->{serialize} = {RootName => 'job', NoAttr => 1};
 


### PR DESCRIPTION
### Name of the story

Resolves #442 

![](https://media.giphy.com/media/xTiIzAjgTOdqUvwRWM/giphy.gif)

### Acceptance Criteria

- [x] The endpoints on the stub API should require Basic auth;
- [x] The auth credentials should be pulled from env;
- [x] The documentation should be updated to explain this requirement.
