### PR TITLE
return 404 if job is not found

### DIFF
--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
 
 fn get_env_or_default(key: &str, default: String) -> String {
     env::var(key).unwrap_or_else(|e| {
-        log::error!("defaulting {} to {} ({})", key, &default, e);
+        log::warn!(r#"defaulting {} to "{}" ({})"#, key, &default, e);
         default.to_string()
     })
 }

--- a/medicines/doc-index-updater/src/state_manager/mod.rs
+++ b/medicines/doc-index-updater/src/state_manager/mod.rs
@@ -48,7 +48,11 @@ pub fn get_job_status(
 }
 
 async fn get_status_handler(id: Uuid, mgr: StateManager) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&mgr.get_status(id).await?))
+    let response = mgr.get_status(id).await?;
+    match response.status {
+        JobStatus::NotFound => Err(warp::reject::not_found()),
+        _ => Ok(warp::reply::json(&response)),
+    }
 }
 
 pub fn set_job_status(

--- a/medicines/doc-index-updater/src/state_manager/mod.rs
+++ b/medicines/doc-index-updater/src/state_manager/mod.rs
@@ -3,8 +3,7 @@ use self::redis::{get_from_redis, set_in_redis, MyRedisError};
 use crate::models::{JobStatus, JobStatusResponse};
 use ::redis::Client;
 use uuid::Uuid;
-use warp::{reply::Json, Filter, Rejection, Reply};
-
+use warp::{http::StatusCode, reply::Json, Filter, Rejection, Reply};
 mod redis;
 
 #[derive(Clone)]
@@ -47,11 +46,12 @@ pub fn get_job_status(
         .and_then(get_status_handler)
 }
 
-async fn get_status_handler(id: Uuid, mgr: StateManager) -> Result<Json, Rejection> {
+async fn get_status_handler(id: Uuid, mgr: StateManager) -> Result<impl Reply, Rejection> {
     let response = mgr.get_status(id).await?;
+    let json = warp::reply::json(&response);
     match response.status {
-        JobStatus::NotFound => Err(warp::reject::not_found()),
-        _ => Ok(warp::reply::json(&response)),
+        JobStatus::NotFound => Ok(warp::reply::with_status(json, StatusCode::NOT_FOUND)),
+        _ => Ok(warp::reply::with_status(json, StatusCode::OK)),
     }
 }
 


### PR DESCRIPTION
Now that we have immediate consistency it makes more sense to return HTTP `404 Not Found`, when there is no job related to the UUID specified in the URL path