### PR TITLE
Redis SET does not give JobStatus return value

### DIFF
--- a/medicines/doc-index-updater/src/state_manager/mod.rs
+++ b/medicines/doc-index-updater/src/state_manager/mod.rs
@@ -88,6 +88,10 @@ async fn set_status_handler(
 ) -> Result<Json, Rejection> {
     mgr.set_status(id, status)
         .await
+        .or_else(|e: MyRedisError| {
+            tracing::error!("{}", e);
+            Err(e)
+        })
         .map_err(Into::into)
         .map(|r| warp::reply::json(&r))
 }

--- a/medicines/doc-index-updater/src/state_manager/redis.rs
+++ b/medicines/doc-index-updater/src/state_manager/redis.rs
@@ -79,7 +79,9 @@ pub async fn set_in_redis(client: Client, id: Uuid, status: JobStatus) -> RedisR
         .arg(id.to_string())
         .arg(status.clone())
         .query_async(&mut con)
-        .await
+        .await?;
+
+    get_from_redis(client, id).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Returning the correct JobStatus value from set_status method

Fixes a bug due to #460.

Redis `SET` responses are not convertable to the enum `JobStatus`. This was throwing an error in the `set_status` method. This broke functionality introduced in #456. 

### Acceptance Criteria

- [ ] Calling `StateManager.set_status` sets the status in Redis
- [ ] Calling `set_status` does not return an error when the status is successfully set
- [ ] Calling `set_status` returns the status in Redis when the status is successfully set
- [ ] Has an end-to-end test to test all of this

### Testing information

Run a local redis server, run the doc-index-updater binary, curl the status setter.

```sh
redis-server&
cargo run&
curl -vvv http://localhost:8000/jobs/5c391785-50bb-42b1-b785-171cd2c77ed2/Accepted -XPOST
```

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
