### PR TITLE
Timlee/stop ga reinitialisation

### DIFF
--- a/medicines/web/src/components/page/index.tsx
+++ b/medicines/web/src/components/page/index.tsx
@@ -1,13 +1,11 @@
 import Head from 'next/head';
-import React, { useEffect, useState } from 'react';
-import ReactGA from 'react-ga';
-import TagManager from 'react-gtm-module';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { Normalize } from 'styled-normalize';
 
+import Events from '../../services/events';
 import { anchorColour, mhra } from '../../styles/colors';
 import { desktopMaxWidth } from '../../styles/dimensions';
-import { useGACookieToTestInitialization } from '../../hooks';
 import CookieBanner from '../cookie-policy';
 import Footer from '../footer';
 import Header from '../header';
@@ -60,20 +58,9 @@ interface IPageProps {
 }
 
 const App: React.FC<IPageProps> = props => {
-  const [trackingInitialized, setTrackingInitialized] = useState(false);
-
   useEffect(() => {
-    console.log('USING EFFECT');
-    if (props.storageAllowed && !trackingInitialized) {
-      console.log('INITIALIZING SCRIPTS');
-      setTrackingInitialized(true);
-      TagManager.initialize({
-        gtmId: process.env.GOOGLE_GTM_CONTAINER_ID as string,
-        dataLayerName: 'dataLayer',
-      });
-      ReactGA.initialize(process.env.GOOGLE_TRACKING_ID as string, {
-        debug: true,
-      });
+    if (props.storageAllowed) {
+      Events.initializeTrackingScripts();
     }
   }, [props.storageAllowed]);
 

--- a/medicines/web/src/components/page/index.tsx
+++ b/medicines/web/src/components/page/index.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactGA from 'react-ga';
 import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
@@ -7,6 +7,7 @@ import { Normalize } from 'styled-normalize';
 
 import { anchorColour, mhra } from '../../styles/colors';
 import { desktopMaxWidth } from '../../styles/dimensions';
+import { useGACookieToTestInitialization } from '../../hooks';
 import CookieBanner from '../cookie-policy';
 import Footer from '../footer';
 import Header from '../header';
@@ -59,8 +60,13 @@ interface IPageProps {
 }
 
 const App: React.FC<IPageProps> = props => {
+  const [trackingInitialized, setTrackingInitialized] = useState(false);
+
   useEffect(() => {
-    if (props.storageAllowed) {
+    console.log('USING EFFECT');
+    if (props.storageAllowed && !trackingInitialized) {
+      console.log('INITIALIZING SCRIPTS');
+      setTrackingInitialized(true);
       TagManager.initialize({
         gtmId: process.env.GOOGLE_GTM_CONTAINER_ID as string,
         dataLayerName: 'dataLayer',

--- a/medicines/web/src/components/search-wrapper/index.tsx
+++ b/medicines/web/src/components/search-wrapper/index.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { FormEvent, useEffect } from 'react';
-import ReactGA from 'react-ga';
 import styled from 'styled-components';
 import { baseSpace, mobileBreakpoint } from '../../styles/dimensions';
 
@@ -76,11 +75,6 @@ const SearchWrapper: React.FC<ISearchWrapperProps> = props => {
     if (search.length > 0) {
       rerouteSearchResults(formattedSearchTerm);
     }
-
-    ReactGA.event({
-      category: 'Search',
-      action: `Searched for '${search}'`,
-    });
   };
 
   const rerouteSearchResults = (searchTerm: string) => {

--- a/medicines/web/src/hooks/index.tsx
+++ b/medicines/web/src/hooks/index.tsx
@@ -1,5 +1,4 @@
-import { useState, Dispatch, SetStateAction } from 'react';
-import Cookies from 'universal-cookie';
+import { useState } from 'react';
 
 // useSessionStorage and useLocalStorage adapted from
 // https://usehooks.com/useLocalStorage/
@@ -78,15 +77,4 @@ This is probably because we can't access the browser window object server-side.`
     }
   };
   return [storedValue, setValue];
-};
-
-export const useGACookieToTestInitialization = (): [
-  boolean,
-  Dispatch<SetStateAction<boolean>>,
-] => {
-  return useState(() => {
-    const cookieContext = new Cookies();
-    const gaValue = cookieContext.get('_ga');
-    return !!gaValue;
-  });
 };

--- a/medicines/web/src/hooks/index.tsx
+++ b/medicines/web/src/hooks/index.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
+import Cookies from 'universal-cookie';
 
 // useSessionStorage and useLocalStorage adapted from
 // https://usehooks.com/useLocalStorage/
@@ -77,4 +78,15 @@ This is probably because we can't access the browser window object server-side.`
     }
   };
   return [storedValue, setValue];
+};
+
+export const useGACookieToTestInitialization = (): [
+  boolean,
+  Dispatch<SetStateAction<boolean>>,
+] => {
+  return useState(() => {
+    const cookieContext = new Cookies();
+    const gaValue = cookieContext.get('_ga');
+    return !!gaValue;
+  });
 };

--- a/medicines/web/src/pages/_app.tsx
+++ b/medicines/web/src/pages/_app.tsx
@@ -1,11 +1,11 @@
 import { default as BaseApp } from 'next/app';
 import Router from 'next/router';
-import ReactGA from 'react-ga';
-import TagManager from 'react-gtm-module';
+
+import Events from '../services/events';
 
 class App extends BaseApp {
   public componentDidMount(): void {
-    Router.events.on('routeChangeComplete', url => ReactGA.pageview(url));
+    Router.events.on('routeChangeComplete', Events.recordPageView);
   }
 }
 

--- a/medicines/web/src/services/events.ts
+++ b/medicines/web/src/services/events.ts
@@ -1,6 +1,13 @@
+import ReactGA from 'react-ga';
 import TagManager from 'react-gtm-module';
 
+let gaInitialized = false;
+
 const pushToDataLayer = (dataLayer: any) => {
+  if (!gaInitialized) {
+    return null;
+  }
+
   TagManager.dataLayer({
     dataLayer,
   });
@@ -13,6 +20,27 @@ const recordHistoryForNextEvent = (event: string) => {
       previousEvent: event,
       pageCategory: event,
     },
+  });
+};
+
+const recordPageView = (url: string) => {
+  if (!gaInitialized) {
+    return null;
+  }
+  ReactGA.pageview(url);
+};
+
+const initializeTrackingScripts = () => {
+  if (gaInitialized) {
+    return null;
+  }
+  gaInitialized = true;
+  TagManager.initialize({
+    gtmId: process.env.GOOGLE_GTM_CONTAINER_ID as string,
+    dataLayerName: 'dataLayer',
+  });
+  ReactGA.initialize(process.env.GOOGLE_TRACKING_ID as string, {
+    debug: true,
   });
 };
 
@@ -29,6 +57,8 @@ interface IProductSearchEvent {
 }
 
 export default {
+  initializeTrackingScripts,
+  recordPageView,
   searchForProductsMatchingKeywords: (searchEvent: ISearchEvent) => {
     pushToDataLayer({
       event: 'search',


### PR DESCRIPTION
# Stop GA and GTM scripts from being initialized for every page navigation

Currently every client-side navigation results in the scripts being initialised and inserted into the head again. 

These changes prevent that from happening so the initialisation occurs only once, on page load.

Relates to issue #447 

![](https://media.giphy.com/media/l0HlCSRTZIlN2WJfW/giphy.gif)

### Acceptance Criteria

- [ ] On client-side navigations, no duplicate GA/GTM scripts should be inserted in the head
- [ ] On hard refreshes of the site, when cookies are enabled, GA/GTM should be initialized and a single script for each inserted into the head

### Testing information
- [ ] Serve site, open up dev tools and inspect the DOM
- [ ] Try navigating between pages and refreshing the site, ensuring AC's are met
- [ ] Acceptance criteria met
_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
