### PR TITLE
DocIndexUpdaterQueue

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -1,6 +1,5 @@
-use crate::service_bus_client::create_factory;
+use crate::{models::CreateMessage, service_bus_client::create_factory};
 use azure_sdk_core::errors::AzureError;
-use azure_sdk_service_bus::prelude::Client;
 use std::time::Duration;
 use tokio::time::delay_for;
 
@@ -9,21 +8,18 @@ pub async fn create_service_worker() -> Result<String, AzureError> {
     let mut create_client = create_factory().await?;
 
     loop {
-        if let Ok(message) = get_message(&mut create_client).await {
+        let message_result: Result<CreateMessage, AzureError> = create_client.receive().await;
+        if let Ok(message) = message_result {
             tracing::info!("{:?} message receive!", message);
+            retrieve_file_from_sftp(message.document.file_path).await;
+            // TODO: create file in blob storage
+            // TODO: Update index
+            // TODO: Notify state manager
         }
         delay_for(Duration::from_secs(10)).await;
     }
-    // TODO: create file in blob storage
-    // TODO: Update index
-    // TODO: Notify state manager
 }
 
-pub async fn get_message(create_client: &mut Client) -> Result<String, AzureError> {
-    let message = create_client
-        .peek_lock(time::Duration::days(1), Some(time::Duration::seconds(1)))
-        .await
-        .map_err(|e| tracing::error!("{:?}", e))?;
-
-    return Ok(message);
+async fn retrieve_file_from_sftp(filepath: String) -> String {
+    filepath
 }

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -1,4 +1,4 @@
-use crate::service_bus_client::delete_factory;
+use crate::{models::DeleteMessage, service_bus_client::delete_factory};
 use azure_sdk_core::errors::AzureError;
 use azure_sdk_service_bus::prelude::Client;
 use std::time::Duration;
@@ -9,7 +9,8 @@ pub async fn delete_service_worker() -> Result<String, AzureError> {
     let mut delete_client = delete_factory().await?;
 
     loop {
-        if let Ok(message) = get_message(&mut delete_client).await {
+        let message_result: Result<DeleteMessage, AzureError> = delete_client.receive().await;
+        if let Ok(message) = message_result {
             tracing::info!("{:?} message receive!", message);
         }
         delay_for(Duration::from_secs(10)).await;

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -74,10 +74,37 @@ pub struct CreateMessage {
     pub document: Document,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DeleteMessage {
     pub job_id: Uuid,
     pub document_content_id: String,
+}
+
+pub trait Message {
+    fn from_string(message: String) -> Self;
+    fn to_json_string(&self) -> String;
+}
+
+impl Message for CreateMessage {
+    fn from_string(message: String) -> Self {
+        serde_json::from_slice::<CreateMessage>(message.as_bytes()).unwrap()
+        // TODO: fix these unwraps
+    }
+    fn to_json_string(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+        // TODO: fix these unwraps
+    }
+}
+
+impl Message for DeleteMessage {
+    fn from_string(message: String) -> Self {
+        serde_json::from_slice::<DeleteMessage>(message.as_bytes()).unwrap()
+        // TODO: fix these unwraps
+    }
+    fn to_json_string(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+        // TODO: fix these unwraps
+    }
 }
 
 #[cfg(test)]

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -74,7 +74,7 @@ pub struct CreateMessage {
     pub document: Document,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct DeleteMessage {
     pub job_id: Uuid,
     pub document_content_id: String,

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -80,30 +80,26 @@ pub struct DeleteMessage {
     pub document_content_id: String,
 }
 
-pub trait Message {
-    fn from_string(message: String) -> Self;
-    fn to_json_string(&self) -> String;
+pub trait Message: Sized {
+    fn from_string(message: String) -> Result<Self, serde_json::Error>;
+    fn to_json_string(&self) -> Result<String, serde_json::Error>;
 }
 
 impl Message for CreateMessage {
-    fn from_string(message: String) -> Self {
-        serde_json::from_slice::<CreateMessage>(message.as_bytes()).unwrap()
-        // TODO: fix these unwraps
+    fn from_string(message: String) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_slice::<CreateMessage>(message.as_bytes())?)
     }
-    fn to_json_string(&self) -> String {
-        serde_json::to_string(&self).unwrap()
-        // TODO: fix these unwraps
+    fn to_json_string(&self) -> Result<String, serde_json::Error> {
+        Ok(serde_json::to_string(&self)?)
     }
 }
 
 impl Message for DeleteMessage {
-    fn from_string(message: String) -> Self {
-        serde_json::from_slice::<DeleteMessage>(message.as_bytes()).unwrap()
-        // TODO: fix these unwraps
+    fn from_string(message: String) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_slice::<DeleteMessage>(message.as_bytes())?)
     }
-    fn to_json_string(&self) -> String {
-        serde_json::to_string(&self).unwrap()
-        // TODO: fix these unwraps
+    fn to_json_string(&self) -> Result<String, serde_json::Error> {
+        Ok(serde_json::to_string(&self)?)
     }
 }
 

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -53,7 +53,7 @@ impl DocIndexUpdaterQueue {
             .await
             .map_err(|e| tracing::error!("{:?}", e))?;
 
-        Ok(T::from_string(message.to_owned()))
+        Ok(T::from_string(message.to_owned())?)
     }
 
     pub async fn send<T: Message>(
@@ -61,7 +61,7 @@ impl DocIndexUpdaterQueue {
         message: T,
         duration: Duration,
     ) -> Result<(), AzureError> {
-        let evt = message.to_json_string();
+        let evt = message.to_json_string()?;
         Ok(self.service_bus.send_event(evt.as_str(), duration).await?)
     }
 }

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -1,7 +1,9 @@
+use crate::models::Message;
 use azure_sdk_core::errors::AzureError;
 use azure_sdk_service_bus::prelude::Client;
+use time::Duration;
 
-pub async fn delete_factory() -> Result<Client, AzureError> {
+pub async fn delete_factory() -> Result<DocIndexUpdaterQueue, AzureError> {
     let service_bus_namespace = std::env::var("SERVICE_BUS_NAMESPACE")
         .expect("Set env variable SERVICE_BUS_NAMESPACE first!");
 
@@ -14,10 +16,11 @@ pub async fn delete_factory() -> Result<Client, AzureError> {
     let policy_key = std::env::var("DELETE_QUEUE_POLICY_KEY")
         .expect("Set env variable DELETE_QUEUE_POLICY_KEY first!");
 
-    Client::new(service_bus_namespace, queue_name, policy_name, policy_key)
+    let service_bus = Client::new(service_bus_namespace, queue_name, policy_name, policy_key)?;
+    Ok(DocIndexUpdaterQueue::new(service_bus))
 }
 
-pub async fn create_factory() -> Result<Client, AzureError> {
+pub async fn create_factory() -> Result<DocIndexUpdaterQueue, AzureError> {
     let service_bus_namespace = std::env::var("SERVICE_BUS_NAMESPACE")
         .expect("Set env variable SERVICE_BUS_NAMESPACE first!");
 
@@ -30,5 +33,35 @@ pub async fn create_factory() -> Result<Client, AzureError> {
     let policy_key = std::env::var("CREATE_QUEUE_POLICY_KEY")
         .expect("Set env variable CREATE_QUEUE_POLICY_KEY first!");
 
-    Client::new(service_bus_namespace, queue_name, policy_name, policy_key)
+    let service_bus = Client::new(service_bus_namespace, queue_name, policy_name, policy_key)?;
+    Ok(DocIndexUpdaterQueue::new(service_bus))
+}
+
+pub struct DocIndexUpdaterQueue {
+    service_bus: Client,
+}
+
+impl DocIndexUpdaterQueue {
+    fn new(service_bus: Client) -> Self {
+        Self { service_bus }
+    }
+
+    pub async fn receive<T: Message>(&mut self) -> Result<T, AzureError> {
+        let message = self
+            .service_bus
+            .peek_lock(time::Duration::days(1), Some(time::Duration::seconds(1)))
+            .await
+            .map_err(|e| tracing::error!("{:?}", e))?;
+
+        Ok(T::from_string(message.to_owned()))
+    }
+
+    pub async fn send<T: Message>(
+        &mut self,
+        message: T,
+        duration: Duration,
+    ) -> Result<(), AzureError> {
+        let evt = message.to_json_string();
+        Ok(self.service_bus.send_event(evt.as_str(), duration).await?)
+    }
 }

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -1,8 +1,13 @@
 extern crate doc_index_updater;
 
 mod support;
-use doc_index_updater::{models::CreateMessage, service_bus_client::create_factory};
+use azure_sdk_core::errors::AzureError;
+use doc_index_updater::{
+    models::CreateMessage,
+    service_bus_client::{create_factory, DocIndexUpdaterQueue},
+};
 use support::{get_ok, get_test_create_message};
+use tokio_test::block_on;
 use uuid::Uuid;
 
 #[test]
@@ -13,10 +18,25 @@ fn create_queue_works() {
     let mut queue = get_ok(create_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = get_ok(queue.receive::<CreateMessage>());
+    let mut received_message = block_on(get_message_safely(&mut queue));
     while received_message != sent_message {
-        received_message = get_ok(queue.receive::<CreateMessage>());
+        received_message = block_on(get_message_safely(&mut queue));
     }
 
     assert_eq!(received_message, sent_message);
+}
+
+async fn get_message_safely(queue: &mut DocIndexUpdaterQueue) -> CreateMessage {
+    // This ensures test messages
+    // which aren't deserializable
+    // don't panic the entire test
+    loop {
+        match queue.receive::<CreateMessage>().await {
+            Ok(a) => return a,
+            Err(AzureError::JSONError(_)) => continue,
+            Err(_) => {
+                panic!("bad error");
+            }
+        }
+    }
 }

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -2,12 +2,14 @@ extern crate doc_index_updater;
 
 mod support;
 use doc_index_updater::{create_manager, service_bus_client::create_factory};
-use support::get_ok;
+use support::{get_ok, get_test_create_message};
+use uuid::Uuid;
 
 #[test]
 #[ignore]
 fn create_manager_works() {
-    let sent_message = "This is the create test message";
+    let id = Uuid::new_v4();
+    let sent_message = get_test_create_message(id);
     let mut create_client = get_ok(create_factory());
     get_ok(create_client.send_event(sent_message, time::Duration::seconds(1)));
 

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -1,21 +1,21 @@
 extern crate doc_index_updater;
 
 mod support;
-use doc_index_updater::{create_manager, service_bus_client::create_factory};
+use doc_index_updater::{models::CreateMessage, service_bus_client::create_factory};
 use support::{get_ok, get_test_create_message};
 use uuid::Uuid;
 
 #[test]
 #[ignore]
-fn create_manager_works() {
+fn create_queue_works() {
     let id = Uuid::new_v4();
     let sent_message = get_test_create_message(id);
-    let mut create_client = get_ok(create_factory());
-    get_ok(create_client.send_event(sent_message, time::Duration::seconds(1)));
+    let mut queue = get_ok(create_factory());
+    get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = get_ok(create_manager::get_message(&mut create_client));
+    let mut received_message = get_ok(queue.receive::<CreateMessage>());
     while received_message != sent_message {
-        received_message = get_ok(create_manager::get_message(&mut create_client));
+        received_message = get_ok(queue.receive::<CreateMessage>());
     }
 
     assert_eq!(received_message, sent_message);

--- a/medicines/doc-index-updater/tests/delete_manager.rs
+++ b/medicines/doc-index-updater/tests/delete_manager.rs
@@ -1,19 +1,22 @@
 extern crate doc_index_updater;
 
 mod support;
-use doc_index_updater::{delete_manager, service_bus_client::delete_factory};
+use crate::support::get_test_delete_message;
+use doc_index_updater::{models::DeleteMessage, service_bus_client::delete_factory};
 use support::get_ok;
+use uuid::Uuid;
 
 #[test]
 #[ignore]
-fn delete_manager_works() {
-    let sent_message = "This is the delete test message";
-    let mut delete_client = get_ok(delete_factory());
-    get_ok(delete_client.send_event(sent_message, time::Duration::seconds(1)));
+fn delete_queue_works() {
+    let id = Uuid::new_v4();
+    let sent_message = get_test_delete_message(id);
+    let mut queue = get_ok(delete_factory());
+    get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = get_ok(delete_manager::get_message(&mut delete_client));
+    let mut received_message = get_ok(queue.receive::<DeleteMessage>());
     while received_message != sent_message {
-        received_message = get_ok(delete_manager::get_message(&mut delete_client));
+        received_message = get_ok(queue.receive::<DeleteMessage>());
     }
 
     assert_eq!(received_message, sent_message);

--- a/medicines/doc-index-updater/tests/delete_manager.rs
+++ b/medicines/doc-index-updater/tests/delete_manager.rs
@@ -1,23 +1,42 @@
 extern crate doc_index_updater;
 
 mod support;
-use crate::support::get_test_delete_message;
-use doc_index_updater::{models::DeleteMessage, service_bus_client::delete_factory};
-use support::get_ok;
+use azure_sdk_core::errors::AzureError;
+use doc_index_updater::{
+    models::DeleteMessage,
+    service_bus_client::{delete_factory, DocIndexUpdaterQueue},
+};
+use support::{get_ok, get_test_delete_message};
+use tokio_test::block_on;
 use uuid::Uuid;
 
 #[test]
 #[ignore]
 fn delete_queue_works() {
     let id = Uuid::new_v4();
-    let sent_message = get_test_delete_message(id);
+    let sent_message = get_test_delete_message(id, format!("doc-{}", id));
     let mut queue = get_ok(delete_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = get_ok(queue.receive::<DeleteMessage>());
+    let mut received_message = block_on(get_message_safely(&mut queue));
     while received_message != sent_message {
-        received_message = get_ok(queue.receive::<DeleteMessage>());
+        received_message = block_on(get_message_safely(&mut queue));
     }
 
     assert_eq!(received_message, sent_message);
+}
+
+async fn get_message_safely(queue: &mut DocIndexUpdaterQueue) -> DeleteMessage {
+    // This ensures test messages
+    // which aren't deserializable
+    // don't panic the entire test
+    loop {
+        match queue.receive::<DeleteMessage>().await {
+            Ok(a) => return a,
+            Err(AzureError::JSONError(_)) => continue,
+            Err(_) => {
+                panic!("bad error");
+            }
+        }
+    }
 }

--- a/medicines/doc-index-updater/tests/integration.rs
+++ b/medicines/doc-index-updater/tests/integration.rs
@@ -1,10 +1,11 @@
 extern crate doc_index_updater;
 
 mod support;
+use crate::support::get_test_delete_message;
 use doc_index_updater::{
-    create_manager, document_manager,
-    models::{CreateMessage, JobStatus, JobStatusResponse},
-    service_bus_client::create_factory,
+    document_manager,
+    models::{CreateMessage, DeleteMessage, JobStatus, JobStatusResponse},
+    service_bus_client::{create_factory, delete_factory},
     state_manager,
 };
 use support::{get_ok, get_test_create_message, get_test_document, TestContext};
@@ -78,6 +79,19 @@ fn delete_endpoint_sets_state() {
     let id = response.id;
     let response = get_ok(state.get_status(id));
     assert_eq!(response.status, JobStatus::Accepted);
+
+    let mut delete_client = get_ok(delete_factory());
+
+    let mut received_message = get_ok(delete_client.receive::<DeleteMessage>());
+    let expected = get_test_delete_message(id);
+
+    loop {
+        if received_message.job_id == id {
+            assert_eq!(received_message, expected);
+            return;
+        }
+        received_message = get_ok(delete_client.receive::<DeleteMessage>());
+    }
 }
 
 #[ignore]
@@ -106,16 +120,14 @@ fn create_endpoint_sets_state() {
 
     let mut create_client = get_ok(create_factory());
 
-    let mut received_message = get_ok(create_manager::get_message(&mut create_client));
+    let mut received_message = get_ok(create_client.receive::<CreateMessage>());
     let expected = get_test_create_message(id);
 
     loop {
-        if let Ok(result) = serde_json::from_slice::<CreateMessage>(received_message.as_bytes()) {
-            if result.job_id == id {
-                assert_eq!(result, expected);
-                return;
-            }
+        if received_message.job_id == id {
+            assert_eq!(received_message, expected);
+            return;
         }
-        received_message = get_ok(create_manager::get_message(&mut create_client));
+        received_message = get_ok(create_client.receive::<CreateMessage>());
     }
 }

--- a/medicines/doc-index-updater/tests/integration.rs
+++ b/medicines/doc-index-updater/tests/integration.rs
@@ -83,7 +83,7 @@ fn delete_endpoint_sets_state() {
     let mut delete_client = get_ok(delete_factory());
 
     let mut received_message = get_ok(delete_client.receive::<DeleteMessage>());
-    let expected = get_test_delete_message(id);
+    let expected = get_test_delete_message(id, "hello-string".to_string());
 
     loop {
         if received_message.job_id == id {

--- a/medicines/doc-index-updater/tests/support/mod.rs
+++ b/medicines/doc-index-updater/tests/support/mod.rs
@@ -191,9 +191,9 @@ pub fn get_test_create_message(id: Uuid) -> CreateMessage {
     }
 }
 
-pub fn get_test_delete_message(id: Uuid) -> DeleteMessage {
+pub fn get_test_delete_message(job_id: Uuid, document_content_id: String) -> DeleteMessage {
     DeleteMessage {
-        job_id: id,
-        document_content_id: "id".to_string(),
+        job_id,
+        document_content_id,
     }
 }

--- a/medicines/doc-index-updater/tests/support/mod.rs
+++ b/medicines/doc-index-updater/tests/support/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use core::{fmt::Debug, future::Future};
-use doc_index_updater::models::{CreateMessage, Document, DocumentType};
+use doc_index_updater::models::{CreateMessage, DeleteMessage, Document, DocumentType};
 use redis::{self, Value};
 use std::{fs, io, process, thread::sleep, time::Duration};
 use tokio_test::block_on;
@@ -188,5 +188,12 @@ pub fn get_test_create_message(id: Uuid) -> CreateMessage {
     CreateMessage {
         job_id: id,
         document: get_test_document(),
+    }
+}
+
+pub fn get_test_delete_message(id: Uuid) -> DeleteMessage {
+    DeleteMessage {
+        job_id: id,
+        document_content_id: "id".to_string(),
     }
 }


### PR DESCRIPTION
# DocIndexUpdaterQueue

Refactors work done in #472 to allow for more direct handling and strong typing of the two messages we put onto and take off of the Service Bus.

### Acceptance Criteria

- [ ] Creates a `DocIndexUpdaterQueue` type
- [ ] `DocIndexerUpdaterQueue` type has methods for sending and receiving messages
- [ ] `send` method handles serialisation
- [ ] `receive` method handles deserialisation
- [ ] Methods are used in appropriate contexts where we were previously talking directly to Azure Service Bus Client and handling de/serialisation

### Testing information

Run `cargo test -- --ignored` and `cargo test`.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
