### PR TITLE
Error message for install redis when running tests

### DIFF
--- a/medicines/doc-index-updater/tests/support/mod.rs
+++ b/medicines/doc-index-updater/tests/support/mod.rs
@@ -32,7 +32,7 @@ impl Default for RedisServer {
 
         let addr = redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), server_port);
 
-        RedisServer::new_with_addr(addr, |cmd| cmd.spawn().unwrap())
+        RedisServer::new_with_addr(addr, |cmd| cmd.spawn().expect("Could not find redis, try installing redis server."))
     }
 }
 


### PR DESCRIPTION
# Error message more helpful when redis not installed

`cargo test` fails with a non descriptive error about File or Directory not existing when redis isn't installed.  This change gives a bit more information and tells the developer to install redis (ie brew install redis) if they get this error happen

### Acceptance Criteria

- [x] Better error message when redis not installed
- [x] Tests pass when it is installed

### Testing information

NA

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
