### PR TITLE
Remove messages on success

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "azure_sdk_core"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#602f4b10376a1c4657bf33f18fc2d1ab6fcad866"
+source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
 dependencies = [
  "RustyXML",
  "base64 0.11.0",
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_service_bus"
 version = "0.42.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#602f4b10376a1c4657bf33f18fc2d1ab6fcad866"
+source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -109,7 +109,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_storage_blob"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#602f4b10376a1c4657bf33f18fc2d1ab6fcad866"
+source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_storage_core"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#602f4b10376a1c4657bf33f18fc2d1ab6fcad866"
+source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17b52e737c40a7d75abca20b29a19a0eb7ba9fc72c5a72dd282a0a3c2c0dc35"
+checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
 dependencies = [
  "cc",
  "libc",

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -1,6 +1,8 @@
 use crate::{
     models::{CreateMessage, JobStatus},
-    service_bus_client::{create_factory, DocIndexUpdaterQueue, RetrieveFromQueueError},
+    service_bus_client::{
+        create_factory, DocIndexUpdaterQueue, RetrieveFromQueueError, RetrievedMessage,
+    },
     state_manager::StateManager,
 };
 use anyhow::anyhow;
@@ -49,14 +51,21 @@ async fn try_process_from_queue(
     create_client: &mut DocIndexUpdaterQueue,
 ) -> Result<FileProcessStatus, anyhow::Error> {
     tracing::info!("Checking for create messages");
-    let message_result: Result<CreateMessage, RetrieveFromQueueError> =
+    let retrieved_result: Result<RetrievedMessage<CreateMessage>, RetrieveFromQueueError> =
         create_client.receive().await;
-    if let Ok(message) = message_result {
+
+    if let Ok(retrieval) = retrieved_result {
+        let message = retrieval.message;
         tracing::info!("{:?} message receive!", message);
         let file =
             sftp_client::retrieve(message.document.file_source, message.document.file_path).await?;
         let blob = create_file_in_blob(file).await;
         add_to_search_index(blob).await;
+        let queue_removal_result = retrieval.peek_lock.delete_message().await.map_err(|e| {
+            tracing::error!("{:?}", e);
+            anyhow!("Queue Removal Error")
+        });
+        tracing::info!("Removed job from ServiceBus ({:?})", queue_removal_result);
 
         Ok(FileProcessStatus::Success(message.job_id))
     } else {

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -36,6 +36,13 @@ pub async fn delete_service_worker(
                         anyhow!("Couldn't delete blob {}", &blob_name)
                     })?;
                 // TODO: Update index
+                let queue_removal_result =
+                    retrieval.peek_lock.delete_message().await.map_err(|e| {
+                        tracing::error!("{:?}", e);
+                        anyhow!("Queue Removal Error")
+                    });
+                tracing::info!("Removed job from ServiceBus ({:?})", queue_removal_result);
+
                 // TODO: Notify state manager
             }
             Err(azure_error) => tracing::warn!("Azure error! {:?}", azure_error),

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -25,7 +25,7 @@ pub async fn delete_service_worker(
 
         match retrieved_result {
             Ok(retrieval) => {
-                let message = retrieval.message;
+                let message = retrieval.message.clone();
                 tracing::info!("{:?} message receive!", message);
 
                 let blob_name = get_blob_name_from_content_id(&message.document_content_id).await?;
@@ -35,13 +35,7 @@ pub async fn delete_service_worker(
                         tracing::error!("{:?}", e);
                         anyhow!("Couldn't delete blob {}", &blob_name)
                     })?;
-                // TODO: Update index
-                let queue_removal_result =
-                    retrieval.peek_lock.delete_message().await.map_err(|e| {
-                        tracing::error!("{:?}", e);
-                        anyhow!("Queue Removal Error")
-                    });
-                tracing::info!("Removed job from ServiceBus ({:?})", queue_removal_result);
+                retrieval.remove().await?;
 
                 // TODO: Notify state manager
             }

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     models::DeleteMessage,
     search,
-    service_bus_client::{delete_factory, RetrieveFromQueueError},
+    service_bus_client::{delete_factory, RetrieveFromQueueError, RetrievedMessage},
     storage_client,
 };
 use anyhow::anyhow;
@@ -20,10 +20,12 @@ pub async fn delete_service_worker(
     })?;
 
     loop {
-        let message_result: Result<DeleteMessage, RetrieveFromQueueError> =
+        let retrieved_result: Result<RetrievedMessage<DeleteMessage>, RetrieveFromQueueError> =
             delete_client.receive().await;
-        match message_result {
-            Ok(message) => {
+
+        match retrieved_result {
+            Ok(retrieval) => {
+                let message = retrieval.message;
                 tracing::info!("{:?} message receive!", message);
 
                 let blob_name = get_blob_name_from_content_id(&message.document_content_id).await?;

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -115,11 +115,11 @@ impl DocIndexUpdaterQueue {
                 Ok(RetrievedMessage { message, peek_lock })
             }
             Err(_) => {
-                tracing::warn!(
+                tracing::error!(
                     "Message found could not be parsed ({:?}). Gonna go ahead and delete it.",
                     body
                 );
-                // let _ = peek_lock.delete_message().await;
+                let _ = peek_lock.delete_message().await;
                 Err(RetrieveFromQueueError::ParseError(body))
             }
         }

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -1,11 +1,8 @@
 extern crate doc_index_updater;
 
 mod support;
-use doc_index_updater::{
-    models::CreateMessage,
-    service_bus_client::{create_factory, DocIndexUpdaterQueue, RetrieveFromQueueError},
-};
-use support::{get_ok, get_test_create_message};
+use doc_index_updater::{models::CreateMessage, service_bus_client::create_factory};
+use support::{get_message_safely, get_ok, get_test_create_message};
 use tokio_test::block_on;
 use uuid::Uuid;
 
@@ -17,26 +14,10 @@ fn create_queue_works() {
     let mut queue = get_ok(create_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(30)));
 
-    let mut received_message = block_on(get_message_safely(&mut queue));
+    let mut received_message = block_on(get_message_safely::<CreateMessage>(&mut queue));
     while received_message != sent_message {
-        received_message = block_on(get_message_safely(&mut queue));
+        received_message = block_on(get_message_safely::<CreateMessage>(&mut queue));
     }
 
     assert_eq!(received_message, sent_message);
-}
-
-async fn get_message_safely(queue: &mut DocIndexUpdaterQueue) -> CreateMessage {
-    // This ensures test messages
-    // which aren't deserializable
-    // don't panic the entire test
-    loop {
-        match queue.receive::<CreateMessage>().await {
-            Ok(a) => return a,
-            Err(RetrieveFromQueueError::ParseError(_)) => continue,
-            Err(RetrieveFromQueueError::NotFoundError) => continue,
-            Err(e) => {
-                panic!("bad error: {:?}", e);
-            }
-        }
-    }
 }

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -14,10 +14,14 @@ fn create_queue_works() {
     let mut queue = get_ok(create_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(30)));
 
-    let mut received_message = block_on(get_message_safely::<CreateMessage>(&mut queue));
-    while received_message != sent_message {
-        received_message = block_on(get_message_safely::<CreateMessage>(&mut queue));
+    let mut retrieval = block_on(get_message_safely::<CreateMessage>(&mut queue));
+    while retrieval.message != sent_message {
+        retrieval = block_on(get_message_safely::<CreateMessage>(&mut queue));
     }
 
-    assert_eq!(received_message, sent_message);
+    assert_eq!(retrieval.message, sent_message);
+
+    let queue_removal_response = block_on(retrieval.peek_lock.delete_message());
+    assert!(queue_removal_response.is_ok());
+    assert_eq!(queue_removal_response.unwrap(), "");
 }

--- a/medicines/doc-index-updater/tests/create_manager.rs
+++ b/medicines/doc-index-updater/tests/create_manager.rs
@@ -21,7 +21,7 @@ fn create_queue_works() {
 
     assert_eq!(retrieval.message, sent_message);
 
-    let queue_removal_response = block_on(retrieval.peek_lock.delete_message());
+    let queue_removal_response = block_on(retrieval.remove());
     assert!(queue_removal_response.is_ok());
     assert_eq!(queue_removal_response.unwrap(), "");
 }

--- a/medicines/doc-index-updater/tests/delete_manager.rs
+++ b/medicines/doc-index-updater/tests/delete_manager.rs
@@ -1,11 +1,8 @@
 extern crate doc_index_updater;
 
 mod support;
-use doc_index_updater::{
-    models::DeleteMessage,
-    service_bus_client::{delete_factory, DocIndexUpdaterQueue, RetrieveFromQueueError},
-};
-use support::{get_ok, get_test_delete_message};
+use doc_index_updater::{models::DeleteMessage, service_bus_client::delete_factory};
+use support::{get_message_safely, get_ok, get_test_delete_message};
 use tokio_test::block_on;
 use uuid::Uuid;
 
@@ -17,26 +14,10 @@ fn delete_queue_works() {
     let mut queue = get_ok(delete_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = block_on(get_message_safely(&mut queue));
+    let mut received_message = block_on(get_message_safely::<DeleteMessage>(&mut queue));
     while received_message != sent_message {
-        received_message = block_on(get_message_safely(&mut queue));
+        received_message = block_on(get_message_safely::<DeleteMessage>(&mut queue));
     }
 
     assert_eq!(received_message, sent_message);
-}
-
-async fn get_message_safely(queue: &mut DocIndexUpdaterQueue) -> DeleteMessage {
-    // This ensures test messages
-    // which aren't deserializable
-    // don't panic the entire test
-    loop {
-        match queue.receive::<DeleteMessage>().await {
-            Ok(a) => return a,
-            Err(RetrieveFromQueueError::ParseError(_)) => continue,
-            Err(RetrieveFromQueueError::NotFoundError) => continue,
-            Err(e) => {
-                panic!("bad error: {:?}", e);
-            }
-        }
-    }
 }

--- a/medicines/doc-index-updater/tests/delete_manager.rs
+++ b/medicines/doc-index-updater/tests/delete_manager.rs
@@ -14,10 +14,14 @@ fn delete_queue_works() {
     let mut queue = get_ok(delete_factory());
     get_ok(queue.send(sent_message.clone(), time::Duration::seconds(1)));
 
-    let mut received_message = block_on(get_message_safely::<DeleteMessage>(&mut queue));
-    while received_message != sent_message {
-        received_message = block_on(get_message_safely::<DeleteMessage>(&mut queue));
+    let mut retrieval = block_on(get_message_safely::<DeleteMessage>(&mut queue));
+    while retrieval.message != sent_message {
+        retrieval = block_on(get_message_safely::<DeleteMessage>(&mut queue));
     }
 
-    assert_eq!(received_message, sent_message);
+    assert_eq!(retrieval.message, sent_message);
+
+    let queue_removal_response = block_on(retrieval.peek_lock.delete_message());
+    assert!(queue_removal_response.is_ok());
+    assert_eq!(queue_removal_response.unwrap(), "");
 }

--- a/medicines/doc-index-updater/tests/delete_manager.rs
+++ b/medicines/doc-index-updater/tests/delete_manager.rs
@@ -21,7 +21,7 @@ fn delete_queue_works() {
 
     assert_eq!(retrieval.message, sent_message);
 
-    let queue_removal_response = block_on(retrieval.peek_lock.delete_message());
+    let queue_removal_response = block_on(retrieval.remove());
     assert!(queue_removal_response.is_ok());
     assert_eq!(queue_removal_response.unwrap(), "");
 }

--- a/medicines/doc-index-updater/tests/integration.rs
+++ b/medicines/doc-index-updater/tests/integration.rs
@@ -82,7 +82,7 @@ fn delete_endpoint_sets_state() {
 
     let mut delete_client = get_ok(delete_factory());
 
-    let mut received_message = get_ok(delete_client.receive::<DeleteMessage>());
+    let mut received_message = get_ok(delete_client.receive::<DeleteMessage>()).message;
     let expected = get_test_delete_message(id, "hello-string".to_string());
 
     loop {
@@ -90,7 +90,7 @@ fn delete_endpoint_sets_state() {
             assert_eq!(received_message, expected);
             return;
         }
-        received_message = get_ok(delete_client.receive::<DeleteMessage>());
+        received_message = get_ok(delete_client.receive::<DeleteMessage>()).message;
     }
 }
 
@@ -120,7 +120,7 @@ fn create_endpoint_sets_state() {
 
     let mut create_client = get_ok(create_factory());
 
-    let mut received_message = get_ok(create_client.receive::<CreateMessage>());
+    let mut received_message = get_ok(create_client.receive::<CreateMessage>()).message;
     let expected = get_test_create_message(id);
 
     loop {
@@ -128,6 +128,6 @@ fn create_endpoint_sets_state() {
             assert_eq!(received_message, expected);
             return;
         }
-        received_message = get_ok(create_client.receive::<CreateMessage>());
+        received_message = get_ok(create_client.receive::<CreateMessage>()).message;
     }
 }


### PR DESCRIPTION
# Remove messages on success

Closes #493. Relates to [AzureSDKForRust#247](https://github.com/MindFlavor/AzureSDKForRust/pull/247/files).

![Delete](https://media.giphy.com/media/Q81NcsY6YxK7jxnr4v/giphy.gif)

### Technical acceptance criteria

- [ ] We remove from the Service Bus messages which we know have been successful
- [ ] We retain on the Service Bus messages which we do not know have been successful
- [ ] We remove from the Service Bus messages which are not deserialisable, as they should not be possible

### Testing acceptance criteria

- [ ] Tests cover the removal of messages
- [ ] Tests cover the ability to pick up a message twice when removal hasn't occurred

### Testing information

`cargo run` and hit the curl

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
