### PR TITLE
Support XML requests for Sentinel

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "quick-error",
  "ring",
  "serde",
- "serde-xml-rs",
+ "serde-xml-rs 0.3.1",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -97,7 +97,7 @@ dependencies = [
  "quick-error",
  "ring",
  "serde",
- "serde-xml-rs",
+ "serde-xml-rs 0.3.1",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -128,7 +128,7 @@ dependencies = [
  "quick-error",
  "ring",
  "serde",
- "serde-xml-rs",
+ "serde-xml-rs 0.3.1",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -158,7 +158,7 @@ dependencies = [
  "quick-error",
  "ring",
  "serde",
- "serde-xml-rs",
+ "serde-xml-rs 0.3.1",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -1641,6 +1641,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe415925cf3d0bbb2fc47d09b56ce03eef51c5d56846468a39bcc293c7a846c"
+dependencies = [
+ "log 0.4.8",
+ "serde",
+ "thiserror",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,8 +2186,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cd1e2b3eb3539284d88b76a9afcf5e20f2ef2fab74db5b21a1c30d7d945e82"
+source = "git+https://github.com/m-doughty/warp?branch=add-xml-support#a2d40cd761e289bf95cda315f7638c0c51192629"
 dependencies = [
  "bytes",
  "futures",
@@ -2189,6 +2200,7 @@ dependencies = [
  "pin-project",
  "scoped-tls",
  "serde",
+ "serde-xml-rs 0.4.0",
  "serde_json",
  "serde_urlencoded",
  "tokio",

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -32,7 +32,7 @@ tracing-futures = "0.2.3"
 tracing-log = "0.1.1"
 tracing-subscriber = "0.2.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-warp = "0.2"
+warp = { git = "https://github.com/m-doughty/warp", branch = "add-xml-support" }
 
 [dev-dependencies]
 test-case = "1.0.0"

--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -1,11 +1,14 @@
 use crate::{
-    models::{CreateMessage, DeleteMessage, Document, JobStatus},
+    models::{CreateMessage, DeleteMessage, Document, JobStatus, XMLDocument},
     service_bus_client::{create_factory, delete_factory},
     state_manager::{with_state, StateManager},
 };
 use time::Duration;
 use uuid::Uuid;
-use warp::{reply::Json, Filter, Rejection, Reply};
+use warp::{
+    reply::{Json, Reply as ReplyReply, Xml},
+    Filter, Rejection, Reply,
+};
 
 #[derive(Debug)]
 struct FailedToDispatchToQueue;
@@ -14,10 +17,27 @@ struct FailedToDeserialize;
 impl warp::reject::Reject for FailedToDispatchToQueue {}
 impl warp::reject::Reject for FailedToDeserialize {}
 
+enum ReplyType {
+    Json,
+    Xml,
+}
+
+fn choose_reply_content_type(accept_header: Option<String>) -> ReplyType {
+    match accept_header {
+        Some(v) => match v {
+            "application/xml" => ReplyType::Xml,
+            "text/xml" => ReplyType::Xml,
+            _ => ReplyType::Json,
+        },
+        _ => ReplyType::Json,
+    }
+}
+
 async fn del_document_handler(
     document_content_id: String,
+    accept_header: Option<String>,
     state_manager: StateManager,
-) -> Result<Json, Rejection> {
+) -> Result<ReplyReply, Rejection> {
     if let Ok(mut queue) = delete_factory().await {
         let id = Uuid::new_v4();
         let message = DeleteMessage {
@@ -27,9 +47,14 @@ async fn del_document_handler(
         let duration = Duration::days(1);
 
         match queue.send(message, duration).await {
-            Ok(_) => Ok(warp::reply::json(
-                &state_manager.set_status(id, JobStatus::Accepted).await?,
-            )),
+            Ok(_) => match choose_reply_content_type(accept_header) {
+                ReplyType::Xml => Ok(warp::reply::xml(
+                    &state_manager.set_status(id, JobStatus::Accepted).await?,
+                )),
+                ReplyType::Json => Ok(warp::reply::json(
+                    &state_manager.set_status(id, JobStatus::Accepted).await?,
+                )),
+            },
             Err(_) => Err(warp::reject::custom(FailedToDispatchToQueue)),
         }
     } else {
@@ -39,8 +64,9 @@ async fn del_document_handler(
 
 async fn check_in_document_handler(
     doc: Document,
+    accept_header: Option<String>,
     state_manager: StateManager,
-) -> Result<Json, Rejection> {
+) -> Result<ReplyReply, Rejection> {
     if let Ok(mut queue) = create_factory().await {
         let id = Uuid::new_v4();
         let message = CreateMessage {
@@ -49,9 +75,14 @@ async fn check_in_document_handler(
         };
         let duration = Duration::days(1);
         match queue.send(message, duration).await {
-            Ok(_) => Ok(warp::reply::json(
-                &state_manager.set_status(id, JobStatus::Accepted).await?,
-            )),
+            Ok(_) => match choose_reply_content_type(accept_header) {
+                ReplyType::Xml => Ok(warp::reply::xml(
+                    &state_manager.set_status(id, JobStatus::Accepted).await?,
+                )),
+                ReplyType::Json => Ok(warp::reply::json(
+                    &state_manager.set_status(id, JobStatus::Accepted).await?,
+                )),
+            },
             Err(_) => Err(warp::reject::custom(FailedToDispatchToQueue)),
         }
     } else {
@@ -64,6 +95,7 @@ pub fn del_document(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents" / String)
         .and(warp::delete())
+        .and(warp::header::optional::<String>("accept"))
         .and(with_state(state_manager))
         .and_then(del_document_handler)
 }
@@ -73,7 +105,11 @@ pub fn check_in_document(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents")
         .and(warp::post())
-        .and(warp::body::json())
+        .and(warp::body::xml_enforce_strict_content_type())
+        .map(|doc: XMLDocument| Document::from(doc))
+        .or(warp::body::json())
+        .unify()
+        .and(warp::header::optional::<String>("accept"))
         .and(with_state(state_manager))
         .and_then(check_in_document_handler)
 }

--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    models::{CreateMessage, DeleteMessage, Document, JobStatus, JobStatusResponse, XMLDocument},
+    models::{
+        CreateMessage, DeleteMessage, Document, JobStatus, JobStatusResponse, XMLDocument,
+        XMLJobStatusResponse,
+    },
     service_bus_client::{create_factory, delete_factory},
     state_manager::{with_state, StateManager},
 };
@@ -43,7 +46,10 @@ async fn del_document_xml_handler(
     state_manager: StateManager,
 ) -> Result<Xml, Rejection> {
     let r = del_document_handler(document_content_id, state_manager).await?;
-    Ok(warp::reply::xml(&r))
+
+    Ok(warp::reply::xml(&XMLJobStatusResponse::from_job_response(
+        r,
+    )))
 }
 
 async fn del_document_json_handler(
@@ -79,7 +85,10 @@ async fn check_in_document_xml_handler(
     state_manager: StateManager,
 ) -> Result<Xml, Rejection> {
     let r = check_in_document_handler(doc, state_manager).await?;
-    Ok(warp::reply::xml(&r))
+
+    Ok(warp::reply::xml(&XMLJobStatusResponse::from_job_response(
+        r,
+    )))
 }
 
 async fn check_in_document_json_handler(

--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -20,7 +20,7 @@ struct FailedToDeserialize;
 impl warp::reject::Reject for FailedToDispatchToQueue {}
 impl warp::reject::Reject for FailedToDeserialize {}
 
-async fn del_document_handler(
+async fn delete_document_handler(
     document_content_id: String,
     state_manager: StateManager,
 ) -> Result<JobStatusResponse, Rejection> {
@@ -41,21 +41,21 @@ async fn del_document_handler(
     }
 }
 
-async fn del_document_xml_handler(
+async fn delete_document_xml_handler(
     document_content_id: String,
     state_manager: StateManager,
 ) -> Result<Xml, Rejection> {
-    let r: XMLJobStatusResponse = del_document_handler(document_content_id, state_manager)
+    let r: XMLJobStatusResponse = delete_document_handler(document_content_id, state_manager)
         .await?
         .into();
     Ok(warp::reply::xml(&r))
 }
 
-async fn del_document_json_handler(
+async fn delete_document_json_handler(
     document_content_id: String,
     state_manager: StateManager,
 ) -> Result<Json, Rejection> {
-    let r = del_document_handler(document_content_id, state_manager).await?;
+    let r = delete_document_handler(document_content_id, state_manager).await?;
     Ok(warp::reply::json(&r))
 }
 
@@ -95,23 +95,23 @@ async fn check_in_document_json_handler(
     Ok(warp::reply::json(&r))
 }
 
-pub fn del_document(
+pub fn delete_document(
     state_manager: StateManager,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents" / String)
         .and(warp::delete())
         .and(with_state(state_manager))
-        .and_then(del_document_json_handler)
+        .and_then(delete_document_json_handler)
 }
 
-pub fn del_document_xml(
+pub fn delete_document_xml(
     state_manager: StateManager,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents" / String)
         .and(warp::delete())
         .and(warp::header::exact_ignore_case("accept", "application/xml"))
         .and(with_state(state_manager))
-        .and_then(del_document_xml_handler)
+        .and_then(delete_document_xml_handler)
 }
 
 pub fn check_in_document(

--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -45,11 +45,10 @@ async fn del_document_xml_handler(
     document_content_id: String,
     state_manager: StateManager,
 ) -> Result<Xml, Rejection> {
-    let r = del_document_handler(document_content_id, state_manager).await?;
-
-    Ok(warp::reply::xml(&XMLJobStatusResponse::from_job_response(
-        r,
-    )))
+    let r: XMLJobStatusResponse = del_document_handler(document_content_id, state_manager)
+        .await?
+        .into();
+    Ok(warp::reply::xml(&r))
 }
 
 async fn del_document_json_handler(
@@ -84,11 +83,8 @@ async fn check_in_document_xml_handler(
     doc: Document,
     state_manager: StateManager,
 ) -> Result<Xml, Rejection> {
-    let r = check_in_document_handler(doc, state_manager).await?;
-
-    Ok(warp::reply::xml(&XMLJobStatusResponse::from_job_response(
-        r,
-    )))
+    let r: XMLJobStatusResponse = check_in_document_handler(doc, state_manager).await?.into();
+    Ok(warp::reply::xml(&r))
 }
 
 async fn check_in_document_json_handler(

--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -104,7 +104,7 @@ pub fn del_document_xml(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents" / String)
         .and(warp::delete())
-        .and(warp::header::exact("accept", "application/xml"))
+        .and(warp::header::exact_ignore_case("accept", "application/xml"))
         .and(with_state(state_manager))
         .and_then(del_document_xml_handler)
 }
@@ -124,7 +124,7 @@ pub fn check_in_xml_document(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("documents")
         .and(warp::post())
-        .and(warp::header::exact("accept", "application/xml"))
+        .and(warp::header::exact_ignore_case("accept", "application/xml"))
         .and(warp::body::xml_enforce_strict_content_type())
         .map(|doc: XMLDocument| Document::from(doc))
         .and(with_state(state_manager))

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -41,7 +41,9 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
                 health::get_health()
                     .or(state_manager::get_job_status(state.clone()))
                     .or(state_manager::set_job_status(state.clone()))
+                    .or(document_manager::check_in_xml_document(state.clone()))
                     .or(document_manager::check_in_document(state.clone()))
+                    .or(document_manager::del_document_xml(state.clone()))
                     .or(document_manager::del_document(state.clone()))
                     .with(warp::log("doc_index_updater")),
             )

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -43,8 +43,8 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
                     .or(state_manager::set_job_status(state.clone()))
                     .or(document_manager::check_in_xml_document(state.clone()))
                     .or(document_manager::check_in_document(state.clone()))
-                    .or(document_manager::del_document_xml(state.clone()))
-                    .or(document_manager::del_document(state.clone()))
+                    .or(document_manager::delete_document_xml(state.clone()))
+                    .or(document_manager::delete_document(state.clone()))
                     .with(warp::log("doc_index_updater")),
             )
             .run(addr.clone())

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -62,6 +62,75 @@ pub struct Document {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum FileSource {
     Sentinel,
+    Unknown,
+}
+
+impl Document {
+    pub fn from(doc: XMLDocument) -> Self {
+        Self {
+            id: doc.id,
+            name: doc.name,
+            document_type: doc.document_type,
+            author: doc.author,
+            products: doc
+                .products
+                .iter()
+                .map(move |active_substance| active_substance.name.clone())
+                .collect::<Vec<String>>(),
+            keywords: match doc.keywords {
+                Some(kw) => Some(
+                    kw.iter()
+                        .map(move |keyword| keyword.name.clone())
+                        .collect::<Vec<String>>(),
+                ),
+                None => None,
+            },
+            pl_number: doc.pl_number,
+            active_substances: doc
+                .active_substances
+                .iter()
+                .map(move |active_substance| active_substance.name.clone())
+                .collect::<Vec<String>>(),
+            file_source: match doc.file_source {
+                "sentinel" => FileSource::Sentinel,
+                _ => FileSource::Unknown,
+            },
+            file_path: doc.file_path,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Product {
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Keyword {
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ActiveSubstance {
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct XMLDocument {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub document_type: DocumentType,
+    pub author: String,
+    pub products: Vec<Product>,
+    pub keywords: Option<Vec<Keyword>>,
+    pub pl_number: String,
+    pub active_substances: Vec<ActiveSubstance>,
+    pub file_source: String,
+    pub file_path: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -76,11 +145,15 @@ pub enum DocumentType {
 
 impl fmt::Display for DocumentType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match &self {
-            DocumentType::Spc => "Spc",
-            DocumentType::Pil => "Pil",
-            DocumentType::Par => "Par"
-        })
+        write!(
+            f,
+            "{}",
+            match &self {
+                DocumentType::Spc => "Spc",
+                DocumentType::Pil => "Pil",
+                DocumentType::Par => "Par",
+            }
+        )
     }
 }
 

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -136,11 +136,11 @@ pub struct XMLJobStatusResponse {
     status: String,
 }
 
-impl XMLJobStatusResponse {
-    pub fn from_job_response(j: JobStatusResponse) -> Self {
-        Self {
-            id: j.id.to_string(),
-            status: j.status.to_string(),
+impl Into<XMLJobStatusResponse> for JobStatusResponse {
+    fn into(self) -> XMLJobStatusResponse {
+        XMLJobStatusResponse {
+            id: self.id.to_string(),
+            status: self.status.to_string(),
         }
     }
 }

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -62,7 +62,6 @@ pub struct Document {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum FileSource {
     Sentinel,
-    Unknown,
 }
 
 impl Document {
@@ -91,10 +90,7 @@ impl Document {
                 .iter()
                 .map(move |active_substance| active_substance.name.clone())
                 .collect::<Vec<String>>(),
-            file_source: match doc.file_source {
-                "sentinel" => FileSource::Sentinel,
-                _ => FileSource::Unknown,
-            },
+            file_source: doc.file_source,
             file_path: doc.file_path,
         }
     }
@@ -129,7 +125,7 @@ pub struct XMLDocument {
     pub keywords: Option<Vec<Keyword>>,
     pub pl_number: String,
     pub active_substances: Vec<ActiveSubstance>,
-    pub file_source: String,
+    pub file_source: FileSource,
     pub file_path: String,
 }
 

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -61,6 +61,7 @@ pub struct Document {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum FileSource {
+    #[serde(alias = "sentinel")]
     Sentinel,
 }
 

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -38,7 +38,7 @@ impl FromStr for JobStatus {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JobStatusResponse {
     pub id: Uuid,
     pub status: JobStatus,
@@ -131,6 +131,22 @@ pub struct XMLDocument {
     pub active_substances: Vec<ActiveSubstance>,
     pub file_source: String,
     pub file_path: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename = "job")]
+pub struct XMLJobStatusResponse {
+    id: String,
+    status: String,
+}
+
+impl XMLJobStatusResponse {
+    pub fn from_job_response(j: JobStatusResponse) -> Self {
+        Self {
+            id: j.id.to_string(),
+            status: j.status.to_string(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/medicines/doc-index-updater/tests/integration.rs
+++ b/medicines/doc-index-updater/tests/integration.rs
@@ -65,7 +65,7 @@ fn delete_endpoint_sets_state() {
     let ctx = TestContext::default();
 
     let state = state_manager::StateManager::new(ctx.client);
-    let delete_filter = document_manager::del_document(state.clone());
+    let delete_filter = document_manager::delete_document(state.clone());
 
     let r = block_on(
         warp::test::request()


### PR DESCRIPTION
# Allows XML requests as well as JSON, and provides XML responses

resolves #486 

![](https://media.giphy.com/media/3o6Zto3GLAbK27C0co/giphy.gif)

### Acceptance Criteria

- [x] If the user sends a request with `Content-Type` set to `application/xml`, we should assume the body is XML;
- [x] If the user sends a request with `Accept` set to `application/xml`, we should send our reply in XML;
- [x] Otherwise, we should default to JSON.

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
