### PR TITLE
Fix fuzzy search for product licences

### DIFF
--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -17,4 +17,16 @@ describe(buildFuzzyQuery, () => {
       'K~1 K^4 L~1 L^4 POULTICE~1 POULTICE^4 KAOLIN~1 KAOLIN^4 POULTICE~1 POULTICE^4 BP~1 BP^4',
     );
   });
+
+  it('normalizes product licence', () => {
+    const fuzzyQuery = buildFuzzyQuery('pl 30464/0140');
+    expect(fuzzyQuery).toBe('PL304640140~1 PL304640140^4');
+  });
+
+  it('extracts and normalizes product licence', () => {
+    const fuzzyQuery = buildFuzzyQuery('amlodipine pl 30464/0140');
+    expect(fuzzyQuery).toBe(
+      'amlodipine~1 amlodipine^4 PL304640140~1 PL304640140^4',
+    );
+  });
 });

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -12,7 +12,7 @@ const escapeSpecialWords = (word: string): string =>
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
   `${word}~${searchWordFuzziness} ${word}^${searchExactnessBoost}`;
 
-const addNormalizedProductLicenses = (q: string): string => {
+const extractNormalizedProductLicenses = (q: string): string => {
   const normalizedProductLicences = q
     .match(extractProductLicenseRegExp)
     ?.map(match => match.replace(extractProductLicenseRegExp, 'PL$3$5'));
@@ -21,7 +21,8 @@ const addNormalizedProductLicenses = (q: string): string => {
     const normalizedProductLicencesString: string = normalizedProductLicences.join(
       ' ',
     );
-    return `${q} ${normalizedProductLicencesString}`;
+    const qWithoutProductLicences = q.replace(extractProductLicenseRegExp, '');
+    return `${qWithoutProductLicences} ${normalizedProductLicencesString}`;
   }
 
   return `${q}`;
@@ -31,7 +32,7 @@ const splitByNonSearchableCharacters = (query: string) =>
   query.split(/(?:[,+\-!(){}\[\]^~*?:\/]|\s+)/gi);
 
 export const buildFuzzyQuery = (query: string): string => {
-  return splitByNonSearchableCharacters(addNormalizedProductLicenses(query))
+  return splitByNonSearchableCharacters(extractNormalizedProductLicenses(query))
     .filter(x => x.length > 0)
     .map(word => escapeSpecialWords(word))
     .map(word => preferExactMatchButSupportFuzzyMatch(word))


### PR DESCRIPTION
# Fix the way produce licences get searched for.

See details in bug #512 

![](https://media.giphy.com/media/NsDgJPXkk5CK7pPYkJ/giphy.gif)

### Acceptance Criteria
- A search for a produce licence number (e.g. `PL 30464/0140`) should return both SPC and PIL files

### Testing information
- Search for produce licences using several different numbers and ensure each time that both SPC and PIL files are returned.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"