### PR TITLE
Timlee/fix search for percent

### DIFF
--- a/medicines/web/src/components/search-wrapper/index.tsx
+++ b/medicines/web/src/components/search-wrapper/index.tsx
@@ -32,7 +32,7 @@ interface ISearchWrapperProps {
 
 const formatInitialSearchTerm = (searchTerm: string | string[]) => {
   if (searchTerm) {
-    return decodeURIComponent(searchTerm.toString());
+    return searchTerm.toString();
   }
   return '';
 };

--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -7,8 +7,12 @@ describe(buildFuzzyQuery, () => {
   });
 
   it('ignores special characters', () => {
-    const fuzzyQuery = buildFuzzyQuery('hello*');
-    expect(fuzzyQuery).toBe('hello~1 hello^4');
+    const fuzzyQuery = buildFuzzyQuery(
+      'bacteriostatic solvent (0.3%w/v metacresol in wfi)',
+    );
+    expect(fuzzyQuery).toBe(
+      'bacteriostatic~1 bacteriostatic^4 solvent~1 solvent^4 0.3~1 0.3^4 w~1 w^4 v~1 v^4 metacresol~1 metacresol^4 in~1 in^4 wfi~1 wfi^4',
+    );
   });
 
   it('builds fuzzy words from product name', () => {

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -29,7 +29,7 @@ const extractNormalizedProductLicenses = (q: string): string => {
 };
 
 const splitByNonSearchableCharacters = (query: string) =>
-  query.split(/(?:[,+\-!(){}\[\]^~*?:\/]|\s+)/gi);
+  query.split(/(?:[,+\-!(){}\[\]^~*?:%\/]|\s+)/gi);
 
 export const buildFuzzyQuery = (query: string): string => {
   return splitByNonSearchableCharacters(extractNormalizedProductLicenses(query))


### PR DESCRIPTION
# Fix search for `%`
See details in bug #511 

![](https://media.giphy.com/media/2fI8ZJJoforJui4gyM/giphy.gif)

### Acceptance Criteria

- [ ] Searching for terms with `%` in should not throw an error

### Testing information
Search for a term with `%` in - no error should be thrown. E.g. `bacteriostatic solvent (0.3%w/v metacresol in wfi)`

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
