### PR TITLE
Handle errors in delete worker

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/metadata.rs
+++ b/medicines/doc-index-updater/src/create_manager/metadata.rs
@@ -2,8 +2,7 @@ use crate::models::Document;
 
 use lazy_static;
 use regex::Regex;
-use std::collections::HashMap;
-use std::str;
+use std::{collections::HashMap, str};
 
 pub fn derive_metadata_from_message(document: &Document) -> HashMap<String, String> {
     let mut metadata: HashMap<String, String> = HashMap::new();

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -56,13 +56,15 @@ async fn try_process_from_queue(
                     == "Couldn't retrieve file: [-31] Failed opening remote file".to_string()
                 {
                     tracing::info!("Updating state to errored and removing message");
-                    let _ = state_manager.set_status(
-                        retrieval.message.job_id,
-                        JobStatus::Error {
-                            message: "Couldn't find file".to_string(),
-                            code: "404".to_string(),
-                        },
-                    );
+                    let _ = state_manager
+                        .set_status(
+                            retrieval.message.job_id,
+                            JobStatus::Error {
+                                message: "Couldn't find file".to_string(),
+                                code: "404".to_string(),
+                            },
+                        )
+                        .await?;
                     // TODO: Uncomment before releasing
                     // or when we have a centralised SFTP server for dev
                     // let _ = retrieval.remove().await?;
@@ -119,7 +121,7 @@ pub async fn create_blob(
     for (key, val) in metadata {
         metadata_ref.insert(&key, &val);
     }
-    
+
     storage_client
         .put_block_blob()
         .with_container_name(&container_name)

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -36,12 +36,15 @@ impl FromStr for JobStatus {
                     let colon_index = status.find(":").unwrap();
                     let string_length = status.chars().count();
                     return Ok(JobStatus::Error {
-                        message: status.get(colon_index+2..string_length-1).unwrap().to_string(),
+                        message: status
+                            .get(colon_index + 2..string_length - 1)
+                            .unwrap()
+                            .to_string(),
                         code: status.get(6..colon_index).unwrap().to_string(),
                     });
                 }
                 Err(format!("Status unknown: {}", status))
-            },
+            }
         }
     }
 }

--- a/medicines/doc-index-updater/src/state_manager/redis.rs
+++ b/medicines/doc-index-updater/src/state_manager/redis.rs
@@ -88,7 +88,7 @@ mod test {
 
     #[test_case(&Value::Status("Accepted".to_string()), Ok(JobStatus::Accepted))]
     #[test_case(&Value::Status("Done".to_string()), Ok(JobStatus::Done))]
-    #[test_case(&Value::Status("Error".to_string()), Ok(JobStatus::Error {message:"Error status".to_owned(), code:"0x0".to_owned()}))]
+    #[test_case(&Value::Status("Error(0x0: Error status)".to_string()), Ok(JobStatus::Error {message:"Error status".to_owned(), code:"0x0".to_owned()}))]
     #[test_case(&Value::Status("Bedro".to_string()), Err(to_redis_error( "Status unknown: Bedro".to_string())))]
     fn from_redis_value(input: &Value, output: Result<JobStatus, RedisError>) {
         assert_eq!(JobStatus::from_redis_value(input), output);


### PR DESCRIPTION
* Set error state in state manager.
* Remove message from queue.
* Reflect the structure of the create worker in the delete worker.

Resolves issues found during testing of #422.

![giphy-16](https://user-images.githubusercontent.com/76330/76989508-631daf00-693e-11ea-98d4-014c6d897eb2.gif)
