### PR TITLE
K8's creds update script

### DIFF
--- a/infrastructure/scripts/update-kubernetes-config.sh
+++ b/infrastructure/scripts/update-kubernetes-config.sh
@@ -2,20 +2,16 @@
 set -euo pipefail
 
 PS3='Please enter your current environment: '
-OPTIONS=("non-prod" "prod" "dev" "quit")
+OPTIONS=("non-prod" "prod" "quit")
 
 select opt in "${OPTIONS[@]}"; do
   case "$opt,$REPLY" in
   non-prod,* | *,non-prod)
-    az aks get-credentials --resource-group 'adazr-rg-1001' --name 'aks'
+    az aks get-credentials --resource-group 'adazr-rg-1001' --name 'non-prod'
     break
     ;;
   prod,* | *,prod)
     echo 'TODO 🏗'
-    break
-    ;;
-  dev,* | *,dev)
-    az aks get-credentials --resource-group 'MHRA-dev' --name 'aks'
     break
     ;;
   quit,* | *,quit)


### PR DESCRIPTION
# Update Kubernetes cred script

Current **non-prod** cluster is called _non-prod_ instead of _aks_, so to enable automated update KUBECONFIG credentials, We changed the script to reflect that

![](https://media.giphy.com/media/X4SS63h7k5umY/giphy.gif)

### Acceptance Criteria

- When you run `update-kubernetes-config.sh` should update your K8's credentials
