### PR TITLE
Reload page so accepting cookies works in Safari

### DIFF
--- a/medicines/web/src/components/cookie-policy/index.tsx
+++ b/medicines/web/src/components/cookie-policy/index.tsx
@@ -56,6 +56,12 @@ interface ICookieBanner {
 const CookieBanner: React.FC<ICookieBanner> = props => {
   const buttonOnClick = () => {
     props.setStorageAllowed(true, true);
+
+    // Window reload required to trigger cookies in Safari.
+    // Strip trailing slash from URL path so routing works in dev.
+    window.location.href = window.location.href
+      .replace(/\/$/, '')
+      .replace(/\/\?/, '?');
   };
 
   // Set up state so that the banner is hidden by default.


### PR DESCRIPTION
Reload page so accepting cookies works in Safari.

Addressing an issue found while testing #498.

![giphy-17](https://user-images.githubusercontent.com/76330/77154910-865a7280-6a94-11ea-9218-2f906150cb53.gif)
