### PR TITLE
/healthz returns a blank response (204).

### DIFF
--- a/medicines/doc-index-updater/src/health.rs
+++ b/medicines/doc-index-updater/src/health.rs
@@ -1,34 +1,8 @@
-use warp::{
-    reply::{Json, Xml},
-    Filter, Rejection, Reply,
-};
-
-use std::collections::HashMap;
-
-fn get_health_handler() -> HashMap<String, bool> {
-    let mut result = HashMap::new();
-    result.insert("healthy".to_string(), true);
-
-    result
-}
-
-async fn get_health_handler_json() -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&get_health_handler()))
-}
-
-async fn get_health_handler_xml() -> Result<Xml, Rejection> {
-    Ok(warp::reply::xml(&get_health_handler()))
-}
+use warp::{http::StatusCode, Filter, Rejection, Reply};
 
 pub fn get_health() -> impl Filter<Extract = impl Reply, Error = Rejection> + Copy {
     warp::path!("healthz")
         .and(warp::get())
-        .and_then(get_health_handler_json)
-}
-
-pub fn get_health_xml() -> impl Filter<Extract = impl Reply, Error = Rejection> + Copy {
-    warp::path!("healthz")
-        .and(warp::get())
-        .and(warp::header::exact_ignore_case("accept", "application/xml"))
-        .and_then(get_health_handler_xml)
+        .map(warp::reply)
+        .map(|reply| warp::reply::with_status(reply, StatusCode::NO_CONTENT))
 }

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -41,8 +41,7 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     let _ = tokio::join!(
         tokio::spawn(async move {
             warp::serve(
-                health::get_health_xml()
-                    .or(health::get_health())
+                health::get_health()
                     .or(state_manager::get_job_status(state.clone()))
                     .or(state_manager::set_job_status(state.clone()))
                     .or(document_manager::check_in_xml_document(state.clone()))


### PR DESCRIPTION
# Replace /healthz response with 204 & no content

![](https://media.giphy.com/media/ZZiLDJ98R2GOY/giphy.gif)

### Acceptance Criteria

- [x] `/healthz` returns an empty response
- [x] `/healthz` returns a 204

### Testing information

GET /healthz

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
