### PR TITLE
Added correlation ids to log messages

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -74,7 +74,7 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Err
     let correlation_id = message.job_id.to_string();
     let correlation_id = correlation_id.as_str();
     
-    tracing::info!(
+    tracing::debug!(
         message = format!("Message received: {:?} ", message).as_str(),
         correlation_id
     );
@@ -94,15 +94,15 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Err
     let blob = create_blob(&storage_client, &file, metadata.clone()).await?;
     let name = blob.name.clone();
     
-    tracing::info!(
-        message = format!("Uploaded blob {}", &name).as_str(), 
+    tracing::debug!(
+        message = format!("Uploaded blob {}.", &name).as_str(), 
         correlation_id
     );
     
     add_blob_to_search_index(&search_client, blob).await?;
     
     tracing::info!(
-        message = format!("Added to index {}", &name).as_str(), 
+        message = format!("Successfully added {} to index.", &name).as_str(), 
         correlation_id
     );
     

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -50,9 +50,9 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
         e: anyhow::Error,
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
-        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file".to_string() {
+        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file" {
             tracing::warn!(
-                message = "Couldn't find file. Updating state to errored and removing message.", 
+                message = "Couldn't find file. Updating state to errored and removing message.",  
                 correlation_id = self.message.job_id.to_string().as_str()
             );
             let _ = state_manager

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -51,7 +51,7 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
         if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file".to_string() {
-            tracing::info!(
+            tracing::warn!(
                 message = "Couldn't find file. Updating state to errored and removing message.", 
                 correlation_id = self.message.job_id.to_string().as_str()
             );

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -50,8 +50,11 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
         e: anyhow::Error,
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
-        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file" {
-            tracing::info!("Updating state to errored and removing message");
+        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file".to_string() {
+            tracing::info!(
+                message = "Couldn't find file. Updating state to errored and removing message.", 
+                correlation_id = self.message.job_id.to_string().as_str()
+            );
             let _ = state_manager
                 .set_status(
                     self.message.job_id,
@@ -68,7 +71,10 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
 }
 
 pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Error> {
-    tracing::info!("Message received: {:?} ", message);
+    tracing::info!(
+        message = format!("Message received: {:?} ", message).as_str(),
+        correlation_id = message.job_id.to_string().as_str()
+    );
 
     let search_client = search_client::factory();
     let storage_client = storage_client::factory()
@@ -84,11 +90,15 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Err
     let metadata: BlobMetadata = message.document.into();
     let blob = create_blob(&storage_client, &file, metadata.clone()).await?;
     let name = blob.name.clone();
-    tracing::info!("Uploaded blob {} for job {}", &name, &message.job_id);
-
+    tracing::info!(
+        message = format!("Uploaded blob {}", &name).as_str(), 
+        correlation_id = &message.job_id.to_string().as_str()
+    );
     add_blob_to_search_index(&search_client, blob).await?;
-    tracing::info!("Added to index {} for job {}", &name, &message.job_id);
-
+    tracing::info!(
+        message = format!("Added to index {}", &name).as_str(), 
+        correlation_id = &message.job_id.to_string().as_str()
+    );
     Ok(message.job_id)
 }
 

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -29,7 +29,7 @@ pub async fn delete_service_worker(
             .await
         {
             Ok(()) => {}
-            Err(e) => tracing::error!("{:?}", e),
+            Err(e) => tracing::error!("{:?}", e)
         }
         delay_for(time_to_wait).await;
     }
@@ -42,9 +42,8 @@ impl ProcessRetrievalError for RetrievedMessage<DeleteMessage> {
         e: anyhow::Error,
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
-        tracing::info!(
-            "Setting error state in state manager for job {}",
-            self.message.job_id
+        tracing::info!(message = "Setting error state in state manager",
+            correlation_id = self.message.job_id.to_string().as_str()
         );
         state_manager
             .set_status(
@@ -71,28 +70,25 @@ pub async fn process_message(message: DeleteMessage) -> Result<Uuid, anyhow::Err
     let blob_name =
         get_blob_name_from_content_id(message.document_content_id.clone(), &search_client).await?;
     tracing::info!(
-        "Found blob name {} for document content ID {} from index for job {}",
-        &blob_name,
-        &message.document_content_id,
-        &message.job_id,
+        message = format!("Found blob name {} for document content ID {} from index", &blob_name, &message.document_content_id).as_str(),
+        correlation_id = &message.job_id.to_string().as_str()
     );
     delete_from_index(&search_client, &blob_name).await?;
     tracing::info!(
-        "Deleted blob {} from index for job {}",
-        &blob_name,
-        &message.job_id
+        message = format!("Deleted blob {} from index", &blob_name).as_str(),
+        correlation_id = &message.job_id.to_string().as_str()
     );
     delete_blob(&storage_client, &storage_container_name, &blob_name)
         .await
         .map_err(|e| {
-            tracing::error!("Error deleting blob: {:?}", e);
+            tracing::error!(
+                message = format!("Error deleting blob: {:?}", e).as_str(), 
+                correlation_id = &message.job_id.to_string().as_str());
             anyhow!("Couldn't delete blob {}", &blob_name)
         })?;
     tracing::info!(
-        "Deleted blob {} from storage container {} for job {}",
-        &blob_name,
-        &storage_container_name,
-        &message.job_id
+        message = format!("Deleted blob {} from storage container {}", &blob_name, &storage_container_name).as_str(),
+        correlation_id = &message.job_id.to_string().as_str()
     );
 
     Ok(message.job_id)
@@ -100,7 +96,7 @@ pub async fn process_message(message: DeleteMessage) -> Result<Uuid, anyhow::Err
 
 pub async fn get_blob_name_from_content_id(
     content_id: String,
-    search_client: &search_client::AzureSearchClient,
+    search_client: &search_client::AzureSearchClient
 ) -> Result<String, anyhow::Error> {
     let search_results = search_client.search(content_id.to_owned()).await?;
     for result in search_results.search_results {
@@ -108,8 +104,7 @@ pub async fn get_blob_name_from_content_id(
             return Ok(result.metadata_storage_name);
         }
     }
-    let error_message = format!("Cannot find document with content ID {}", content_id);
-    Err(anyhow!(error_message))
+    Err(anyhow!(format!("Cannot find document with content ID {}", content_id)))
 }
 
 async fn delete_blob(

--- a/medicines/doc-index-updater/src/search_client/mod.rs
+++ b/medicines/doc-index-updater/src/search_client/mod.rs
@@ -144,11 +144,12 @@ async fn search(
         .header("api-key", &config.api_key)
         .build()?;
 
-    println!("Requesting from URL: {}", &req.url());
+    tracing::debug!("Requesting from URL: {}", &req.url());
 
     client
         .execute(req)
         .await?
+        .error_for_status()?
         .json::<AzureSearchResults>()
         .await
 }

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -78,7 +78,7 @@ impl<T: Message> RetrievedMessage<T> {
             tracing::error!("{:?}", e);
             anyhow!("Queue Removal Error")
         })?;
-        tracing::info!("Removed job from ServiceBus ({:?})", queue_removal_result);
+        tracing::debug!("Removed job from ServiceBus ({:?})", queue_removal_result);
         Ok(queue_removal_result)
     }
 }
@@ -110,7 +110,7 @@ impl DocIndexUpdaterQueue {
             })?;
 
         if peek_lock.status() == StatusCode::NO_CONTENT {
-            tracing::info!("No new messages found.");
+            tracing::debug!("No new messages found.");
             return Err(RetrieveFromQueueError::NotFoundError);
         }
 
@@ -118,7 +118,7 @@ impl DocIndexUpdaterQueue {
 
         match body.parse::<T>() {
             Ok(message) => {
-                tracing::info!(
+                tracing::debug!(
                     "Message found perfectly parseable ({:?}).\n{:?}",
                     body,
                     message.to_json_string()
@@ -153,7 +153,7 @@ impl DocIndexUpdaterQueue {
         T: Message,
         RetrievedMessage<T>: ProcessRetrievalError,
     {
-        tracing::info!("Checking for messages.");
+        tracing::debug!("Checking for messages.");
         let retrieved_result: Result<RetrievedMessage<T>, RetrieveFromQueueError> =
             self.receive().await;
 

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -127,7 +127,7 @@ impl DocIndexUpdaterQueue {
             }
             Err(_) => {
                 tracing::error!(
-                    "Message found could not be parsed ({:?}). Gonna go ahead and delete it.",
+                    "Message found could not be parsed ({:?}). Deleting it.",
                     body
                 );
                 let _ = peek_lock.delete_message().await;
@@ -153,7 +153,7 @@ impl DocIndexUpdaterQueue {
         T: Message,
         RetrievedMessage<T>: ProcessRetrievalError,
     {
-        tracing::info!("Checking for messages");
+        tracing::info!("Checking for messages.");
         let retrieved_result: Result<RetrievedMessage<T>, RetrieveFromQueueError> =
             self.receive().await;
 
@@ -166,9 +166,8 @@ impl DocIndexUpdaterQueue {
                 }
                 Err(e) => {
                     tracing::error!(
-                        "Error {:?} while processing message {}",
-                        e,
-                        retrieval.message.get_id()
+                        message = format!("Error {:?}", e).as_str(),
+                        correlation_id = retrieval.message.get_id().to_string().as_str()
                     );
                     retrieval.handle_processing_error(e, &state_manager).await?;
                 }

--- a/medicines/doc-index-updater/src/state_manager/redis.rs
+++ b/medicines/doc-index-updater/src/state_manager/redis.rs
@@ -51,7 +51,7 @@ impl ToRedisArgs for JobStatus {
         W: ?Sized + RedisWrite,
     {
         let s = self.to_string();
-        tracing::info!("{:#}", s);
+        tracing::debug!("{:#}", s);
         out.write_arg(s.as_bytes());
     }
 }


### PR DESCRIPTION
# Correlation id of job id on messages

Adds correlation id to the structured trace/error messages

Relates to issue #523

![](https://media.giphy.com/media/QWvcBw9qXs9wiVypPm/giphy.gif)

### Acceptance Criteria

- [ ] Correlation id of the job id against log messages where that is available

### Testing information

logs are in json and look something like this
```
{"timestamp":"2020-03-23T16:17:18.317941+00:00 ","level":"ERROR","span":{"name":"create_service_worker","state_manager":"StateManager { client: Client { connection_info: ConnectionInfo { addr: Tcp(\"127.0.0.1\", 6379), db: 0, passwd: None } } }","time_to_wait":"30s"},"target":"doc_index_updater::service_bus_client","message":"Error Couldn't retrieve file: [-31] Failed opening remote file","correlation_id":"8aacd062-8179-4852-9f9d-58d4c7f961d3"}
```
### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
