### PR TITLE
Helpful bad STORAGE_MASTER_KEY error

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "azure_sdk_service_bus",
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",
- "base64 0.12.0",
+ "base64 0.11.0",
  "chrono",
  "futures",
  "hyper",

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -14,7 +14,7 @@ azure_sdk_service_bus = { git = "https://github.com/redbadger/AzureSDKForRust", 
 azure_sdk_storage_blob = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
 azure_sdk_storage_core = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
 chrono = "0.4.11"
-base64 = "0.12.0"
+base64 = "0.11.0"
 futures = "0.3.4"
 hyper = "0.13"
 lazy_static = "1.4.0"

--- a/medicines/doc-index-updater/src/auth_manager/mod.rs
+++ b/medicines/doc-index-updater/src/auth_manager/mod.rs
@@ -33,7 +33,7 @@ fn extract_encoded_credentials(auth_header: String) -> Option<String> {
 }
 
 fn decode_credentials(encoded_credentials: String) -> Option<(String, String)> {
-    if let Ok(credentials) = base64::decode(encoded_credentials) {
+    if let Ok(credentials) = base64::decode(&encoded_credentials) {
         let re = Regex::new(r"^(?P<username>\w+):(?P<password>\w+)$").unwrap();
         match re.captures(std::str::from_utf8(&credentials).unwrap_or("")) {
             Some(caps) => {

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -8,5 +8,8 @@ pub fn factory() -> Result<Client, AzureError> {
     let master_key =
         std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
 
-    Client::new(&storage_account, &master_key)
+    match base64::decode(&master_key) {
+        Ok(_) => Client::new(&storage_account, &master_key),
+        Err(e) => Err(AzureError::Base64DecodeError(e)),
+    }
 }


### PR DESCRIPTION
@craiga discovered while testing #427 that if his `STORAGE_MASTER_KEY` is weird, i.e. not a valid base64-encoded string, he gets an unhelpful and confusing error message about an unwrap at `azure_sdk_storage_core/src/rest_client.rs:415:17`.

This PR is to ensure we do a minimal check to highlight this problem, so devs spend less time hunting through dependent crates when their setup is marginally wrong.

### Acceptance Criteria

- [ ] When the retrieved `STORAGE_MASTER_KEY` is not a valid base64-encoded value, throw an error there and then

### Testing information

Add a character at the start of a valid `STORAGE_MASTER_KEY` to make it the wrong length.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
