### PR TITLE
Fail CI build if there are clippy warnings

### DIFF
--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Stuart Harris <stuart.harris@red-badger.com>", "Robin James Kerrison <robinjames.kerrison@red-badger.com>", "Matt Doughty <matt.doughty@red-badger.com>", "Pedro Martin <pedro.martin@red-badger.com>", "Craig Anderson <craig.anderson@red-badger.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1.0.26"
 async-trait = "0.1.24"

--- a/medicines/doc-index-updater/Dockerfile
+++ b/medicines/doc-index-updater/Dockerfile
@@ -1,11 +1,11 @@
 # Setup rust build environment
-FROM rust:1.41.0 AS build-context
+FROM rust:1.42.0 AS build-context
 
 RUN apt-get update && apt-get install -y \
   redis \
   ;
 
-RUN rustup component add rustfmt
+RUN rustup component add rustfmt clippy
 
 WORKDIR /usr/src/doc-index-updater
 
@@ -44,7 +44,8 @@ FROM build-context AS build
 
 COPY ./src ./src
 
-RUN cargo test --release && \
+RUN cargo clippy --release -- -D warnings && \
+  cargo test --release && \
   cargo build --release
 
 # Create the release

--- a/medicines/doc-index-updater/src/auth_manager/mod.rs
+++ b/medicines/doc-index-updater/src/auth_manager/mod.rs
@@ -1,4 +1,3 @@
-use base64;
 use futures::future;
 use regex::Regex;
 use warp::{Filter, Rejection};
@@ -67,10 +66,13 @@ fn attempt_basic_auth(auth_header: String) -> bool {
 pub fn with_basic_auth() -> impl Filter<Extract = (), Error = Rejection> + Copy {
     warp::header::optional::<String>("Authorization")
         .and_then(|header: Option<String>| match header {
-            Some(auth_header) => match attempt_basic_auth(auth_header) {
-                true => future::ok(()),
-                false => future::err(warp::reject::custom(AuthenticationFailed)),
-            },
+            Some(auth_header) => {
+                if attempt_basic_auth(auth_header) {
+                    future::ok(())
+                } else {
+                    future::err(warp::reject::custom(AuthenticationFailed))
+                }
+            }
             None => future::err(warp::reject::custom(AuthenticationFailed)),
         })
         .untuple_one()

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -50,7 +50,7 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
         e: anyhow::Error,
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
-        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file".to_string() {
+        if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file" {
             tracing::info!("Updating state to errored and removing message");
             let _ = state_manager
                 .set_status(
@@ -82,7 +82,7 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Err
     .map_err(|e| anyhow!("Couldn't retrieve file: {:?}", e))?;
 
     let metadata: BlobMetadata = message.document.into();
-    let blob = create_blob(&storage_client, &file, metadata.clone().into()).await?;
+    let blob = create_blob(&storage_client, &file, metadata.clone()).await?;
     let name = blob.name.clone();
     tracing::info!("Uploaded blob {} for job {}", &name, &message.job_id);
 

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 use chrono::{SecondsFormat, Utc};
-use lazy_static;
 use regex::Regex;
 use serde::Serialize;
 use std::{collections::HashMap, str};
@@ -57,7 +56,7 @@ impl Into<HashMap<String, String>> for BlobMetadata {
         let mut metadata: HashMap<String, String> = HashMap::new();
 
         metadata.insert("file_name".to_string(), self.file_name.clone());
-        metadata.insert("doc_type".to_string(), self.doc_type.clone().to_string());
+        metadata.insert("doc_type".to_string(), self.doc_type.to_string());
         metadata.insert("title".to_string(), self.title.clone());
         metadata.insert(
             "product_name".to_string(),
@@ -72,7 +71,7 @@ impl Into<HashMap<String, String>> for BlobMetadata {
             metadata.insert("keywords".to_string(), keywords.join(" "));
         }
         metadata.insert("pl_number".to_string(), self.pl_number.clone());
-        metadata.insert("author".to_string(), self.author.clone());
+        metadata.insert("author".to_string(), self.author);
 
         metadata
     }

--- a/medicines/doc-index-updater/tests/integration.rs
+++ b/medicines/doc-index-updater/tests/integration.rs
@@ -23,7 +23,7 @@ fn set_get_compatibility_on_state_manager(status: JobStatus) {
 
     let response = get_ok(state.set_status(id, status.clone()));
 
-    assert_eq!(response.status, status.clone());
+    assert_eq!(response.status, status);
 
     let response = get_ok(state.get_status(id));
     assert_eq!(response.status, status);
@@ -47,7 +47,7 @@ fn set_get_on_state_manager_endpoints(status: JobStatus) {
 
     let response: JobStatusResponse = serde_json::from_slice(r.body()).unwrap();
 
-    assert_eq!(response.status, status.clone());
+    assert_eq!(response.status, status);
 
     let r = block_on(
         warp::test::request()


### PR DESCRIPTION
The Docker build will fail now if clippy lints show warnings. Also fixes existing lint warnings in codebase.