### PR TITLE
Removing is_deleted from index

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -100,7 +100,6 @@ pub struct IndexEntry {
     suggestions: Vec<String>,
     substance_name: Vec<String>,
     facets: Vec<String>,
-    is_deleted: bool,
 }
 
 impl IndexEntry {
@@ -124,7 +123,6 @@ impl IndexEntry {
             suggestions: vec![],
             substance_name: blob.metadata.active_substances.clone(),
             facets: blob.metadata.facets(),
-            is_deleted: false,
             metadata_storage_content_type: String::default(),
             metadata_storage_size: blob.size,
             metadata_storage_last_modified: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),


### PR DESCRIPTION
# Remove is_deleted from index

Removes a field which is not in the index.

### Acceptance Criteria

- [ ] `is_deleted` is not part of `IndexEntry`
- [ ] Indexes created in non-prod with the right config

### Testing information

Run against non-prod by calling `make get-env`, then run `make`.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
