### PR TITLE
Add daily indexer schedule to indexer definition

### DIFF
--- a/medicines/search/definitions/indexers/default.json
+++ b/medicines/search/definitions/indexers/default.json
@@ -2,6 +2,10 @@
   "name": "INDEXER_NAME_PLACEHOLDER",
   "dataSourceName": "DATASOURCE_NAME_PLACEHOLDER",
   "targetIndexName": "INDEX_NAME_PLACEHOLDER",
+  "schedule": {
+    "interval": "P1D",
+    "startTime": "2020-01-01T00:00:00Z"
+  },
   "parameters": {
     "configuration": { "indexStorageMetadataOnlyForOversizedDocuments": true }
   },


### PR DESCRIPTION
# Add daily schedule for indexer to run

Relates to #396 
See [documentation](https://docs.microsoft.com/en-us/rest/api/searchservice/create-indexer#indexer-schedule) for adding a scheduler when creating indexers.

![](https://media.giphy.com/media/RHYMdZNKkxO48/giphy.gif)

### Acceptance Criteria

- [ ] Creates an indexer with a schedule to run once daily

### Testing information

- Delete existing indexer in non-prod environment
- Set environment variables necessary for non-prod and `az login`
- Execute `cargo run create_indexer`

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
