### PR TITLE
Add fuzzy search functionality back in

### DIFF
--- a/medicines/web/cypress/integration/tests.js
+++ b/medicines/web/cypress/integration/tests.js
@@ -34,43 +34,43 @@ Cypress.on('window:before:load', win => {
 
 const mockParacetamolResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(paracetamol~1||paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(paracetamol~1+||+paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockParacetamolResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(paracetamol~1||paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(paracetamol~1+||+paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockIbuprofenResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1+||+ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockIbuprofenResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1+||+ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.page2.json',
   );
 
 const mockIbuprofenSpcResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1+||+ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
     'fixture:search_results.spc.json',
   );
 
 const mockIbuprofenSpcResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1+||+ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
     'fixture:search_results.spc.page2.json',
   );
 
 const mockIbuprofenSpcPilResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc'+or+doc_type+eq+'Pil')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1+||+ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc'+or+doc_type+eq+'Pil')`,
     'fixture:search_results.spcpil.json',
   );
 

--- a/medicines/web/cypress/integration/tests.js
+++ b/medicines/web/cypress/integration/tests.js
@@ -34,43 +34,43 @@ Cypress.on('window:before:load', win => {
 
 const mockParacetamolResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(paracetamol~1||paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockParacetamolResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=paracetamol~1+paracetamol^4&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(paracetamol~1||paracetamol^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockIbuprofenResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=ibuprofen~1+ibuprofen^4&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.json',
   );
 
 const mockIbuprofenResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=ibuprofen~1+ibuprofen^4&scoringProfile=preferKeywords&searchMode=all`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all`,
     'fixture:search_results.page2.json',
   );
 
 const mockIbuprofenSpcResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=ibuprofen~1+ibuprofen^4&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
     'fixture:search_results.spc.json',
   );
 
 const mockIbuprofenSpcResultsPage2 = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=ibuprofen~1+ibuprofen^4&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=10&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc')`,
     'fixture:search_results.spc.page2.json',
   );
 
 const mockIbuprofenSpcPilResults = () =>
   cy.route(
-    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=ibuprofen~1+ibuprofen^4&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc'+or+doc_type+eq+'Pil')`,
+    `${baseUrl}?${apiKey}&${genericSearchParams}&$top=10&$skip=0&search=(ibuprofen~1||ibuprofen^4)&scoringProfile=preferKeywords&searchMode=all&$filter=(doc_type+eq+'Spc'+or+doc_type+eq+'Pil')`,
     'fixture:search_results.spcpil.json',
   );
 

--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -11,26 +11,26 @@ describe(buildFuzzyQuery, () => {
       'bacteriostatic solvent (0.3%w/v metacresol in wfi)',
     );
     expect(fuzzyQuery).toBe(
-      '(bacteriostatic~1||bacteriostatic^4) (solvent~1||solvent^4) (0.3~1||0.3^4) (w~1||w^4) (v~1||v^4) (metacresol~1||metacresol^4) (in~1||in^4) (wfi~1||wfi^4)',
+      '(bacteriostatic~1 || bacteriostatic^4) (solvent~1 || solvent^4) (0.3~1 || 0.3^4) (w~1 || w^4) (v~1 || v^4) (metacresol~1 || metacresol^4) (in~1 || in^4) (wfi~1 || wfi^4)',
     );
   });
 
   it('builds fuzzy words from product name', () => {
     const fuzzyQuery = buildFuzzyQuery('K/L POULTICE (KAOLIN POULTICE BP)');
     expect(fuzzyQuery).toBe(
-      '(K~1||K^4) (L~1||L^4) (POULTICE~1||POULTICE^4) (KAOLIN~1||KAOLIN^4) (POULTICE~1||POULTICE^4) (BP~1||BP^4)',
+      '(K~1 || K^4) (L~1 || L^4) (POULTICE~1 || POULTICE^4) (KAOLIN~1 || KAOLIN^4) (POULTICE~1 || POULTICE^4) (BP~1 || BP^4)',
     );
   });
 
   it('normalizes product licence', () => {
     const fuzzyQuery = buildFuzzyQuery('pl 30464/0140');
-    expect(fuzzyQuery).toBe('(PL304640140~1||PL304640140^4)');
+    expect(fuzzyQuery).toBe('(PL304640140~1 || PL304640140^4)');
   });
 
   it('extracts and normalizes product licence', () => {
     const fuzzyQuery = buildFuzzyQuery('amlodipine pl 30464/0140');
     expect(fuzzyQuery).toBe(
-      '(amlodipine~1||amlodipine^4) (PL304640140~1||PL304640140^4)',
+      '(amlodipine~1 || amlodipine^4) (PL304640140~1 || PL304640140^4)',
     );
   });
 });

--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -11,26 +11,26 @@ describe(buildFuzzyQuery, () => {
       'bacteriostatic solvent (0.3%w/v metacresol in wfi)',
     );
     expect(fuzzyQuery).toBe(
-      'bacteriostatic~1 bacteriostatic^4 solvent~1 solvent^4 0.3~1 0.3^4 w~1 w^4 v~1 v^4 metacresol~1 metacresol^4 in~1 in^4 wfi~1 wfi^4',
+      '(bacteriostatic~1||bacteriostatic^4) (solvent~1||solvent^4) (0.3~1||0.3^4) (w~1||w^4) (v~1||v^4) (metacresol~1||metacresol^4) (in~1||in^4) (wfi~1||wfi^4)',
     );
   });
 
   it('builds fuzzy words from product name', () => {
     const fuzzyQuery = buildFuzzyQuery('K/L POULTICE (KAOLIN POULTICE BP)');
     expect(fuzzyQuery).toBe(
-      'K~1 K^4 L~1 L^4 POULTICE~1 POULTICE^4 KAOLIN~1 KAOLIN^4 POULTICE~1 POULTICE^4 BP~1 BP^4',
+      '(K~1||K^4) (L~1||L^4) (POULTICE~1||POULTICE^4) (KAOLIN~1||KAOLIN^4) (POULTICE~1||POULTICE^4) (BP~1||BP^4)',
     );
   });
 
   it('normalizes product licence', () => {
     const fuzzyQuery = buildFuzzyQuery('pl 30464/0140');
-    expect(fuzzyQuery).toBe('PL304640140~1 PL304640140^4');
+    expect(fuzzyQuery).toBe('(PL304640140~1||PL304640140^4)');
   });
 
   it('extracts and normalizes product licence', () => {
     const fuzzyQuery = buildFuzzyQuery('amlodipine pl 30464/0140');
     expect(fuzzyQuery).toBe(
-      'amlodipine~1 amlodipine^4 PL304640140~1 PL304640140^4',
+      '(amlodipine~1||amlodipine^4) (PL304640140~1||PL304640140^4)',
     );
   });
 });

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -10,7 +10,7 @@ const escapeSpecialWords = (word: string): string =>
   word.replace(/(\|\||&&|\bAND\b|\bOR\b|\bNOT\b)/gi, `\\$1`);
 
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
-  `${word}~${searchWordFuzziness} ${word}^${searchExactnessBoost}`;
+  `(${word}~${searchWordFuzziness}||${word}^${searchExactnessBoost})`;
 
 const extractNormalizedProductLicenses = (q: string): string => {
   const normalizedProductLicences = q

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -10,7 +10,7 @@ const escapeSpecialWords = (word: string): string =>
   word.replace(/(\|\||&&|\bAND\b|\bOR\b|\bNOT\b)/gi, `\\$1`);
 
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
-  `(${word}~${searchWordFuzziness}||${word}^${searchExactnessBoost})`;
+  `(${word}~${searchWordFuzziness} || ${word}^${searchExactnessBoost})`;
 
 const extractNormalizedProductLicenses = (q: string): string => {
   const normalizedProductLicences = q


### PR DESCRIPTION
# Add search functionality back in
Relates to #558

![](https://media.giphy.com/media/gRcnTd940VFIY/giphy.gif)

### Acceptance Criteria
- [ ] Search for words or phrases that have at most one typo per word return sensible results

### Testing information
- Search for "paracetamon" returns the same top results as "paracetamol" (but not necessarily same number of results in total)
- Search for "ibuproven gel" returns the same top results as "ibuprofen gel" (but not necessarily same number of results in total)

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
