### PR TITLE
Overrides for .env that don't get blasted with make get-env

### DIFF
--- a/medicines/doc-index-updater/Makefile
+++ b/medicines/doc-index-updater/Makefile
@@ -4,7 +4,7 @@ tag := latest
 
 .PHONY: default
 default: ## run locally
-	export $$(cat .env | xargs) && cargo run
+	export $$(cat .env .env.overrides 2> /dev/null | xargs) && cargo run
 
 .PHONY: get-env
 get-env: ## run locally


### PR DESCRIPTION
# Have a local env file that gets applied after .env for cargo run

put any overrides in .env.overrides locally and they will replace any environment variables you want to keep for your local setup whilst still allowing you to do `make get-env` to bring at the rest up to date

![](https://media.giphy.com/media/l2JejvkIM7havSTPa/giphy.gif)

### Acceptance Criteria

- [ ] overrides .env variables without changing .env file (using .env.overrides)

### Testing information

Create a .env.overrides file and change something that is set in .env - eg `JSON_LOGS=true` and see that cargo run now uses that (but also all the main .env variables)

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
