### PR TITLE
Get job status XML endpoint

### DIFF
--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
         tokio::spawn(async move {
             warp::serve(
                 health::get_health()
+                    .or(state_manager::get_job_status_xml(state.clone()))
                     .or(state_manager::get_job_status(state.clone()))
                     .or(state_manager::set_job_status(state.clone()))
                     .or(document_manager::check_in_xml_document(state.clone()))


### PR DESCRIPTION
# Get job status with an XML response

Fixes #582.

![](https://media.giphy.com/media/xT5LMGufvl9b2Jlbji/giphy.gif)

### Acceptance Criteria

- [ ] Calling the `jobs/<id>` endpoint with a header `Accept: application/xml` receives an XML response

### Testing information

Running this

```sh
curl -vvv http://localhost:8000/jobs/c8ef024d-6efd-414a-8271-54d2dbb29668 \
-u username:password \
-H "Accept: application/xml"
```

should return this

```<job><id>c8ef024d-6efd-414a-8271-54d2dbb29668</id><status>Done</status></job>```

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
