### PR TITLE
Pointing to MindFlavor/AzureSDKForRust master

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "azure_sdk_core"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
+source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
 dependencies = [
  "RustyXML",
  "base64 0.11.0",
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_service_bus"
 version = "0.42.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
+source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_storage_blob"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
+source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "azure_sdk_storage_core"
 version = "0.40.0"
-source = "git+https://github.com/redbadger/AzureSDKForRust?branch=service-bus-peek-lock-timeout#ce612fd96759e2514b4611a039fb9726e0995645"
+source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.26"
 async-trait = "0.1.24"
-azure_sdk_core = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
-azure_sdk_service_bus = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
-azure_sdk_storage_blob = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
-azure_sdk_storage_core = { git = "https://github.com/redbadger/AzureSDKForRust", branch = "service-bus-peek-lock-timeout" }
+azure_sdk_core = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
+azure_sdk_service_bus = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
+azure_sdk_storage_blob = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
+azure_sdk_storage_core = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
 chrono = "0.4.11"
 base64 = "0.11.0"
 futures = "0.3.4"


### PR DESCRIPTION
After MindFlavor/AzureSDKForRust#247, we can use **master**. We can't yet use a release, as the release hasn't happened yet.

![Tapping](https://media.giphy.com/media/25A17crsUbYje/giphy.gif)

### Acceptance Criteria

- [ ] All Azure operations still work
- [ ] We are using MindFlavor/AzureSDKForRust for azure crates

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
