### PR TITLE
Rename list items to be singular version of list name

### DIFF
--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -109,18 +109,21 @@ impl Into<Document> for XMLDocument {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Product {
     #[serde(default)]
+    #[serde(rename = "product")]
     pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Keyword {
     #[serde(default)]
+    #[serde(rename = "keyword")]
     pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActiveSubstance {
     #[serde(default)]
+    #[serde(rename = "active_substance")]
     pub name: String,
 }
 


### PR DESCRIPTION
# Rename list items to be singular version of list name

Currently the XML deserialization relies on the individual liste items of the `products`, `active_substances` and `keywords` lists being enclosed in `name` tags, which isn't that intiuitive.

This PR adds deserialization for the singular versions (`product`, `active_substance` and `keyword`).

![](https://media.giphy.com/media/iSKSQoRNzzNsY/giphy.gif)

### Acceptance Criteria

- [ ] XML requests use the singular name of each list name for list items

### Testing information
Make an xml request with the following body and ensure the fields get deserialized as expected:
`<document>
  <id>con33333333</id>
  <name>Name of an SPC</name>
  <type>SPC</type>
  <author>theauthor</author>
  <products>
    <product>Generic Statin</product>
  </products>
  <pl_number>PL 12345/0010-0001</pl_number>
  <active_substances>
    <active_substance>statin</active_substance>
  </active_substances>
  <keywords>
  	<keyword>a keyword</keyword>
  </keywords>
  <file_source>Sentinel</file_source>
  <file_path>example_file.txt</file_path>
</document>`

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
