### PR TITLE
More structure to the logs

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -51,10 +51,7 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
         if e.to_string() == "Couldn't retrieve file: [-31] Failed opening remote file" {
-            tracing::warn!(
-                message = "Couldn't find file. Updating state to errored and removing message.",
-                correlation_id = self.message.job_id.to_string().as_str()
-            );
+            tracing::warn!("Couldn't find file. Updating state to errored and removing message.");
             let _ = state_manager
                 .set_status(
                     self.message.job_id,

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -22,7 +22,6 @@ mod sanitiser;
 mod search_index;
 mod sftp_client;
 
-#[tracing::instrument(skip(state_manager))]
 pub async fn create_service_worker(
     time_to_wait: Duration,
     state_manager: StateManager,
@@ -72,13 +71,7 @@ impl ProcessRetrievalError for RetrievedMessage<CreateMessage> {
 }
 
 pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Error> {
-    let correlation_id = message.job_id.to_string();
-    let correlation_id = correlation_id.as_str();
-
-    tracing::debug!(
-        message = format!("Message received: {:?} ", message).as_str(),
-        correlation_id
-    );
+    tracing::debug!("Message received: {:?} ", message);
 
     let search_client = search_client::factory();
     let storage_client = storage_client::factory()
@@ -95,17 +88,11 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, anyhow::Err
     let blob = create_blob(&storage_client, &file, metadata.clone()).await?;
     let name = blob.name.clone();
 
-    tracing::debug!(
-        message = format!("Uploaded blob {}.", &name).as_str(),
-        correlation_id
-    );
+    tracing::debug!("Uploaded blob {}.", &name);
 
     add_blob_to_search_index(&search_client, blob).await?;
 
-    tracing::info!(
-        message = format!("Successfully added {} to index.", &name).as_str(),
-        correlation_id
-    );
+    tracing::info!("Successfully added {} to index.", &name);
 
     Ok(message.job_id)
 }

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -41,10 +41,7 @@ impl ProcessRetrievalError for RetrievedMessage<DeleteMessage> {
         e: anyhow::Error,
         state_manager: &StateManager,
     ) -> anyhow::Result<()> {
-        tracing::info!(
-            message = "Setting error state in state manager",
-            correlation_id = self.message.job_id.to_string().as_str()
-        );
+        tracing::info!("Setting error state in state manager");
         state_manager
             .set_status(
                 self.message.job_id,

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use tokio::time::delay_for;
 use uuid::Uuid;
 
-#[tracing::instrument(skip(state_manager))]
 pub async fn delete_service_worker(
     time_to_wait: Duration,
     state_manager: StateManager,
@@ -63,9 +62,6 @@ impl ProcessRetrievalError for RetrievedMessage<DeleteMessage> {
 pub async fn process_message(message: DeleteMessage) -> Result<Uuid, anyhow::Error> {
     tracing::info!("Message received: {:?} ", message);
 
-    let correlation_id = message.job_id.to_string();
-    let correlation_id = correlation_id.as_str();
-
     let search_client = search_client::factory();
     let storage_client = storage_client::factory()
         .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
@@ -75,34 +71,22 @@ pub async fn process_message(message: DeleteMessage) -> Result<Uuid, anyhow::Err
         get_blob_name_from_content_id(message.document_content_id.clone(), &search_client).await?;
 
     tracing::info!(
-        message = format!(
-            "Found blob name {} for document content ID {} from index",
-            &blob_name, &message.document_content_id
-        )
-        .as_str(),
-        correlation_id
+        "Found blob name {} for document content ID {} from index",
+        &blob_name,
+        &message.document_content_id
     );
     delete_from_index(&search_client, &blob_name).await?;
-    tracing::info!(
-        message = format!("Deleted blob {} from index", &blob_name).as_str(),
-        correlation_id
-    );
+    tracing::info!("Deleted blob {} from index", &blob_name);
     delete_blob(&storage_client, &storage_container_name, &blob_name)
         .await
         .map_err(|e| {
-            tracing::error!(
-                message = format!("Error deleting blob: {:?}", e).as_str(),
-                correlation_id
-            );
+            tracing::error!("Error deleting blob: {:?}", e);
             anyhow!("Couldn't delete blob {}", &blob_name)
         })?;
     tracing::info!(
-        message = format!(
-            "Deleted blob {} from storage container {}",
-            &blob_name, &storage_container_name
-        )
-        .as_str(),
-        correlation_id
+        "Deleted blob {} from storage container {}",
+        &blob_name,
+        &storage_container_name
     );
 
     Ok(message.job_id)

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -232,7 +232,7 @@ impl Message for CreateMessage {
         crate::create_manager::process_message(self.clone())
             .instrument(tracing::info_span!(
                 "processing_CREATE",
-                correlation_id = self.get_id().to_string().as_str()
+                correlation_id = self.get_id().to_string().as_str()         
             ))
             .await
     }

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -3,6 +3,7 @@ use core::fmt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use tracing_futures::Instrument;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -226,8 +227,14 @@ impl Message for CreateMessage {
     fn to_json_string(&self) -> Result<String, serde_json::Error> {
         Ok(serde_json::to_string(&self)?)
     }
+
     async fn process(self) -> std::result::Result<uuid::Uuid, anyhow::Error> {
-        crate::create_manager::process_message(self).await
+        crate::create_manager::process_message(self.clone())
+            .instrument(tracing::info_span!(
+                "processing_CREATE",
+                correlation_id = self.get_id().to_string().as_str()
+            ))
+            .await
     }
 }
 
@@ -240,8 +247,14 @@ impl Message for DeleteMessage {
     fn to_json_string(&self) -> Result<String, serde_json::Error> {
         Ok(serde_json::to_string(&self)?)
     }
+
     async fn process(self) -> std::result::Result<uuid::Uuid, anyhow::Error> {
-        crate::delete_manager::process_message(self).await
+        crate::delete_manager::process_message(self.clone())
+            .instrument(tracing::info_span!(
+                "processing_DELETE",
+                correlation_id = self.get_id().to_string().as_str()
+            ))
+            .await
     }
 }
 

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use tracing_futures::Instrument;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -229,12 +228,7 @@ impl Message for CreateMessage {
     }
 
     async fn process(self) -> std::result::Result<uuid::Uuid, anyhow::Error> {
-        crate::create_manager::process_message(self.clone())
-            .instrument(tracing::info_span!(
-                "processing_CREATE",
-                correlation_id = self.get_id().to_string().as_str()         
-            ))
-            .await
+        crate::create_manager::process_message(self.clone()).await
     }
 }
 
@@ -249,12 +243,7 @@ impl Message for DeleteMessage {
     }
 
     async fn process(self) -> std::result::Result<uuid::Uuid, anyhow::Error> {
-        crate::delete_manager::process_message(self.clone())
-            .instrument(tracing::info_span!(
-                "processing_DELETE",
-                correlation_id = self.get_id().to_string().as_str()
-            ))
-            .await
+        crate::delete_manager::process_message(self.clone()).await
     }
 }
 

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -170,7 +170,10 @@ impl DocIndexUpdaterQueue {
             let correlation_id = correlation_id.as_str();
 
             process(retrieval, state_manager)
-                .instrument(tracing::info_span!("processing", correlation_id))
+                .instrument(tracing::info_span!(
+                    "try_process_from_queue",
+                    correlation_id
+                ))
                 .await?
         }
         Ok(())

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -10,6 +10,7 @@ use azure_sdk_service_bus::{event_hub::PeekLockResponse, prelude::Client};
 use hyper::StatusCode;
 use std::error::Error;
 use time::Duration;
+use tracing_futures::Instrument;
 
 pub async fn delete_factory() -> Result<DocIndexUpdaterQueue, AzureError> {
     let service_bus_namespace = std::env::var("SERVICE_BUS_NAMESPACE")
@@ -155,7 +156,7 @@ impl DocIndexUpdaterQueue {
     pub async fn try_process_from_queue<T>(
         &mut self,
         state_manager: &StateManager,
-    ) -> Result<(), anyhow::Error>
+    ) -> anyhow::Result<()>
     where
         T: Message,
         RetrievedMessage<T>: ProcessRetrievalError,
@@ -168,19 +169,33 @@ impl DocIndexUpdaterQueue {
             let correlation_id = retrieval.message.get_id().to_string();
             let correlation_id = correlation_id.as_str();
 
-            let processing_result = retrieval.message.clone().process().await;
-
-            match processing_result {
-                Ok(job_id) => {
-                    state_manager.set_status(job_id, JobStatus::Done).await?;
-                    retrieval.remove().await?;
-                }
-                Err(e) => {
-                    tracing::error!(message = format!("Error {:?}", e).as_str(), correlation_id);
-                    retrieval.handle_processing_error(e, &state_manager).await?;
-                }
-            };
+            process(retrieval, state_manager)
+                .instrument(tracing::info_span!("processing", correlation_id))
+                .await?
         }
         Ok(())
     }
+}
+
+async fn process<T>(
+    retrieval: RetrievedMessage<T>,
+    state_manager: &StateManager,
+) -> anyhow::Result<()>
+where
+    T: Message,
+    RetrievedMessage<T>: ProcessRetrievalError,
+{
+    let processing_result = retrieval.message.clone().process().await;
+
+    match processing_result {
+        Ok(job_id) => {
+            state_manager.set_status(job_id, JobStatus::Done).await?;
+            retrieval.remove().await?;
+        }
+        Err(e) => {
+            tracing::error!(message = format!("Error {:?}", e).as_str());
+            retrieval.handle_processing_error(e, &state_manager).await?;
+        }
+    };
+    Ok(())
 }


### PR DESCRIPTION
# Simplification of logging with more standard structure

QA from @craiga highlighted that correlation id was sometimes in "span" and sometimes in "fields" and sometimes not there at all in the logs.

This has now been corrected and standardised so that the whole flow can be seen in the same structure of correlation_id in the span in the tracing logs.

![](https://media.giphy.com/media/vS2qy4SjaX2ta/giphy.gif)

### Acceptance Criteria

- [ ] correlation_id only in spans
- [ ] whole thread of execution (create/delete) can be traced on azure monitor with correlation_id


### Testing information

JSON_LOGS=true/false  to see the correlation ids - nicer view locally with false.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
