### PR TITLE
Correctly parse PL number when converting from Document to BlobMetadata.

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/sanitiser.rs
+++ b/medicines/doc-index-updater/src/create_manager/sanitiser.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SanitisedString {
     inner: String,
 }
@@ -31,7 +31,7 @@ impl ToString for SanitisedString {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VecSanitisedString {
     inner: Vec<String>,
 }


### PR DESCRIPTION
# A nice friendly title for what this PR does

_Correctly populate PL number in blob storage uploads._

![](https://media.giphy.com/media/dSd0f3W5zOzAmBfeW3/giphy.gif)

### Acceptance Criteria

- [x] PL number should be populated correctly when uploading via doc-index-updater
- [x] Test to cover the above

### Testing information

1. Run the automated tests;
2. Send a request to create a document, make sure the PL number is present on Azure storage & index.

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
