### PR TITLE
Log sftp file and dir info for debugging

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -100,7 +100,7 @@ async fn retrieve_file_from_sftp(
             }
         }
         else {
-            tracing::debug!("Couldn't find dir contents", file_stat);
+            tracing::debug!("Couldn't find dir contents");
         }
     }
 

--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -91,9 +91,9 @@ async fn retrieve_file_from_sftp(
     // Additional logging to debug observed sftp issue
     // in nonprod environment
     let parent_dir = path.parent();
-    if let Some(parnet_dir_path) = parent_dir {
-        tracing::debug!("Finding contents of {:?}", &parnet_dir_path);
-        if let Ok(file_stats) = sftp.readdir(parnet_dir_path) {
+    if let Some(parent_dir_path) = parent_dir {
+        tracing::debug!("Finding contents of {:?}", &parent_dir_path);
+        if let Ok(file_stats) = sftp.readdir(parent_dir_path) {
             for (path_buf, file_stat) in file_stats {
                 tracing::debug!("{:?}", path_buf.to_str());
                 tracing::debug!("File stats: {:#?}", file_stat);

--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -87,6 +87,19 @@ async fn retrieve_file_from_sftp(
         Err(_) => path,
     };
     tracing::info!("{:?}", path);
+
+    let dir = path.parent();
+    if let Some(d_path) = dir {
+        tracing::info!("Finding contents of {:?}", &d_path);
+        let files_result = sftp.readdir(d_path);
+        if let Ok(file_stats) = files_result {
+            for (path_buf, file_stat) in file_stats {
+                tracing::info!("{:?}", path_buf.to_str());
+                tracing::info!("File stats: {:#?}", file_stat);
+            }
+        }
+    }
+
     Ok(sftp.open(path).map_err(|e| {
         tracing::error!("{:?}", e);
         e

--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -88,15 +88,19 @@ async fn retrieve_file_from_sftp(
     };
     tracing::info!("{:?}", path);
 
+    // Additional logging to debug observed sftp issue
+    // in nonprod environment
     let parent_dir = path.parent();
     if let Some(parnet_dir_path) = parent_dir {
-        tracing::info!("Finding contents of {:?}", &parnet_dir_path);
-        let files_result = sftp.readdir(parnet_dir_path);
-        if let Ok(file_stats) = files_result {
+        tracing::debug!("Finding contents of {:?}", &parnet_dir_path);
+        if let Ok(file_stats) = sftp.readdir(parnet_dir_path) {
             for (path_buf, file_stat) in file_stats {
-                tracing::info!("{:?}", path_buf.to_str());
-                tracing::info!("File stats: {:#?}", file_stat);
+                tracing::debug!("{:?}", path_buf.to_str());
+                tracing::debug!("File stats: {:#?}", file_stat);
             }
+        }
+        else {
+            tracing::debug!("Couldn't find dir contents", file_stat);
         }
     }
 

--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -88,10 +88,10 @@ async fn retrieve_file_from_sftp(
     };
     tracing::info!("{:?}", path);
 
-    let dir = path.parent();
-    if let Some(d_path) = dir {
-        tracing::info!("Finding contents of {:?}", &d_path);
-        let files_result = sftp.readdir(d_path);
+    let parent_dir = path.parent();
+    if let Some(parnet_dir_path) = parent_dir {
+        tracing::info!("Finding contents of {:?}", &parnet_dir_path);
+        let files_result = sftp.readdir(parnet_dir_path);
         if let Ok(file_stats) = files_result {
             for (path_buf, file_stat) in file_stats {
                 tracing::info!("{:?}", path_buf.to_str());


### PR DESCRIPTION
# Log sftp file and dir info for debugging

Relates to #619
Log info about all files in the request file's containing directory, along with permissions info, in order to better diagnose sftp "File could not be opened" issue.

### Acceptance Criteria

- [ ] Info about file and dir written to logs

### Testing information

- Check in file
- Observe logs to see file and dir info written

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
