### PR TITLE
unstructured error debug string at end of message

### DIFF
--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -46,7 +46,7 @@ where
         Ok(_) => Ok(state_manager.get_status(message.get_id()).await?),
         Err(e) => {
             tracing::error!(
-                "{:?}. Failed to dispatch to queue. Check API Keys or Policy values in environment variables.",
+                "Failed to dispatch to queue. Check environment variables align for queue names, policies and keys. Error: ({:?})",
                 e
             );
             let state = state_manager


### PR DESCRIPTION
Proposed change for #622 to make the error debug printout the last part of the custom error log.

![JJ editing hard](https://media.giphy.com/media/XaqTwZmFkJGHS/giphy.gif)
