### PR TITLE
sftp: replace assert panic with error

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -32,7 +32,7 @@ impl BlobMetadata {
 impl Into<BlobMetadata> for Document {
     fn into(self) -> BlobMetadata {
         let title = SanitisedString::from(&self.name);
-        let pl_number = extract_product_licences(&self.pl_number.to_string());
+        let pl_number = extract_product_licences(&self.pl_number);
 
         BlobMetadata {
             file_name: SanitisedString::from(&self.id),


### PR DESCRIPTION
Replaces an `assert!` panic with a returned error if sftp session is not authenticated.