### PR TITLE
add GSSAPIAuthentication no to ssh config

### DIFF
--- a/medicines/doc-index-updater/Dockerfile
+++ b/medicines/doc-index-updater/Dockerfile
@@ -55,6 +55,13 @@ COPY --from=build /usr/src/doc-index-updater/target/release/doc_index_updater /
 
 RUN chown -R svc /doc_index_updater
 
+RUN (cd $HOME && \
+  mkdir -p .ssh && \
+  chown svc .ssh && \
+  cd .ssh && \
+  echo "GSSAPIAuthentication no" >>config && \
+  chown svc config)
+
 USER svc
 
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
Adds `GSSAPIAuthentication no` to `~/.ssh/config` (as per https://askubuntu.com/questions/246323/why-does-sshs-password-prompt-take-so-long-to-appear) in an attempt to speed up `sftp` transactions.