### PR TITLE
Set delegate credentials to yes in ssh config file

### DIFF
--- a/medicines/doc-index-updater/Dockerfile
+++ b/medicines/doc-index-updater/Dockerfile
@@ -60,6 +60,7 @@ RUN (cd $HOME && \
   chown svc .ssh && \
   cd .ssh && \
   echo "GSSAPIAuthentication no" >>config && \
+  echo "GSSAPIDelegateCredentials yes" >>config && \
   chown svc config)
 
 USER svc


### PR DESCRIPTION
# Set delegate credentials to yes in ssh config file

Adds GSSAPIDelegateCredentials yes to ~/.ssh/config (as per https://superuser.com/questions/359344/ssh-is-slow-to-make-a-connection) in an attempt to speed up sftp transactions.
