### PR TITLE
Don't strip leading slash from sftp file path

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/sftp_client.rs
+++ b/medicines/doc-index-updater/src/create_manager/sftp_client.rs
@@ -70,10 +70,7 @@ async fn retrieve_file_from_sftp(
     filepath: String,
 ) -> Result<File, anyhow::Error> {
     let path = std::path::Path::new(&filepath);
-    let path = match path.strip_prefix("/") {
-        Ok(p) => p,
-        Err(_) => path,
-    };
+
     tracing::info!("{:?}", path);
 
     // Additional logging to debug observed sftp issue


### PR DESCRIPTION
# Don't strip leading slash from sftp file path

Could be causing issues opening files from Sentinel - all file paths are absolute but default dir when logging into an sftp server is home. We sometimes see "file could not be found" issue and this would help to rule out this class of error.