### PR TITLE
Test get blob from content id

### DIFF
--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -254,22 +254,27 @@ mod test {
 
     fn when_getting_blob_name_from_content_id(
         search_client: impl Searchable,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String, ProcessMessageError> {
         block_on(get_blob_name_from_content_id(
             String::from("non existent content id"),
             &search_client,
         ))
     }
 
-    fn then_document_not_found_in_index_error_raised(result: Result<String, anyhow::Error>) {
+    fn then_document_not_found_in_index_error_raised(result: Result<String, ProcessMessageError>) {
         assert_eq!(result.is_err(), true);
 
-        println!("{:?}", result);
-
-        match result {
-            Ok(_) => assert!(false, "Should have been an error"),
-            Err(e) => assert_eq!(e.is::<errors::DocumentNotFoundInIndex>(), true),
-        }
+        assert!(
+            if let Err(ProcessMessageError::DocumentNotFoundInIndex(_)) = result {
+                true
+            } else {
+                false
+            },
+            format!(
+                "Should have been an error with type: DocumentNotFoundInIndex, but was {:?}",
+                result
+            )
+        );
     }
 
     struct TestAzureSearchClientWithNoResults {}

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -243,11 +243,13 @@ mod test {
 
     #[test]
     fn get_blob_name_from_content_id_raises_document_not_found_in_index_error_when_not_there() {
-        let search_client = TestAzureSearchClientWithNoResults {};
-
+        let search_client = given_a_search_client_that_returns_no_results();
         let result = when_getting_blob_name_from_content_id(search_client);
-
         then_document_not_found_in_index_error_raised(result);
+    }
+
+    fn given_a_search_client_that_returns_no_results() -> impl Searchable {
+        TestAzureSearchClientWithNoResults {}
     }
 
     fn when_getting_blob_name_from_content_id(
@@ -269,6 +271,7 @@ mod test {
             Err(e) => assert_eq!(e.is::<errors::DocumentNotFoundInIndex>(), true),
         }
     }
+
     struct TestAzureSearchClientWithNoResults {}
 
     #[async_trait]

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -73,6 +73,7 @@ where
         self.message.clone()
     }
 }
+
 #[async_trait]
 pub trait Removeable {
     async fn remove(&mut self) -> Result<String, anyhow::Error>;


### PR DESCRIPTION
# Brings get_blob_name_from_content_id under test


Adds a **trait** called Searchable implemented by the SearchClient so that we can intercept the response and instead return empty results, therefore making it possible to test that the DocumentNotFoundInIndex is raised as an error. 

![](https://media.giphy.com/media/ZZroMGabozrWLK94EX/giphy.gif)

### Acceptance Criteria

- [ ] brings some untested code under unit test

### Testing information

`make test`

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
