### PR TITLE
Better documentation for viewing logs

### DIFF
--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -58,10 +58,6 @@ stern -n doc-index-updater doc-index-updater
 
 See the [stern docs][stern] for more info.
 
-### Viewing container logs in Azure
-
-[`stern`][stern] is the best way to view container logs, although you can view the container logs in the Logs Analytics workspace if you wish.
-
 [1]: ../scripts/update-kubernetes-config.sh
 [stern]: https://github.com/wercker/stern
 [kubernetes]: https://kubernetes.io/

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -1,8 +1,16 @@
 # Logs
 
+This document explains how to get the logs we use to monitor running services from this monorepo.
+We have the following types of logs:
+
+- [Prometheus logs](#prometheus-logs)
+- [Container logs](#container-logs)
+
+More background on the infrastructure as a whole can be found at [`./infrastructure.md`](./infrastructure.md).
+
 ## Prometheus Logs
 
-Prometheus is a pod automatically included with istio.
+Prometheus gathers logs from a [kubernetes][kubernetes] cluster. It runs as a kubernetes pod automatically included with [istio][istio], which we use to manage ingress and egress from our [kubernetes][kubernetes] cluster.
 
 ### Viewing a cluster Prometheus dashboard locally
 
@@ -26,7 +34,7 @@ InsightsMetrics
 | where Namespace == "prometheus"
 ```
 
-## Viewing container logs
+## Container logs
 
 ### Using stern
 
@@ -36,11 +44,13 @@ To view all of the logs for the doc-index-updater:
 stern -n doc-index-updater doc-index-updater
 ```
 
-See the [stern docs][2] for more info.
+See the [stern docs][stern] for more info.
 
 ### Viewing container logs in Azure
 
-[`stern`][2] is the best way to view container logs, although you can view the container logs in the Logs Analytics workspace if you wish.
+[`stern`][stern] is the best way to view container logs, although you can view the container logs in the Logs Analytics workspace if you wish.
 
 [1]: ../scripts/update-kubernetes-config.sh
-[2]: https://github.com/wercker/stern
+[stern]: https://github.com/wercker/stern
+[kubernetes]: https://kubernetes.io/
+[istio]: https://istio.io/

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -1,6 +1,6 @@
 # Logs
 
-For an overview of this repository and the services in it, go to [the top-level](../..).
+For an overview of this repository and the services in it, go to [the top-level README](../../README.md).
 To view logs from deployed services, follow this guide.
 
 We have the following types of logs:

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -12,7 +12,7 @@ More background on the infrastructure as a whole can be found at [`./infrastruct
 
 ## Prometheus Logs
 
-Prometheus gathers logs from a [kubernetes][kubernetes] cluster. It runs as a kubernetes pod automatically included with [istio][istio], which we use to manage ingress and egress from our [kubernetes][kubernetes] cluster.
+[Prometheus][prometheus] gathers logs from a [kubernetes][kubernetes] cluster. It runs as a kubernetes pod automatically included with [istio][istio], which we use to manage ingress and egress from our [kubernetes][kubernetes] cluster.
 
 To view the logs, use one of the following means:
 
@@ -29,7 +29,7 @@ istioctl dashboard prometheus
 
 ### Viewing Prometheus logs in Azure
 
-Alternatively, to see Prometheus logs, you can run a query in the Azure Log Analytics workspace.
+Alternatively, to see [Prometheus][prometheus] logs, you can run a query in the Azure Log Analytics workspace.
 
 1. Open the "Log Analytics workspaces" area in the Azure portal.
 2. Open the analytics workspace which is in the same resource group as your cluster.
@@ -61,3 +61,4 @@ See the [stern docs][stern] for more info.
 [stern]: https://github.com/wercker/stern
 [kubernetes]: https://kubernetes.io/
 [istio]: https://istio.io/
+[prometheus]: https://prometheus.io/

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -21,7 +21,10 @@ To view the logs, use one of the following means:
 
 ### Viewing a cluster Prometheus dashboard locally
 
-After [targeting your favourite kubernetes cluster][1], run
+You will need to target a specific kubernetes cluster for which you'd like to see logs.
+See our [docs on connection to a kubernetes cluster](./kubernetes.md#connecting-to-a-kubernetes-cluster).
+
+Once you're targeting a kubernetes cluster, run the following command to see its logs.
 
 ```
 istioctl dashboard prometheus

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -14,6 +14,11 @@ More background on the infrastructure as a whole can be found at [`./infrastruct
 
 Prometheus gathers logs from a [kubernetes][kubernetes] cluster. It runs as a kubernetes pod automatically included with [istio][istio], which we use to manage ingress and egress from our [kubernetes][kubernetes] cluster.
 
+To view the logs, use one of the following means:
+
+- [local Prometheus dashboard](#viewing-a-cluster-prometheus-dashboard-locally)
+- [Azure Log Analytics workspace](#viewing-prometheus-logs-in-azure)
+
 ### Viewing a cluster Prometheus dashboard locally
 
 After [targeting your favourite kubernetes cluster][1], run

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -19,6 +19,8 @@ To view the logs, use one of the following means:
 - [local Prometheus dashboard](#viewing-a-cluster-prometheus-dashboard-locally)
 - [Azure Log Analytics workspace](#viewing-prometheus-logs-in-azure)
 
+For more on getting started with Prometheus, [go to the Prometheus docs][prometheus getting started], or watch [this introductory talk from Prometheus co-founder Julius Volz][prometheus co-founder video].
+
 ### Viewing a cluster Prometheus dashboard locally
 
 You will need to target a specific kubernetes cluster for which you'd like to see logs.
@@ -65,3 +67,5 @@ See the [stern docs][stern] for more info.
 [kubernetes]: https://kubernetes.io/
 [istio]: https://istio.io/
 [prometheus]: https://prometheus.io/
+[prometheus getting started]: https://prometheus.io/docs/prometheus/latest/getting_started/#starting-prometheus
+[prometheus co-founder video]: https://www.youtube.com/watch?v=PDxcEzu62jk

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -56,6 +56,16 @@ To view all of the logs for the doc-index-updater:
 stern -n doc-index-updater doc-index-updater
 ```
 
+A useful command for viewing the logs related to a specific correlation id
+would be to use the `-i` or `--include` parameter with a regex
+which looks for `INFO`, `WARN`, and `ERROR` messages matching that id.
+
+See here, for `b9912c04-325e-4f1b-8943-3ef319a88989`:
+
+```sh
+stern doc-index-updater -n doc-index-updater -i 'level.:.(INFO|WARN|ERROR).*b9912c04-325e-4f1b-8943-3ef319a88989'
+```
+
 See the [stern docs][stern] for more info.
 
 [1]: ../scripts/update-kubernetes-config.sh

--- a/infrastructure/docs/logs.md
+++ b/infrastructure/docs/logs.md
@@ -1,6 +1,8 @@
 # Logs
 
-This document explains how to get the logs we use to monitor running services from this monorepo.
+For an overview of this repository and the services in it, go to [the top-level](../..).
+To view logs from deployed services, follow this guide.
+
 We have the following types of logs:
 
 - [Prometheus logs](#prometheus-logs)


### PR DESCRIPTION
# Better logs documentation

Addresses documentation issues found in #524.

![We call her the log lady](https://media.giphy.com/media/T2VCIPbVrr5ks/giphy.gif "I do not introduce the log")

### Acceptance Criteria

- [x] a sentence at the start of the document explaining that this document explains how to get Prometheus and container logs
- [x] a similar sentence at the start of the Prometheus section explaining that there are two ways of viewing Prometheus logs
- [x] the nouns `Prometheus`, `istio`,  `kubernetes` should be links to the different projects' web sites
- [x] explain (or link to an explanation) for `update-kubernetes-config.sh`
- [x] some guidance or just a link to a document explaining how to use the Prometheus dashboard would be appreciated
- [x] some common scenarios as to how we'd use stern: for example, how can I get log entries with a particular correlation ID
- [x] the "Viewing container logs in Azure" section should either be expanded or removed

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
