### PR TITLE
Createable deleteable into search crate

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "md5",
- "mhra_products_search_client",
+ "mhra_products_search_client_temp",
  "net2",
  "pretty_assertions",
  "redis",
@@ -927,10 +927,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "mhra_products_search_client"
-version = "0.0.1"
+name = "mhra_products_search_client_temp"
+version = "0.0.2-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899373e0b92af23c8d904ba5a5cbd3feb3e3fc7d4ea2129c223b6acbf2a4b84e"
+checksum = "431a4863167c130a8a1847d9a855111f7243fa4b2265cf842afd6d4caace3693"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -409,7 +409,6 @@ dependencies = [
  "hyper",
  "lazy_static",
  "md5",
- "mhra_products_search_client_temp",
  "net2",
  "pretty_assertions",
  "redis",
@@ -925,21 +924,6 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "mhra_products_search_client_temp"
-version = "0.0.2-rc2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431a4863167c130a8a1847d9a855111f7243fa4b2265cf842afd6d4caace3693"
-dependencies = [
- "anyhow",
- "async-trait",
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "tracing",
-]
 
 [[package]]
 name = "mime"

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -20,7 +20,7 @@ md5 = "0.7.0"
 redis = { version = "0.15.1", features = ["tokio-rt-core"] }
 regex = "1.3.1"
 reqwest = { version = "0.10.4", features = ["json"] }
-mhra_products_search_client_temp = "0.0.2-rc2"
+search_client =  { git = "https://github.com/MHRA/products", branch = "createable-deleteable-into-search-crate" }
 serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0"

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -20,7 +20,7 @@ md5 = "0.7.0"
 redis = { version = "0.15.1", features = ["tokio-rt-core"] }
 regex = "1.3.1"
 reqwest = { version = "0.10.4", features = ["json"] }
-mhra_products_search_client = "0.0.1"
+mhra_products_search_client_temp = "0.0.2-rc2"
 serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0"

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use azure_sdk_core::prelude::*;
 use azure_sdk_storage_blob::prelude::*;
-use mhra_products_search_client_temp;
+use search_client;
 use search_index::add_blob_to_search_index;
 pub use sftp_client::SftpError;
 use std::{collections::HashMap, time::Duration};
@@ -84,7 +84,7 @@ where
 pub async fn process_message(message: CreateMessage) -> Result<Uuid, ProcessMessageError> {
     tracing::debug!("Message received: {:?} ", message);
 
-    let search_client = mhra_products_search_client_temp::factory();
+    let search_client = search_client::factory();
     let storage_client = storage_client::factory()
         .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
 

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -100,7 +100,7 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, ProcessMess
 
     tracing::debug!("Uploaded blob {}.", &name);
 
-    add_blob_to_search_index(&search_client, blob).await?;
+    add_blob_to_search_index(search_client, blob).await?;
 
     tracing::info!("Successfully added {} to index.", &name);
 

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use azure_sdk_core::prelude::*;
 use azure_sdk_storage_blob::prelude::*;
-use mhra_products_search_client;
+use mhra_products_search_client_temp;
 use search_index::add_blob_to_search_index;
 pub use sftp_client::SftpError;
 use std::{collections::HashMap, time::Duration};
@@ -84,7 +84,7 @@ where
 pub async fn process_message(message: CreateMessage) -> Result<Uuid, ProcessMessageError> {
     tracing::debug!("Message received: {:?} ", message);
 
-    let search_client = mhra_products_search_client::factory();
+    let search_client = mhra_products_search_client_temp::factory();
     let storage_client = storage_client::factory()
         .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
 

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -4,8 +4,8 @@ use crate::{
     models::{Document, DocumentType},
 };
 use chrono::{SecondsFormat, Utc};
-use mhra_products_search_client_temp::models::IndexEntry;
 use regex::Regex;
+use search_client::models::IndexEntry;
 use std::{collections::HashMap, str};
 
 #[derive(Clone, Debug, PartialEq)]

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -4,7 +4,7 @@ use crate::{
     models::{Document, DocumentType},
 };
 use chrono::{SecondsFormat, Utc};
-use mhra_products_search_client::models::IndexEntry;
+use mhra_products_search_client_temp::models::IndexEntry;
 use regex::Regex;
 use std::{collections::HashMap, str};
 

--- a/medicines/doc-index-updater/src/create_manager/search_index.rs
+++ b/medicines/doc-index-updater/src/create_manager/search_index.rs
@@ -1,8 +1,8 @@
 use crate::create_manager::Blob;
-use mhra_products_search_client::{models::IndexEntry, AzureSearchClient};
+use mhra_products_search_client_temp::{models::IndexEntry, Createable};
 
 pub async fn add_blob_to_search_index(
-    search_client: impl search_client::Createable,
+    search_client: impl Createable,
     blob: Blob,
 ) -> Result<(), anyhow::Error> {
     let entry: IndexEntry = blob.into();

--- a/medicines/doc-index-updater/src/create_manager/search_index.rs
+++ b/medicines/doc-index-updater/src/create_manager/search_index.rs
@@ -2,7 +2,7 @@ use crate::create_manager::Blob;
 use mhra_products_search_client::{models::IndexEntry, AzureSearchClient};
 
 pub async fn add_blob_to_search_index(
-    search_client: &AzureSearchClient,
+    search_client: impl search_client::Createable,
     blob: Blob,
 ) -> Result<(), anyhow::Error> {
     let entry: IndexEntry = blob.into();

--- a/medicines/doc-index-updater/src/create_manager/search_index.rs
+++ b/medicines/doc-index-updater/src/create_manager/search_index.rs
@@ -1,5 +1,5 @@
 use crate::create_manager::Blob;
-use mhra_products_search_client_temp::{models::IndexEntry, Createable};
+use search_client::{models::IndexEntry, Createable};
 
 pub async fn add_blob_to_search_index(
     search_client: impl Createable,

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -11,7 +11,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use azure_sdk_core::{errors::AzureError, prelude::*, DeleteSnapshotsMethod};
 use azure_sdk_storage_blob::prelude::*;
-use mhra_products_search_client_temp::{self, Deletable, Searchable};
+use search_client::{Deletable, Searchable};
 use std::time::Duration;
 use tokio::time::delay_for;
 use uuid::Uuid;
@@ -80,7 +80,7 @@ where
 pub async fn process_message(message: DeleteMessage) -> Result<Uuid, ProcessMessageError> {
     tracing::info!("Message received: {:?} ", message);
 
-    let search_client = mhra_products_search_client_temp::factory();
+    let search_client = search_client::factory();
     let storage_client = storage_client::factory()
         .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
 
@@ -160,7 +160,7 @@ mod test {
         models::DeleteMessage, service_bus_client::test::TestRemoveableMessage,
         state_manager::TestJobStatusClient,
     };
-    use mhra_products_search_client_temp::{models::AzureSearchResults, Searchable};
+    use search_client::{models::AzureSearchResults, Searchable};
     use tokio_test::block_on;
 
     #[test]

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
     models::{DeleteMessage, JobStatus},
+    search_client,
+    search_client::{Deletable, Searchable},
     service_bus_client::{
         delete_factory, ProcessMessageError, ProcessRetrievalError, RemoveableMessage,
         RetrievedMessage,
@@ -93,7 +95,7 @@ pub async fn process_message(message: DeleteMessage) -> Result<Uuid, ProcessMess
         &blob_name,
         &message.document_content_id
     );
-    delete_from_index(&search_client, &blob_name).await?;
+    delete_from_index(search_client, &blob_name).await?;
     tracing::info!("Deleted blob {} from index", &blob_name);
     delete_blob(&storage_client, &storage_container_name, &blob_name)
         .await
@@ -142,7 +144,7 @@ async fn delete_blob(
 }
 
 pub async fn delete_from_index(
-    search_client: &AzureSearchClient,
+    search_client: impl Deletable,
     blob_name: &str,
 ) -> Result<(), anyhow::Error> {
     search_client

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -1,7 +1,5 @@
 use crate::{
     models::{DeleteMessage, JobStatus},
-    search_client,
-    search_client::{Deletable, Searchable},
     service_bus_client::{
         delete_factory, ProcessMessageError, ProcessRetrievalError, RemoveableMessage,
         RetrievedMessage,
@@ -13,7 +11,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use azure_sdk_core::{errors::AzureError, prelude::*, DeleteSnapshotsMethod};
 use azure_sdk_storage_blob::prelude::*;
-use mhra_products_search_client::{self, AzureSearchClient, Searchable};
+use mhra_products_search_client_temp::{self, Deletable, Searchable};
 use std::time::Duration;
 use tokio::time::delay_for;
 use uuid::Uuid;
@@ -82,7 +80,7 @@ where
 pub async fn process_message(message: DeleteMessage) -> Result<Uuid, ProcessMessageError> {
     tracing::info!("Message received: {:?} ", message);
 
-    let search_client = mhra_products_search_client::factory();
+    let search_client = mhra_products_search_client_temp::factory();
     let storage_client = storage_client::factory()
         .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
 
@@ -162,7 +160,7 @@ mod test {
         models::DeleteMessage, service_bus_client::test::TestRemoveableMessage,
         state_manager::TestJobStatusClient,
     };
-    use mhra_products_search_client::{models::AzureSearchResults, Searchable};
+    use mhra_products_search_client_temp::{models::AzureSearchResults, Searchable};
     use tokio_test::block_on;
 
     #[test]

--- a/medicines/search-client/Cargo.lock
+++ b/medicines/search-client/Cargo.lock
@@ -347,8 +347,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "mhra_products_search_client"
-version = "0.0.1"
+name = "mhra_products_search_client_temp"
+version = "0.0.2-rc2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/medicines/search-client/Cargo.toml
+++ b/medicines/search-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "mhra_products_search_client"
-version = "0.0.1"
+name = "mhra_products_search_client_temp"
+version = "0.0.2-rc2"
 authors = ["Matt Doughty <matt.doughty@mhra.gov.uk>", "Craig Anderson <craig.anderson@red-badger.com>"]
 edition = "2018"
 license = "MIT"

--- a/medicines/search-client/Cargo.toml
+++ b/medicines/search-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "mhra_products_search_client_temp"
-version = "0.0.2-rc2"
+name = "search_client"
+version = "0.0.1"
 authors = ["Matt Doughty <matt.doughty@mhra.gov.uk>", "Craig Anderson <craig.anderson@red-badger.com>"]
 edition = "2018"
 license = "MIT"

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -52,8 +52,18 @@ impl Searchable for AzureSearchClient {
     }
 }
 
-impl AzureSearchClient {
-    pub async fn delete(
+#[async_trait]
+pub trait Deletable {
+    async fn delete(
+        &self,
+        key_name: &str,
+        value: &str,
+    ) -> Result<AzureIndexChangedResults, anyhow::Error>;
+}
+
+#[async_trait]
+impl Deletable for AzureSearchClient {
+    async fn delete(
         &self,
         key_name: &str,
         value: &str,
@@ -64,7 +74,9 @@ impl AzureSearchClient {
 
         update_index(key_values, &self.client, &self.config).await
     }
+}
 
+impl AzureSearchClient {
     pub async fn create(
         &self,
         key_values: IndexEntry,

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -23,7 +23,7 @@ pub fn get_env(key: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| panic!("Set env variable {} first!", key))
 }
 
-pub fn factory() -> AzureSearchClient {
+pub fn factory() -> impl Searchable + Deletable + Createable {
     let api_key = get_env("AZURE_API_ADMIN_KEY");
     let search_index = get_env("AZURE_SEARCH_INDEX");
     let search_service = get_env("SEARCH_SERVICE");
@@ -76,8 +76,17 @@ impl Deletable for AzureSearchClient {
     }
 }
 
-impl AzureSearchClient {
-    pub async fn create(
+#[async_trait]
+pub trait Createable {
+    async fn create(
+        &self,
+        key_values: IndexEntry,
+    ) -> Result<AzureIndexChangedResults, anyhow::Error>;
+}
+
+#[async_trait]
+impl Createable for AzureSearchClient {
+    async fn create(
         &self,
         key_values: IndexEntry,
     ) -> Result<AzureIndexChangedResults, anyhow::Error> {


### PR DESCRIPTION
Same as PR #646 except merging to the search client crate extraction branch (if we choose to go with that approach)

I didn't have permission on crates.io ->`mhra_products_search_client` so had to temporarily push to the same name+  `_temp` in order to reference it in the client code.

Note: I think this would be confusing a tricky for a new developer to do.