### PR TITLE
Return an error if adding a message to the service bus fails

### DIFF
--- a/medicines/doc-index-updater/src/document_manager/mod.rs
+++ b/medicines/doc-index-updater/src/document_manager/mod.rs
@@ -11,16 +11,25 @@ use time::Duration;
 use tracing_futures::Instrument;
 use uuid::Uuid;
 use warp::{
+    reject,
     reply::{Json, Xml},
     Filter, Rejection, Reply,
 };
 
 #[derive(Debug)]
 pub struct FailedToDispatchToQueue;
+
+impl warp::reject::Reject for FailedToDispatchToQueue {}
+
 #[derive(Debug)]
 pub struct FailedToDeserialize;
-impl warp::reject::Reject for FailedToDispatchToQueue {}
+
 impl warp::reject::Reject for FailedToDeserialize {}
+
+#[derive(Debug)]
+pub struct FailedToAddToQueue;
+
+impl warp::reject::Reject for FailedToAddToQueue {}
 
 async fn accept_job(
     state_manager: &impl JobStatusClient,
@@ -42,18 +51,19 @@ async fn queue_job<T>(
 where
     T: Message,
 {
+    let id = message.get_id();
     let duration = Duration::days(1);
 
-    match queue.send(message.clone(), duration).await {
-        Ok(_) => Ok(state_manager.get_status(message.get_id()).await?),
+    match queue.send(message, duration).await {
+        Ok(_) => Ok(state_manager.get_status(id).await?),
         Err(e) => {
             tracing::error!(
                 "Failed to dispatch to queue. Check environment variables align for queue names, policies and keys. Error: ({:?})",
                 e
             );
-            let state = state_manager
+            let _state = state_manager
                 .set_status(
-                    message.get_id(),
+                    id,
                     JobStatus::Error {
                         message: "Failed to dispatch to queue".to_owned(),
                         code: "".to_owned(),
@@ -61,7 +71,7 @@ where
                 )
                 .await?;
 
-            Ok(state)
+            Err(reject::custom(FailedToAddToQueue {}))
         }
     }
 }


### PR DESCRIPTION
Fixes #647:
> #### Describe the bug
> If you make an API request to delete a document and it fails to add the message to the service bus queue it still returns a 200 success response code.
>
> #### To Reproduce
> Whilst the API is disconnected from the service bus make a request to delete a document (example below).
> ```
> curl -vvv -X DELETE --user username:password http://localhost:8000/documents/CON1581657002878
> ...
> ```

This change will affect both the "delete document" API and the "check in document" API as `queue_job` is used in both those places.


### Acceptance Criteria

- [x] If a message is added to the service bus the API should return 200 response
- [x] If a message fails to be added to the service bus the API should return 500 response


![](https://media.giphy.com/media/hpF9R9M1PHN5e5liSx/giphy.gif)