### PR TITLE
Replace two spaces with tab in makefile

### DIFF
--- a/medicines/doc-index-updater/Makefile
+++ b/medicines/doc-index-updater/Makefile
@@ -32,7 +32,7 @@ set-sftp-keys: ## Adds pub/private key for localhost to your .ssh dir
 		--name dev-sentinel-public-key \
 		--query value \
 		--output tsv > ~/.ssh/doc_index_updater.pub && \
-  az keyvault secret show \
+	az keyvault secret show \
 		--vault-name mhra-dev \
 		--name dev-sentinel-private-key \
 		--query value \


### PR DESCRIPTION
# Replace two spaces with tab in makefile
Makefiles can be particular about spaces and tabs. This PR replaces two spaces with a tab to ensure no problems.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
