### PR TITLE
Fix search client master CI build

### DIFF
--- a/.github/workflows/search-client-master.yaml
+++ b/.github/workflows/search-client-master.yaml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Clone Repo
         uses: actions/checkout@v2
-        with:
-          path: products
 
       - name: Test
         working-directory: ./medicines/search-client


### PR DESCRIPTION
The master branch build for the search client is currently failing: https://github.com/MHRA/products/runs/589304928

Hopefully this fixes that
