### PR TITLE
Delete workflow should always result in a consistent state

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -1645,6 +1645,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "reqwest",
  "serde",
  "serde_derive",

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -12,7 +12,6 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use azure_sdk_core::prelude::*;
 use azure_sdk_storage_blob::prelude::*;
-use search_client;
 use search_index::add_blob_to_search_index;
 pub use sftp_client::SftpError;
 use std::{collections::HashMap, time::Duration};

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -86,7 +86,8 @@ pub async fn process_message(message: CreateMessage) -> Result<Uuid, ProcessMess
 
     let search_client = search_client::factory();
     let storage_client = storage_client::factory()
-        .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?;
+        .map_err(|e| anyhow!("Couldn't create storage client: {:?}", e))?
+        .azure_client;
 
     let file = sftp_client::retrieve(
         message.document.file_source.clone(),

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -100,6 +100,7 @@ async fn process_delete_message(
     search_client: impl Search + DeleteIndexEntry + CreateIndexEntry,
 ) -> Result<Uuid, ProcessMessageError> {
     let storage_container_name = std::env::var("STORAGE_CONTAINER").map_err(anyhow::Error::from)?;
+
     let index_record: IndexResult =
         get_index_record_from_content_id(message.document_content_id.clone(), &search_client)
             .await?;
@@ -161,6 +162,16 @@ pub async fn get_index_record_from_content_id(
         }
     }
     Err(ProcessMessageError::DocumentNotFoundInIndex(content_id))
+}
+
+pub async fn delete_from_index(
+    search_client: impl DeleteIndexEntry,
+    blob_name: &str,
+) -> Result<(), anyhow::Error> {
+    search_client
+        .delete_index_entry(&"metadata_storage_name".to_string(), &blob_name)
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -130,14 +130,11 @@ async fn process_delete_message(
             .create_index_entry(IndexEntry::from(index_record.clone()))
             .await
             .map_err(|err| {
-                ProcessMessageError::FailedRestoringIndex(
-                    blob_name.clone(),
-                    err.to_string()
-                )
+                ProcessMessageError::FailedRestoringIndex(blob_name.clone(), err.to_string())
             })?;
         return Err(ProcessMessageError::FailedDeletingBlob(
             blob_name.clone(),
-            e.to_string()
+            e.to_string(),
         ));
     }
 

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
-use search_client::{
-    models::{IndexEntry, IndexResult},
-    CreateIndexEntry, DeleteIndexEntry, Search,
-};
+use search_client::{models::IndexResult, CreateIndexEntry, DeleteIndexEntry, Search};
 use std::time::Duration;
 use storage_client::DeleteBlob;
 use tokio::time::delay_for;
@@ -121,7 +118,7 @@ async fn process_delete_message(
         .delete_blob(&storage_container_name, &blob_name)
         .await
     {
-        tracing::debug!(
+        tracing::error!(
             "Error deleting blob: {:?}, re-creating index: {:?}",
             e,
             &index_record
@@ -170,6 +167,16 @@ pub async fn delete_from_index(
 ) -> Result<(), anyhow::Error> {
     search_client
         .delete_index_entry(&"metadata_storage_name".to_string(), &blob_name)
+        .await?;
+    Ok(())
+}
+
+pub async fn insert_index_entry_from_index_result(
+    search_client: impl CreateIndexEntry,
+    index_result: IndexResult,
+) -> Result<(), anyhow::Error> {
+    search_client
+        .create_index_entry(index_result.into())
         .await?;
     Ok(())
 }

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -9,7 +9,10 @@ use crate::{
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
-use search_client::{models::IndexResult, CreateIndexEntry, DeleteIndexEntry, Search};
+use search_client::{
+    models::{IndexEntry, IndexResult},
+    CreateIndexEntry, DeleteIndexEntry, Search,
+};
 use std::time::Duration;
 use storage_client::DeleteBlob;
 use tokio::time::delay_for;
@@ -118,7 +121,7 @@ async fn process_delete_message(
         .delete_blob(&storage_container_name, &blob_name)
         .await
     {
-        tracing::error!(
+        tracing::debug!(
             "Error deleting blob: {:?}, re-creating index: {:?}",
             e,
             &index_record
@@ -159,26 +162,6 @@ pub async fn get_index_record_from_content_id(
         }
     }
     Err(ProcessMessageError::DocumentNotFoundInIndex(content_id))
-}
-
-pub async fn delete_from_index(
-    search_client: impl DeleteIndexEntry,
-    blob_name: &str,
-) -> Result<(), anyhow::Error> {
-    search_client
-        .delete_index_entry(&"metadata_storage_name".to_string(), &blob_name)
-        .await?;
-    Ok(())
-}
-
-pub async fn insert_index_entry_from_index_result(
-    search_client: impl CreateIndexEntry,
-    index_result: IndexResult,
-) -> Result<(), anyhow::Error> {
-    search_client
-        .create_index_entry(index_result.into())
-        .await?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -373,7 +373,6 @@ mod test {
             storage_client,
             search_client,
         ));
-        unset_process_delete_message_env_vars();
 
         assert_eq!(result.is_err(), false);
     }
@@ -390,7 +389,6 @@ mod test {
             storage_client,
             search_client,
         ));
-        unset_process_delete_message_env_vars();
 
         match result {
             Ok(_) => panic!("Error expected"),
@@ -419,7 +417,6 @@ mod test {
             storage_client,
             search_client,
         ));
-        unset_process_delete_message_env_vars();
 
         match result {
             Ok(_) => panic!("Error expected"),
@@ -448,7 +445,6 @@ mod test {
             storage_client,
             search_client,
         ));
-        unset_process_delete_message_env_vars();
 
         match result {
             Ok(_) => panic!("Error expected"),
@@ -463,10 +459,6 @@ mod test {
 
     fn given_the_necessary_env_vars_are_initialised() {
         env::set_var("STORAGE_CONTAINER", "storage_container");
-    }
-
-    fn unset_process_delete_message_env_vars() {
-        env::remove_var("STORAGE_CONTAINER");
     }
 
     fn given_document_not_found_in_index() -> ProcessMessageError {

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -81,12 +81,12 @@ where
             let _remove = removeable_message.remove().await?;
         }
         ProcessMessageError::FailedRestoringIndex(_, _) => {
-            tracing::error!("{}", error.to_string());
+            tracing::error!("{}", error_message);
             state_manager
                 .set_status(
                     removeable_message.get_message().job_id,
                     JobStatus::Error {
-                        message: error.to_string(),
+                        message: error_message,
                         code: "".to_string(),
                     },
                 )
@@ -94,7 +94,7 @@ where
             let _remove = removeable_message.remove().await?;
         }
         ProcessMessageError::FailedDeletingBlob(_, _) => {
-            tracing::error!("{}", error.to_string());
+            tracing::error!("{}", error_message);
         }
         _ => {}
     }

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -102,6 +102,10 @@ pub enum ProcessMessageError {
     SftpError(#[from] SftpError),
     #[error("Cannot find document with ID {0}")]
     DocumentNotFoundInIndex(String),
+    #[error("Cannot delete blob with ID {0}: {1}")]
+    FailedDeletingBlob(String, String),
+    #[error("Cannot restore index for blob {0}: {1}")]
+    FailedRestoringIndex(String, String),
     #[error(transparent)]
     Generic(#[from] anyhow::Error),
 }

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -104,7 +104,7 @@ pub enum ProcessMessageError {
     DocumentNotFoundInIndex(String),
     #[error("Cannot delete blob with ID {0}: {1}")]
     FailedDeletingBlob(String, String),
-    #[error("Cannot restore index for blob {0}: {1}")]
+    #[error("Cannot restore index for blob with ID {0}: {1}")]
     FailedRestoringIndex(String, String),
     #[error(transparent)]
     Generic(#[from] anyhow::Error),

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -10,7 +10,7 @@ pub struct BlobClient {
 impl BlobClient {
     pub fn new(azure_client: Client) -> BlobClient {
         BlobClient {
-            azure_client: azure_client,
+            azure_client,
         }
     }
 }

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use azure_sdk_core::{errors::AzureError, prelude::*, DeleteSnapshotsMethod};
 use azure_sdk_storage_blob::Blob;
-use azure_sdk_storage_core::prelude::*;
+use azure_sdk_storage_core::prelude::Client;
 
 pub struct BlobClient {
     pub azure_client: Client,

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -1,7 +1,48 @@
-use azure_sdk_core::errors::AzureError;
-use azure_sdk_storage_core::prelude::Client;
+use async_trait::async_trait;
+use azure_sdk_core::{errors::AzureError, prelude::*, DeleteSnapshotsMethod};
+use azure_sdk_storage_blob::Blob;
+use azure_sdk_storage_core::prelude::*;
 
-pub fn factory() -> Result<Client, AzureError> {
+pub struct BlobClient {
+    pub azure_client: Client,
+}
+
+impl BlobClient {
+    pub fn new(azure_client: Client) -> BlobClient {
+        BlobClient {
+            azure_client: azure_client,
+        }
+    }
+}
+
+#[async_trait]
+pub trait DeleteBlob {
+    async fn delete_blob(
+        &mut self,
+        container_name: &str,
+        blob_name: &str,
+    ) -> Result<(), AzureError>;
+}
+
+#[async_trait]
+impl DeleteBlob for BlobClient {
+    async fn delete_blob(
+        &mut self,
+        container_name: &str,
+        blob_name: &str,
+    ) -> Result<(), AzureError> {
+        self.azure_client
+            .delete_blob()
+            .with_container_name(&container_name)
+            .with_blob_name(&blob_name)
+            .with_delete_snapshots_method(DeleteSnapshotsMethod::Include)
+            .finalize()
+            .await?;
+        Ok(())
+    }
+}
+
+pub fn factory() -> Result<BlobClient, AzureError> {
     let storage_account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
 
@@ -9,7 +50,7 @@ pub fn factory() -> Result<Client, AzureError> {
         std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
 
     match base64::decode(&master_key) {
-        Ok(_) => Client::new(&storage_account, &master_key),
+        Ok(_) => Ok(BlobClient::new(Client::new(&storage_account, &master_key)?)),
         Err(e) => Err(AzureError::Base64DecodeError(e)),
     }
 }

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -9,9 +9,7 @@ pub struct BlobClient {
 
 impl BlobClient {
     pub fn new(azure_client: Client) -> BlobClient {
-        BlobClient {
-            azure_client,
-        }
+        BlobClient { azure_client }
     }
 }
 

--- a/medicines/search-client/Cargo.lock
+++ b/medicines/search-client/Cargo.lock
@@ -60,6 +60,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +434,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +667,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "reqwest",
  "serde",
  "serde_derive",

--- a/medicines/search-client/Cargo.toml
+++ b/medicines/search-client/Cargo.toml
@@ -12,6 +12,7 @@ description = "MHRA Products Search Client"
 [dependencies]
 anyhow = "1.0.26"
 async-trait = "0.1.24"
+chrono = "0.4.11"
 reqwest = { version = "0.10.4", features = ["json"] }
 serde = "1.0.105"
 serde_derive = "1.0.105"

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod models;
 
-use crate::models::{AzureIndexChangedResults, AzureSearchResults, IndexEntry};
+use crate::models::{AzureIndexChangedResults, IndexEntry, IndexResults};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use serde::ser::Serialize;
@@ -42,12 +42,12 @@ pub fn factory() -> impl Search + DeleteIndexEntry + CreateIndexEntry {
 
 #[async_trait]
 pub trait Search {
-    async fn search(&self, &mut search_term: String) -> Result<AzureSearchResults, reqwest::Error>;
+    async fn search(&self, &mut search_term: String) -> Result<IndexResults, reqwest::Error>;
 }
 
 #[async_trait]
 impl Search for AzureSearchClient {
-    async fn search(&self, search_term: String) -> Result<AzureSearchResults, reqwest::Error> {
+    async fn search(&self, search_term: String) -> Result<IndexResults, reqwest::Error> {
         search(search_term, &self.client, self.config.clone()).await
     }
 }
@@ -98,14 +98,14 @@ async fn search(
     search_term: String,
     client: &reqwest::Client,
     config: AzureConfig,
-) -> Result<AzureSearchResults, reqwest::Error> {
+) -> Result<IndexResults, reqwest::Error> {
     let req = build_search(search_term, &client, config)?;
     tracing::debug!("Requesting from URL: {}", &req.url());
     client
         .execute(req)
         .await?
         .error_for_status()?
-        .json::<AzureSearchResults>()
+        .json::<IndexResults>()
         .await
 }
 

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -1,3 +1,4 @@
+use chrono::{SecondsFormat, Utc};
 use core::fmt::Debug;
 use serde_derive::{Deserialize, Serialize};
 
@@ -79,4 +80,49 @@ pub struct IndexEntry {
     pub suggestions: Vec<String>,
     pub substance_name: Vec<String>,
     pub facets: Vec<String>,
+}
+
+// The AzureResult model does not contain all of the information we want in the index,
+// however, the automatic index rebuild will populate the missing information.
+impl From<AzureResult> for IndexEntry {
+    fn from(res: AzureResult) -> Self {
+        Self {
+            content: "Content not yet available".to_owned(),
+            rev_label: match res.rev_label {
+                Some(rl) => rl.clone(),
+                None => "1".to_owned(),
+            },
+            product_name: match res.product_name {
+                Some(pn) => pn.clone(),
+                None => "".to_owned(),
+            },
+            created: match res.created {
+                Some(cr) => cr.clone(),
+                None => Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            },
+            release_state: match res.release_state {
+                Some(rs) => rs.clone(),
+                None => "Y".to_owned(),
+            },
+            keywords: match res.keywords {
+                Some(k) => k.clone(),
+                None => "".to_owned(),
+            },
+            title: res.title.clone(),
+            pl_number: vec![],
+            file_name: res.file_name.clone(),
+            doc_type: res.doc_type.clone(),
+            suggestions: res.suggestions.clone(),
+            substance_name: res.substance_name.clone(),
+            facets: res.facets.clone(),
+            metadata_storage_content_type: String::default(),
+            metadata_storage_size: res.metadata_storage_size as usize,
+            metadata_storage_last_modified: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            metadata_storage_content_md5: String::default(),
+            metadata_storage_name: res.metadata_storage_name.clone(),
+            metadata_storage_path: res.metadata_storage_path.clone(),
+            metadata_content_type: String::default(),
+            metadata_language: String::default(),
+        }
+    }
 }

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -32,7 +32,7 @@ pub struct IndexResult {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct AzureSearchResults {
+pub struct IndexResults {
     #[serde(rename = "value")]
     pub search_results: Vec<IndexResult>,
     #[serde(rename = "@odata.context")]
@@ -46,6 +46,15 @@ pub struct AzureIndexChangedResults {
     pub value: Vec<AzureIndexChangedResult>,
     #[serde(rename = "@odata.context")]
     context: String,
+}
+
+impl AzureIndexChangedResults {
+    pub fn new(index_changed_result: AzureIndexChangedResult) -> AzureIndexChangedResults {
+        AzureIndexChangedResults {
+            context: "context".to_string(),
+            value: vec![index_changed_result],
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -3,13 +3,13 @@ use core::fmt::Debug;
 use serde_derive::{Deserialize, Serialize};
 use std::clone::Clone;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct AzureHighlight {
     #[serde(rename = "content")]
     content: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct IndexResult {
     pub doc_type: String,
     pub file_name: String,

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -1,6 +1,7 @@
 use chrono::{SecondsFormat, Utc};
 use core::fmt::Debug;
 use serde_derive::{Deserialize, Serialize};
+use std::clone::Clone;
 
 #[derive(Debug, Deserialize)]
 pub struct AzureHighlight {
@@ -9,7 +10,7 @@ pub struct AzureHighlight {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct AzureResult {
+pub struct IndexResult {
     pub doc_type: String,
     pub file_name: String,
     pub metadata_storage_name: String,
@@ -33,7 +34,7 @@ pub struct AzureResult {
 #[derive(Debug, Deserialize)]
 pub struct AzureSearchResults {
     #[serde(rename = "value")]
-    pub search_results: Vec<AzureResult>,
+    pub search_results: Vec<IndexResult>,
     #[serde(rename = "@odata.context")]
     pub context: String,
     #[serde(rename = "@odata.count")]
@@ -84,8 +85,8 @@ pub struct IndexEntry {
 
 // The AzureResult model does not contain all of the information we want in the index,
 // however, the automatic index rebuild will populate the missing information.
-impl From<AzureResult> for IndexEntry {
-    fn from(res: AzureResult) -> Self {
+impl From<IndexResult> for IndexEntry {
+    fn from(res: IndexResult) -> Self {
         Self {
             content: "Content not yet available".to_owned(),
             rev_label: match res.rev_label {

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -92,7 +92,7 @@ pub struct IndexEntry {
     pub facets: Vec<String>,
 }
 
-// The AzureResult model does not contain all of the information we want in the index,
+// The IndexResult model does not contain all of the information we want in the index,
 // however, the automatic index rebuild will populate the missing information.
 impl From<IndexResult> for IndexEntry {
     fn from(res: IndexResult) -> Self {

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -90,23 +90,23 @@ impl From<IndexResult> for IndexEntry {
         Self {
             content: "Content not yet available".to_owned(),
             rev_label: match res.rev_label {
-                Some(rl) => rl.clone(),
+                Some(rl) => rl,
                 None => "1".to_owned(),
             },
             product_name: match res.product_name {
-                Some(pn) => pn.clone(),
+                Some(pn) => pn,
                 None => "".to_owned(),
             },
             created: match res.created {
-                Some(cr) => cr.clone(),
+                Some(cr) => cr,
                 None => Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
             },
             release_state: match res.release_state {
-                Some(rs) => rs.clone(),
+                Some(rs) => rs,
                 None => "Y".to_owned(),
             },
             keywords: match res.keywords {
-                Some(k) => k.clone(),
+                Some(k) => k,
                 None => "".to_owned(),
             },
             title: res.title.clone(),


### PR DESCRIPTION
# Delete workflow should always result in a consistent state

The Doc Index Updater delete workflow currently can result in an inconsistent state where a result exists in storage but not in the search index. This PR will fix that.

Relates to #653.

![](https://media.giphy.com/media/xT5LMOvMEbCDlmu3mg/giphy.gif)

### Acceptance Criteria

- [ ] The Doc Index Updater delete workflow always either resolves in both index & blob entry being deleted, or neither;
- [ ] If an index was found without a corresponding blob, this raises a NotFound error;

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
