### PR TITLE
Moving onto an azure_sdk_* release

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -71,8 +71,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "azure_sdk_core"
-version = "0.40.0"
-source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e21ee06d328376fb11cadc053d82b81033b71b7f4e2f5659c403c44c458cca"
 dependencies = [
  "RustyXML",
  "base64 0.11.0",
@@ -101,8 +102,9 @@ dependencies = [
 
 [[package]]
 name = "azure_sdk_service_bus"
-version = "0.42.0"
-source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e6f239bcfe291a7ca51a3b29ce494953e8b3fdc3d26905e3fdb8129c7d3a17"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -129,8 +131,9 @@ dependencies = [
 
 [[package]]
 name = "azure_sdk_storage_blob"
-version = "0.40.0"
-source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f650b8535b168aa401e3dd714607568408760e00baa90f70449d1626b091ae"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",
@@ -160,8 +163,9 @@ dependencies = [
 
 [[package]]
 name = "azure_sdk_storage_core"
-version = "0.40.0"
-source = "git+https://github.com/MindFlavor/AzureSDKForRust#3bac38b2ed44835bba6ed9f75fe748e5e6bb9904"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8314c70916ff631873ca35e4e08ca92d1ac1c1c8c57adb78ef90eaa5ac42824"
 dependencies = [
  "RustyXML",
  "azure_sdk_core",

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 anyhow = "1.0.26"
 async-ssh2 = { version = "0.1", git = "https://github.com/spebern/async-ssh2.git" }
 async-trait = "0.1.24"
-azure_sdk_core = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
-azure_sdk_service_bus = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
-azure_sdk_storage_blob = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
-azure_sdk_storage_core = { git = "https://github.com/MindFlavor/AzureSDKForRust", branch = "master" }
+azure_sdk_core = "0.40.1"
+azure_sdk_service_bus = "0.43.0"
+azure_sdk_storage_blob = "0.40.1"
+azure_sdk_storage_core = "0.40.1"
 base64 = "0.11.0"
 chrono = "0.4.11"
 futures = "0.3.4"


### PR DESCRIPTION
# There's been an AzureSDKForRust release

Since the [release of _AzureSDKForRust_ on 2nd April][release 20200402], we can now fetch that from crates.io once again, as it now includes our `peek_lock_response` changes from MindFlavor/AzureSDKForRust#247:

> Update service bus peek lock method to accept timeout. PR [247](MindFlavor/AzureSDKForRust#247) thanks to [Pedro Martin](https://github.com/pataruco) and his team.

![Release the kraken](https://media.giphy.com/media/CDZwopbecAbIc/giphy.gif)

### Acceptance Criteria

- [x] Get us back onto https://crates.io/crates/azure_sdk_core and co.
- [x] Not break anything

### Testing information

Regression test it.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
[release 20200402]: https://github.com/MindFlavor/AzureSDKForRust/releases/tag/mix_20200402