### PR TITLE
Add monitoring section to doc index updater readme

### DIFF
--- a/medicines/doc-index-updater/README.md
+++ b/medicines/doc-index-updater/README.md
@@ -85,3 +85,9 @@ make test TEST=<arguments>
 ```
 
 [azure portal]: https://portal.azure.com/
+
+## Monitoring
+
+There's a dashboard set up in Azure to monitor latency, traffic, errors and saturation.
+
+To find it, go to [Shared Dashboards in the Azure Portal](https://portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/Microsoft.Portal%2Fdashboards).


### PR DESCRIPTION
Add a note to explain how to get to the doc index updater's monitoring dashboard.

![](https://media.giphy.com/media/9dFvgd4ID6ne0/giphy.gif)
