### PR TITLE
Add CORS support to API

### DIFF
--- a/medicines/api/Cargo.lock
+++ b/medicines/api/Cargo.lock
@@ -35,6 +35,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6206917d5c0fdd79d81cec9ef02d3e802df4abf276d96241e1f595d971e002"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "derive_more",
+ "futures",
+]
+
+[[package]]
 name = "actix-http"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +294,7 @@ checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-rt",
  "actix-web",
  "env_logger",

--- a/medicines/api/Cargo.toml
+++ b/medicines/api/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 actix-rt = "1.0.0"
 actix-web = "2.0.0"
+actix-cors = "0.2.0"
 env_logger = "0.7.1"
 futures = "0.3.1"
 juniper = { git = "https://github.com/graphql-rust/juniper", features = ["async"], rev="211737cee0c6b79ad86246d69ed39e2725fc2110" }

--- a/medicines/api/src/main.rs
+++ b/medicines/api/src/main.rs
@@ -42,8 +42,7 @@ async fn healthz() -> impl actix_web::Responder {
 fn cors_middleware() -> actix_cors::CorsFactory {
     Cors::new()
         .allowed_methods(vec!["POST"])
-        .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
-        .allowed_header(http::header::CONTENT_TYPE)
+        .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT, http::header::CONTENT_TYPE])
         .max_age(3600)
         .finish()
 }

--- a/medicines/api/src/main.rs
+++ b/medicines/api/src/main.rs
@@ -1,5 +1,6 @@
 const PORT: u16 = 8000;
-use actix_web::{middleware, web, App, Error, HttpResponse, HttpServer};
+use actix_cors::Cors;
+use actix_web::{http, middleware, web, App, Error, HttpResponse, HttpServer};
 use juniper::http::{graphiql::graphiql_source, GraphQLRequest};
 use listenfd::ListenFd;
 use std::{io, sync::Arc};
@@ -38,9 +39,17 @@ async fn healthz() -> impl actix_web::Responder {
     "OK"
 }
 
+fn cors_middleware() -> actix_cors::CorsFactory {
+    Cors::new()
+        .allowed_methods(vec!["POST"])
+        .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
+        .allowed_header(http::header::CONTENT_TYPE)
+        .max_age(3600)
+        .finish()
+}
+
 #[actix_rt::main]
 async fn main() -> io::Result<()> {
-    std::env::set_var("RUST_LOG", "actix_web=info, actix_server=info");
     env_logger::init();
 
     let mut listenfd = ListenFd::from_env();
@@ -55,6 +64,7 @@ async fn main() -> io::Result<()> {
             .data(schema.clone())
             .data(context.clone())
             .wrap(middleware::Logger::default())
+            .wrap(cors_middleware())
             .service(web::resource("/graphql").route(web::post().to(graphql)))
             .service(web::resource("/graphiql").route(web::get().to(graphiql)))
             .service(web::resource("/healthz").route(web::get().to(healthz)))


### PR DESCRIPTION
Add CORS support to API.

Required for #401, #403, #620, and #621.

![](https://media1.tenor.com/images/ca58f0c42bda8d64f2449d9e045d2fa5/tenor.gif?itemid=16204019)

### Acceptance Criteria

- [ ] Any web page can send a POST request to the API.

Note that _any_ web page should be permitted—this is public data!