### PR TITLE
Mutex get status

### DIFF
--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -234,6 +234,7 @@ mod test {
     fn recoverable_error_during_delete_leaves_job_status_as_accepted() {
         let state_manager = given_a_state_manager();
         let mut removeable_message = given_we_have_a_delete_message();
+        given_the_delete_job_is_accepted(removeable_message.get_message().job_id, &state_manager);
         let error = given_an_unknown_error();
 
         block_on(handle_processing_error_for_delete_message(
@@ -270,6 +271,10 @@ mod test {
             remove_was_called: false,
             message: delete_message,
         }
+    }
+
+    fn given_the_delete_job_is_accepted(id: Uuid, state_manager: &TestJobStatusClient) {
+        let _ = block_on(state_manager.set_status(id, JobStatus::Accepted));
     }
 
     #[test]

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -189,7 +189,7 @@ mod test {
 
     #[test]
     fn not_found_error_during_delete_sets_job_status_as_error() {
-        let mut state_manager = given_a_state_manager();
+        let state_manager = given_a_state_manager();
         let mut removeable_message = given_we_have_a_delete_message();
         let error = given_document_not_found_in_index();
 
@@ -200,8 +200,10 @@ mod test {
         ))
         .unwrap();
 
+        let result =
+            block_on(state_manager.get_status(removeable_message.get_message().job_id)).unwrap();
         assert_eq!(
-            state_manager.get_most_recently_set_status(),
+            result.status,
             JobStatus::Error {
                 message: String::from("Cannot find document with ID any id"),
                 code: String::from(""),
@@ -230,7 +232,7 @@ mod test {
 
     #[test]
     fn recoverable_error_during_delete_leaves_job_status_as_accepted() {
-        let mut state_manager = given_a_state_manager();
+        let state_manager = given_a_state_manager();
         let mut removeable_message = given_we_have_a_delete_message();
         let error = given_an_unknown_error();
 
@@ -241,10 +243,9 @@ mod test {
         ))
         .unwrap();
 
-        assert_eq!(
-            state_manager.get_most_recently_set_status(),
-            JobStatus::Accepted
-        );
+        let result =
+            block_on(state_manager.get_status(removeable_message.get_message().job_id)).unwrap();
+        assert_eq!(result.status, JobStatus::Accepted);
     }
 
     fn given_document_not_found_in_index() -> ProcessMessageError {

--- a/medicines/doc-index-updater/src/state_manager/mod.rs
+++ b/medicines/doc-index-updater/src/state_manager/mod.rs
@@ -170,8 +170,8 @@ pub mod test {
             }
         }
 
-        pub fn get_most_recently_set_status(&mut self) -> JobStatus {
-            self.status.get_mut().unwrap().clone()
+        fn get_most_recently_set_status(&self) -> JobStatus {
+            (*self.status.lock().unwrap()).clone()
         }
     }
 
@@ -179,9 +179,12 @@ pub mod test {
     impl JobStatusClient for TestJobStatusClient {
         async fn get_status(
             &self,
-            _id: Uuid,
+            id: Uuid,
         ) -> Result<crate::models::JobStatusResponse, crate::state_manager::MyRedisError> {
-            unimplemented!()
+            Ok(JobStatusResponse {
+                id,
+                status: self.get_most_recently_set_status(),
+            })
         }
         async fn set_status(
             &self,

--- a/medicines/doc-index-updater/src/state_manager/mod.rs
+++ b/medicines/doc-index-updater/src/state_manager/mod.rs
@@ -181,11 +181,8 @@ pub mod test {
             &self,
             id: Uuid,
         ) -> Result<crate::models::JobStatusResponse, crate::state_manager::MyRedisError> {
-            let s = self.get_statuses();
-            println!("{:?}", s);
-
             Ok(JobStatusResponse {
-                status: s[&id].clone(),
+                status: self.get_statuses()[&id].clone(),
                 id,
             })
         }


### PR DESCRIPTION
# A test version of State Manager

Expands on @majikandy and @sgrowe's work on #668.

`TestJobStatusClient` stores a hashmap for genuinely checking status-setting side-effects per id.

![More hash browns?](https://media.giphy.com/media/3orif6GfHJUGyX99C0/giphy.gif)

### Acceptance Criteria

- [ ] Use `get_status` in tests
- [ ] Tests check a state manager which remembers state per job

### Testing information

Run `make test`.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
