### PR TITLE
Update cluster subnet resource group

### DIFF
--- a/infrastructure/modules/cluster/main.tf
+++ b/infrastructure/modules/cluster/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
 data "azurerm_subnet" "cluster_nodes" {
   name                 = var.cluster_subnet_name
-  resource_group_name  = var.resource_group_name
+  resource_group_name  = var.vnet_resource_group
   virtual_network_name = var.vnet_name
 
   depends_on = [


### PR DESCRIPTION
The resource group for cluster subnet should be the same as its parent network, not the one that is used for everything else. Those are both the same resource group in non-prod (which is how this was missed I guess) but not for prod