### PR TITLE
A11y pages update for query name changes

### DIFF
--- a/medicines/web/.pa11yci
+++ b/medicines/web/.pa11yci
@@ -4,10 +4,10 @@
     "http://localhost:3000/about",
     "http://localhost:3000/accessibility",
     "http://localhost:3000/cookies",
-    "http://localhost:3000/search?query=eyes&page=1",
-    "http://localhost:3000/search?query=eyes&page=1&disclaimer=agree",
-    "http://localhost:3000/substance-index?query=A",
-    "http://localhost:3000/substance?query=IBUPROFEN",
-    "http://localhost:3000/product?query=OLBAS%20OIL&page=1&disclaimer=agree"
+    "http://localhost:3000/search?search=eyes&page=1",
+    "http://localhost:3000/search?search=eyes&page=1&disclaimer=agree",
+    "http://localhost:3000/substance-index?letter=A",
+    "http://localhost:3000/substance?substance=IBUPROFEN",
+    "http://localhost:3000/product?product=OLBAS%20OIL&page=1&disclaimer=agree"
   ]
 }


### PR DESCRIPTION
Fixes a11y issue since #616.

### Acceptance Criteria

- [ ] `.pa11yci` reflects the real URLs

### Testing information

Run `yarn a11y`.

Then override the colours for, for example, products page links to white. The problems (white doesn't contrast well on white) should be picked up by the tool.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
