### PR TITLE
`make cypress` improvements

### DIFF
--- a/medicines/web/Makefile
+++ b/medicines/web/Makefile
@@ -8,7 +8,7 @@ get-env: ## Gets the environment variables from azure keyvault into .env file
 	  --vault-name mhra-dev \
 	  --name web-env \
 	  --query value \
-	  --output tsv > .env
+	  --output tsv | sed '$$d' > .env
 
 .PHONY: set-env
 set-env: ## Takes your current .env file and replaces the keyvault value with the contents of the file

--- a/medicines/web/Makefile
+++ b/medicines/web/Makefile
@@ -19,4 +19,4 @@ set-env: ## Takes your current .env file and replaces the keyvault value with th
 
 .PHONY: cypress
 cypress: ## Launch Cypress
-	yarn run cypress open --env $$(cat .env 2> /dev/null | tr "\n", "," | sed 's/,$$/ /g')
+	yarn run cypress open --env $$(cat .env | sed '/^$$/d' | tr "\n", "," | sed 's/,$$/ /g')


### PR DESCRIPTION
![](https://media.giphy.com/media/9UqRcQHzBou6A/giphy.gif)

make get-env removes an extra blank line that messes up the tr command in `make cypress`

just incase there are blank lines, strip them on the `make cypress` command anyway