### PR TITLE
Automate prod release

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -1,35 +1,63 @@
-name: doc-index-updater-master
+name: doc-index-updater-release
 
 on:
   push:
     tags:
-      - web.v*
+      - diu.v*
 
 env:
-  IMAGE: mhraproductsproductionregistry.azurecr.io/products/doc-index-updater
+  NONPROD_IMAGE: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater
+  PROD_IMAGE: mhraproductsproductionregistry.azurecr.io/products/doc-index-updater
 
 jobs:
   build-and-test:
-    name: Build, Test and Deploy
+    name: Create release and deploy to production
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create release
+      - name: Clone repo
+        uses: actions/checkout@v2
 
-      - name: Docker login
+      - name: Docker login to nonprod
+        uses: azure/docker-login@v1
+        with:
+          login-server: mhraproductsnonprodregistry.azurecr.io
+          username: mhraproductsnonprodregistry
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Fetch image for tagged commit
+        working-directory: ./products/medicines/doc-index-updater
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          make docker-pull image=$NONPROD_IMAGE tag=$TAG
+          echo ::set-env name=TAG::$TAG
+
+      - name: Docker login to prod
         uses: azure/docker-login@v1
         with:
           login-server: mhraproductsproductionregistry.azurecr.io
           username: mhraproductsproductionregistry
-          password: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
+          password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
 
-      - name: Fetch image for tagged commit
+      - name: Push image for tagged commit
+        working-directory: ./products/medicines/doc-index-updater
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
-          make ci-master tag=$TAG
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
-          echo ::set-env name=TAG::$TAG
+          make docker-push image=$PROD_IMAGE tag=$TAG
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${PROD_IMAGE}:${TAG})"
           echo ::set-env name=DIGEST::$DIGEST
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Doc-Index-Updater release ${{ github.ref }}
+          body: |
+            Release of Document Index Updater
+          draft: false
+          prerelease: false
 
       - name: Clone Deployments repo
         uses: actions/checkout@v2

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -1,0 +1,61 @@
+name: doc-index-updater-master
+
+on:
+  push:
+    tags:
+      - web.v*
+
+env:
+  IMAGE: mhraproductsproductionregistry.azurecr.io/products/doc-index-updater
+
+jobs:
+  build-and-test:
+    name: Build, Test and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create release
+
+      - name: Docker login
+        uses: azure/docker-login@v1
+        with:
+          login-server: mhraproductsproductionregistry.azurecr.io
+          username: mhraproductsproductionregistry
+          password: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
+
+      - name: Fetch image for tagged commit
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          make ci-master tag=$TAG
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
+          echo ::set-env name=TAG::$TAG
+          echo ::set-env name=DIGEST::$DIGEST
+
+      - name: Clone Deployments repo
+        uses: actions/checkout@v2
+        with:
+          repository: MHRA/deployments
+          path: deployments
+          token: ${{ secrets.DEPLOYMENTS_REPO_TOKEN }}
+
+      - name: Update image tag
+        uses: stefanprodan/kube-tools@v1
+        with:
+          kustomize: 3.4.0
+          command: |
+            set -eux
+            cd deployments/doc-index-updater/overlays/prod
+
+            kustomize edit set image $DIGEST
+
+            git config --local user.email "CD.no.reply@mhra.gov.uk"
+            git config --local user.name "MHRA CI/CD"
+            git diff-index --quiet HEAD || git commit -am "CI: Update production image for $TAG"
+            declare -i n
+            n=0
+            until [ $n -ge 5 ]
+            do
+              git push && break
+              n+=1
+              git pull --rebase
+            done

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -1,0 +1,81 @@
+name: learning-web-master
+
+on:
+  push:
+    tags:
+      - learningweb.v*
+
+env:
+  GATSBY_GOOGLE_ANALYTICS_TRACKING_ID: UA-6838115-15
+  GATSBY_GOOGLE_TAG_MANAGER_ID: GTM-WJ5TW34
+
+jobs:
+  build:
+    name: Create release and deploy to production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "13.11"
+
+      - name: Install modules
+        working-directory: learning/web
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests with coverage
+        working-directory: learning/web
+        run: yarn test:ci
+
+      - name: Build
+        working-directory: learning/web
+        run: yarn build
+        env:
+          PATH_PREFIX: ""
+
+      - name: Run cypress end-to-end tests
+        working-directory: learning/web
+        run: mkdir -p cypress/screenshots && yarn test-e2e
+
+      - name: Upload cypress screenshots
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: learning-cypress-screenshots
+          path: learning/web/cypress/screenshots
+
+      - name: Upload cypress videos
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: learning-cypress-videos
+          path: learning/web/cypress/videos
+
+      - name: Accessibility check
+        working-directory: learning/web
+        run: yarn a11y
+        env:
+          ROOT_URL_DOMAIN: localhost
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Learning website release ${{ github.ref }}
+          body: |
+            Release of Learning website
+          draft: false
+          prerelease: false
+
+      - name: Deploy learning web to static site in azure storage
+        uses: lauchacarro/Azure-Storage-Action@master
+        with:
+          enabled-static-website: true
+          folder: learning/web/public
+          connection-string: ${{ secrets.AZURE_STORAGE_PROD_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/medicines-web-release.yaml
+++ b/.github/workflows/medicines-web-release.yaml
@@ -1,0 +1,91 @@
+name: medicines-web-release
+
+on:
+  push:
+    tags:
+      - medicinesweb.v*
+
+env:
+  AZURE_SEARCH_API_VERSION: 2017-11-11
+  AZURE_SEARCH_EXACTNESS_BOOST: 4
+  AZURE_SEARCH_INDEX: products-index
+  AZURE_SEARCH_KEY: 650538997E243D9CE334050D9119BA90
+  AZURE_SEARCH_SCORING_PROFILE: preferKeywords
+  AZURE_SEARCH_SERVICE: mhraproductsproduction
+  AZURE_SEARCH_WORD_FUZZINESS: 1
+  GOOGLE_GTM_CONTAINER_ID: GTM-WJ5TW34
+  GOOGLE_TRACKING_ID: UA-6838115-13
+  GOOGLE_USE_DEBUG: false
+  ROOT_URL_DOMAIN: .windows.net
+
+      jobs:
+        build:
+          name: Build, test, create release and deploy to production
+          runs-on: ubuntu-latest
+          steps:
+            - name: Clone repo
+              uses: actions/checkout@v2
+      
+            - name: Setup node.js
+              uses: actions/setup-node@v1
+              with:
+                node-version: "13.11"
+      
+            - name: Install modules
+              working-directory: medicines/web
+              run: yarn install --frozen-lockfile
+      
+            - name: Run tests with coverage
+              working-directory: medicines/web
+              run: yarn test:ci
+      
+            - name: Build and export
+              working-directory: medicines/web
+              run: yarn build && yarn export
+      
+            - name: Run cypress end-to-end tests
+              working-directory: medicines/web
+              run: mkdir -p cypress/screenshots && yarn test-e2e
+              env:
+                ROOT_URL_DOMAIN: localhost
+      
+            - name: Upload cypress screenshots
+              uses: actions/upload-artifact@v1
+              if: failure()
+              with:
+                name: medicines-cypress-screenshots
+                path: medicines/web/cypress/screenshots
+      
+            - name: Upload cypress videos
+              uses: actions/upload-artifact@v1
+              if: always()
+              with:
+                name: medicines-cypress-videos
+                path: medicines/web/cypress/videos
+      
+            - name: Accessibility check
+              working-directory: medicines/web
+              run: yarn a11y
+              env:
+                ROOT_URL_DOMAIN: localhost
+      
+            - name: Create Release
+              id: create_release
+              uses: actions/create-release@latest
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                tag_name: ${{ github.ref }}
+                release_name: Medicines website release ${{ github.ref }}
+                body: |
+                  Release of Medicines website
+                draft: false
+                prerelease: false
+
+            - name: Deploy products web to static site in azure storage
+              uses: lauchacarro/Azure-Storage-Action@master
+              with:
+                enabled-static-website: true
+                folder: medicines/web/dist
+                connection-string: ${{ secrets. AZURE_STORAGE_PROD_PRODUCTS_WEB_CONNECTION_STRING }}
+      

--- a/medicines/doc-index-updater/Makefile
+++ b/medicines/doc-index-updater/Makefile
@@ -66,7 +66,7 @@ docker-run: ## Run Docker image
 
 .PHONY: docker-pull
 docker-pull: ## Pull Docker image
-	docker pull $(image)
+	docker pull image $(image):$(tag)
 
 .PHONY: docker-push
 docker-push: ## Push Docker image


### PR DESCRIPTION
# Automate prod release
Relates to #689 
Creates Github workflows for release to production for:
- Medicines website
- CPD website
- Document index updater

![](https://media.giphy.com/media/E3cQDsj7pUpwI/giphy.gif)

### Acceptance Criteria

- [ ] Creates a release and deploys the tagged commit to production for the CPD website on a push of a tag starting with `learningweb.v`
- [ ] Creates a release and deploys the tagged commit to production for the Medicines website on a push of a tag starting with `medicinesweb.v`
- [ ] Creates a release and deploys the tagged commit to production for the Document Index Updater on a push of a tag starting with `diu.v`

### Testing information
- Not sure the best way to test these, other than in production?

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
