### PR TITLE
Remove repeated relative working directory path

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
 
       - name: Push image for tagged commit
-        working-directory: ./products/medicines/doc-index-updater
+        working-directory: ./
         run: |
           make docker-push image=$PROD_IMAGE tag=$TAG
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${PROD_IMAGE}:${TAG})"


### PR DESCRIPTION
# Remove repeated relative working directory path within same workflow step

Two subsequent `working-directory` commands using relative paths in the same build step could be causing an issue where the second path cannot be found. 

### Acceptance Criteria

- [ ] Causes workflow to succeed


### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
