### PR TITLE
Workflow allows non-prod website to work

### DIFF
--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -20,7 +20,7 @@ env:
   GOOGLE_TRACKING_ID: UA-6838115-11
   GOOGLE_USE_DEBUG: true
   ROOT_URL_DOMAIN: .windows.net
-  GRAPHQL_URL: http://medicines-api-dev.test.mhra.gov.uk/graphql
+  GRAPHQL_URL: https://medicines-api.test.mhra.gov.uk/graphql
 
 jobs:
   build:

--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -20,7 +20,7 @@ env:
   GOOGLE_TRACKING_ID: UA-6838115-11
   GOOGLE_USE_DEBUG: true
   ROOT_URL_DOMAIN: .windows.net
-  GRAPHQL_URL: https://will-be-replaced/with-real-url
+  GRAPHQL_URL: http://medicines-api-dev.test.mhra.gov.uk/graphql
 
 jobs:
   build:


### PR DESCRIPTION
Patches up workflow from #681 etc so that the URL used by the website isn't placeholder.

### Acceptance Criteria

- [ ] graphql URL in medicines website workflow will work for someone with the right /etc/hosts

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
