### PR TITLE
Change to use GITHUB_SHA variable

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Fetch image for tagged commit
         working-directory: ./products/medicines/doc-index-updater
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
           make docker-pull image=$NONPROD_IMAGE tag=$TAG
           echo ::set-env name=TAG::$TAG
 


### PR DESCRIPTION
# Change to use GITHUB_SHA variable

Release workflow currently uses `github.sha` variable, which seems to behave oddly when accessing the sha of the tagged commit (can't find the commit). It seems like `GITHUB_SHA` is the recommended way to access the SHA for pushes and hopefully will be able to properly identify the SHA of the tagged commit.

### Acceptance Criteria

- [ ] Enables workflow to complete successfully

### Testing information

Push a tag of the form `diu.v1.0.0` - did the workflow complete?

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
