### PR TITLE
Search client page size restriction parameters are misnamed.

### DIFF
--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -196,9 +196,6 @@ fn build_search(
             ("api-version", config.api_version.as_str()),
             ("highlight", "content"),
             ("queryType", "full"),
-            ("@count", "true"),
-            ("@top", "10"),
-            ("@skip", "0"),
             ("search", search_term),
             ("scoringProfile", "preferKeywords"),
         ])
@@ -281,7 +278,7 @@ mod test {
     fn then_search_url_is_as_expected(actual_result: Result<reqwest::Request, reqwest::Error>) {
         if let Ok(actual) = actual_result {
             let actual = actual.url().to_string();
-            let expected = "https://search_service.search.windows.net/indexes/search_index/docs?api-version=api_version&highlight=content&queryType=full&%40count=true&%40top=10&%40skip=0&search=cool+beans&scoringProfile=preferKeywords"
+            let expected = "https://search_service.search.windows.net/indexes/search_index/docs?api-version=api_version&highlight=content&queryType=full&search=cool+beans&scoringProfile=preferKeywords"
                 .to_string();
 
             assert_eq!(actual, expected);


### PR DESCRIPTION
Removing them to reduce confusion.

![medicines-api-branch](https://github.com/MHRA/products/workflows/medicines-api-branch/badge.svg?branch=search-client-does-not-restrict-page-size)

![doc-index-updater-branch](https://github.com/MHRA/products/workflows/doc-index-updater-branch/badge.svg?branch=search-client-does-not-restrict-page-size)

![Idris smiling](https://media.giphy.com/media/FyKfseNB6a8tG/giphy.gif)