### PR TITLE
Live document data in the API

### DIFF
--- a/medicines/api/Cargo.lock
+++ b/medicines/api/Cargo.lock
@@ -30,6 +30,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.12.0",
  "futures",
  "juniper",
  "juniper_subscriptions",

--- a/medicines/api/Cargo.lock
+++ b/medicines/api/Cargo.lock
@@ -29,6 +29,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "futures",
  "juniper",
  "juniper_subscriptions",
@@ -41,6 +42,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
+ "tokio-test",
  "tracing",
  "tracing-subscriber",
  "warp",
@@ -1582,6 +1584,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "tokio",
 ]
 
 [[package]]

--- a/medicines/api/Cargo.toml
+++ b/medicines/api/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.28"
+base64 = "0.12.0"
 futures = "0.3.1"
 juniper = { git = "https://github.com/graphql-rust/juniper", branch = "master" }
 juniper_subscriptions = { git = "https://github.com/graphql-rust/juniper", branch = "master" }

--- a/medicines/api/Cargo.toml
+++ b/medicines/api/Cargo.toml
@@ -23,3 +23,7 @@ serde = "^1.0.103"
 serde_derive = "^1.0.103"
 serde_json = "1.0.51"
 warp = "^0.2.2"
+
+[dev-dependencies]
+tokio-test = "0.2.0"
+async-trait = "0.1.24"

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -49,7 +49,7 @@ pub async fn get_documents(
             let bytes = base64::decode(after)?;
             let string = std::str::from_utf8(&bytes)?;
             string.parse::<i32>()? + 1
-        },
+        }
         None => 0,
     };
 
@@ -79,9 +79,10 @@ pub async fn get_documents(
         })
         .collect();
 
+    let result_count = azure_result.search_results.len() as i32;
     let total_count = azure_result.count.unwrap_or(0);
     let has_previous_page = offset != 0;
-    let has_next_page = offset + result_count <= total_count;
+    let has_next_page = offset + result_count < total_count;
     let start_cursor = base64::encode(offset.to_string());
     let end_cursor =
         base64::encode(std::cmp::min(total_count, offset + result_count - 1).to_string());
@@ -142,44 +143,48 @@ mod test {
         }
     }
 
-    fn given_some_search_results() -> Vec<IndexResult> {
+    fn given_a_search_result(product_name: &str) -> IndexResult {
+        IndexResult {
+            product_name: Some(product_name.to_string()),
+            doc_type: "Spc".to_string(),
+            file_name: "our_id".to_string(),
+            metadata_storage_name: "storage_name".to_string(),
+            metadata_storage_path: "test/path".to_string(),
+            substance_name: vec!["substance".to_string()],
+            title: "title".to_string(),
+            created: None,
+            facets: vec!["facet".to_string()],
+            keywords: None,
+            metadata_storage_size: 300,
+            release_state: None,
+            rev_label: None,
+            suggestions: vec!["suggestion".to_string()],
+            score: 1.0,
+            highlights: None,
+        }
+    }
+
+    fn given_first_page_of_search_results() -> Vec<IndexResult> {
         vec![
-            IndexResult {
-                doc_type: "Spc".to_string(),
-                file_name: "our_id".to_string(),
-                metadata_storage_name: "storage_name".to_string(),
-                metadata_storage_path: "test/path".to_string(),
-                product_name: Some("product".to_string()),
-                substance_name: vec!["substance".to_string()],
-                title: "title".to_string(),
-                created: None,
-                facets: vec!["facet".to_string()],
-                keywords: None,
-                metadata_storage_size: 300,
-                release_state: None,
-                rev_label: None,
-                suggestions: vec!["suggestion".to_string()],
-                score: 1.0,
-                highlights: None,
-            },
-            IndexResult {
-                doc_type: "Par".to_string(),
-                file_name: "other_id".to_string(),
-                metadata_storage_name: "other_storage_name".to_string(),
-                metadata_storage_path: "test/other_path".to_string(),
-                product_name: Some("product two".to_string()),
-                substance_name: vec!["ecnatsbus".to_string()],
-                title: "Jaws".to_string(),
-                created: None,
-                facets: vec!["otherfacet".to_string()],
-                keywords: None,
-                metadata_storage_size: 300,
-                release_state: None,
-                rev_label: None,
-                suggestions: vec!["the other document".to_string()],
-                score: 0.9,
-                highlights: None,
-            },
+            given_a_search_result("first"),
+            given_a_search_result("second"),
+            given_a_search_result("third"),
+            given_a_search_result("fourth"),
+            given_a_search_result("fifth"),
+            given_a_search_result("sixth"),
+            given_a_search_result("seventh"),
+            given_a_search_result("eighth"),
+            given_a_search_result("ninth"),
+            given_a_search_result("tenth"),
+        ]
+    }
+
+    fn given_last_page_of_search_results() -> Vec<IndexResult> {
+        vec![
+            given_a_search_result("fourth last"),
+            given_a_search_result("third last"),
+            given_a_search_result("second last"),
+            given_a_search_result("last"),
         ]
     }
 
@@ -209,23 +214,19 @@ mod test {
         .unwrap()
     }
 
-    fn then_we_have_expected_documents(
-        documents_response: &Documents,
-        search_results: &Vec<IndexResult>,
-    ) {
-        assert_eq!(documents_response.edges.len(), search_results.len());
-        let expected_names = search_results
-            .into_iter()
-            .map(|result| result.product_name.to_owned().unwrap());
+    fn then_we_have_the_first_page(documents_response: &Documents) {
+        let expected_names = vec![
+            "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth",
+            "tenth",
+        ];
         let edges = &documents_response.edges;
         let actual_names = edges
             .into_iter()
-            .map(|edge| edge.node.product_name.as_ref().unwrap().as_ref());
-        assert!(expected_names.eq(actual_names));
-    }
+            .map(|edge| edge.node.product_name.as_ref().unwrap());
+        assert!(actual_names.eq(expected_names));
 
-    fn then_we_are_on_first_page(documents_response: &Documents) {
         assert_eq!(1234, documents_response.total_count);
+
         let expected_page_info = PageInfo {
             has_previous_page: false,
             has_next_page: true,
@@ -235,32 +236,38 @@ mod test {
         assert_eq!(expected_page_info, documents_response.page_info);
     }
 
-    fn then_we_are_on_last_page(documents_response: &Documents) {
+    fn then_we_have_the_last_page(documents_response: &Documents) {
+        let expected_names = vec!["fourth last", "third last", "second last", "last"];
+        let edges = &documents_response.edges;
+        let actual_names = edges
+            .into_iter()
+            .map(|edge| edge.node.product_name.as_ref().unwrap());
+
+        assert!(actual_names.eq(expected_names));
+
         assert_eq!(1234, documents_response.total_count);
         let expected_page_info = PageInfo {
             has_previous_page: true,
             has_next_page: false,
             start_cursor: base64::encode("1230"),
-            end_cursor: base64::encode("1234"),
+            end_cursor: base64::encode("1233"),
         };
         assert_eq!(expected_page_info, documents_response.page_info);
     }
 
     #[test]
     fn test_get_documents_first_page() {
-        let search_results = given_some_search_results();
+        let search_results = given_first_page_of_search_results();
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_first_page_of_documents(search_client);
-        then_we_have_expected_documents(&response, &search_results);
-        then_we_are_on_first_page(&response);
+        then_we_have_the_first_page(&response);
     }
 
     #[test]
     fn test_get_documents_last_page() {
-        let search_results = given_some_search_results();
+        let search_results = given_last_page_of_search_results();
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_last_page_of_documents(search_client);
-        then_we_have_expected_documents(&response, &search_results);
-        then_we_are_on_last_page(&response);
+        then_we_have_the_last_page(&response);
     }
 }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -65,7 +65,7 @@ pub async fn get_documents(
         .map(|document| {
             let edge = DocumentEdge {
                 node: document,
-                cursor: cursor.to_string(),
+                cursor: base64::encode(cursor.to_string()),
             };
             cursor += 1;
             return edge;
@@ -75,8 +75,9 @@ pub async fn get_documents(
     let total_count = azure_result.count.unwrap_or(0);
     let has_previous_page = offset != 0;
     let has_next_page = offset + result_count <= total_count;
-    let start_cursor = offset.to_string();
-    let end_cursor = std::cmp::min(total_count, offset + result_count - 1).to_string();
+    let start_cursor = base64::encode(offset.to_string());
+    let end_cursor =
+        base64::encode(std::cmp::min(total_count, offset + result_count - 1).to_string());
 
     Ok(Documents {
         edges,
@@ -221,8 +222,8 @@ mod test {
         let expected_page_info = PageInfo {
             has_previous_page: false,
             has_next_page: true,
-            start_cursor: "0".to_string(),
-            end_cursor: "9".to_string(),
+            start_cursor: base64::encode("0"),
+            end_cursor: base64::encode("9"),
         };
         assert_eq!(expected_page_info, documents_response.page_info);
     }
@@ -232,8 +233,8 @@ mod test {
         let expected_page_info = PageInfo {
             has_previous_page: true,
             has_next_page: false,
-            start_cursor: "1230".to_string(),
-            end_cursor: "1234".to_string(),
+            start_cursor: base64::encode("1230"),
+            end_cursor: base64::encode("1234"),
         };
         assert_eq!(expected_page_info, documents_response.page_info);
     }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -43,8 +43,15 @@ pub async fn get_documents(
     first: Option<i32>,
     after: Option<String>,
 ) -> Result<Documents, anyhow::Error> {
-    let offset = after.unwrap_or("-1".to_string()).parse::<i32>().unwrap() + 1;
     let result_count = first.unwrap_or(10);
+    let offset = match after {
+        Some(after) => {
+            let bytes = base64::decode(after)?;
+            let string = std::str::from_utf8(&bytes)?;
+            string.parse::<i32>()? + 1
+        },
+        None => 0,
+    };
 
     let azure_result = client
         .search_with_pagination(
@@ -197,7 +204,7 @@ mod test {
             &search_client,
             "Search string".to_string(),
             None,
-            Some("1229".to_string()),
+            Some(base64::encode("1229").to_string()),
         ))
         .unwrap()
     }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -45,7 +45,6 @@ pub async fn get_documents(
     before: Option<String>,
     after: Option<String>,
 ) -> Result<Documents, anyhow::Error> {
-
     // TODO: Do something with last and after.
 
     let offset = after.unwrap_or("-1".to_string()).parse::<i32>().unwrap() + 1;
@@ -63,7 +62,8 @@ pub async fn get_documents(
         .await?;
 
     let mut cursor = offset.clone();
-    let edges = azure_result.search_results
+    let edges = azure_result
+        .search_results
         .iter()
         .map(|search_result| Document::from(search_result.clone()))
         .map(|document| {
@@ -92,4 +92,143 @@ pub async fn get_documents(
             end_cursor: end_cursor,
         },
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use async_trait::async_trait;
+    use search_client::models::IndexResults;
+    use tokio_test::block_on;
+
+    struct TestAzureSearchClient {
+        pub search_results: Vec<IndexResult>,
+    }
+
+    #[async_trait]
+    impl Search for TestAzureSearchClient {
+        async fn search(&self, _search_term: &str) -> Result<IndexResults, reqwest::Error> {
+            unimplemented!()
+        }
+        async fn search_with_pagination(
+            &self,
+            _search_term: &str,
+            _pagination: search_client::AzurePagination,
+            _include_count: bool,
+        ) -> Result<IndexResults, reqwest::Error> {
+            Ok(IndexResults {
+                search_results: self.search_results.clone(),
+                context: String::from(""),
+                count: Some(1234),
+            })
+        }
+        async fn filter_by_collection_field(
+            &self,
+            _field_name: &str,
+            _field_value: &str,
+        ) -> Result<IndexResults, reqwest::Error> {
+            unimplemented!()
+        }
+        async fn filter_by_non_collection_field(
+            &self,
+            _field_name: &str,
+            _field_value: &str,
+        ) -> Result<IndexResults, reqwest::Error> {
+            unimplemented!()
+        }
+    }
+
+    fn given_some_search_results() -> Vec<IndexResult> {
+        vec![
+            IndexResult {
+                doc_type: "Spc".to_string(),
+                file_name: "our_id".to_string(),
+                metadata_storage_name: "storage_name".to_string(),
+                metadata_storage_path: "test/path".to_string(),
+                product_name: Some("product".to_string()),
+                substance_name: vec!["substance".to_string()],
+                title: "title".to_string(),
+                created: None,
+                facets: vec!["facet".to_string()],
+                keywords: None,
+                metadata_storage_size: 300,
+                release_state: None,
+                rev_label: None,
+                suggestions: vec!["suggestion".to_string()],
+                score: 1.0,
+                highlights: None,
+            },
+            IndexResult {
+                doc_type: "Par".to_string(),
+                file_name: "other_id".to_string(),
+                metadata_storage_name: "other_storage_name".to_string(),
+                metadata_storage_path: "test/other_path".to_string(),
+                product_name: Some("product two".to_string()),
+                substance_name: vec!["ecnatsbus".to_string()],
+                title: "Jaws".to_string(),
+                created: None,
+                facets: vec!["otherfacet".to_string()],
+                keywords: None,
+                metadata_storage_size: 300,
+                release_state: None,
+                rev_label: None,
+                suggestions: vec!["the other document".to_string()],
+                score: 0.9,
+                highlights: None,
+            },
+        ]
+    }
+
+    fn given_a_search_client(search_results: &Vec<IndexResult>) -> impl Search {
+        TestAzureSearchClient {
+            search_results: search_results.clone(),
+        }
+    }
+
+    fn when_we_get_the_first_page_of_documents(search_client: impl Search) -> Documents {
+        block_on(get_documents(
+            &search_client,
+            "Search string".to_string(),
+            None,
+            None,
+            None,
+            None,
+        ))
+        .unwrap()
+    }
+
+    fn then_we_have_expected_documents(
+        documents_response: &Documents,
+        search_results: &Vec<IndexResult>,
+    ) {
+        assert_eq!(documents_response.edges.len(), search_results.len());
+        let expected_names = search_results
+            .into_iter()
+            .map(|result| result.product_name.to_owned().unwrap());
+        let edges = &documents_response.edges;
+        let actual_names = edges
+            .into_iter()
+            .map(|edge| edge.node.product_name.as_ref().unwrap().as_ref());
+        assert!(expected_names.eq(actual_names));
+    }
+
+    fn then_we_have_first_page(documents_response: &Documents) {
+        assert_eq!(1234, documents_response.total_count);
+        let expected_page_info = PageInfo {
+            has_previous_page: false,
+            has_next_page: true,
+            start_cursor: "0".to_string(),
+            end_cursor: "9".to_string(),
+        };
+        assert_eq!(expected_page_info, documents_response.page_info);
+    }
+
+    #[test]
+    fn test_get_documents_first_page() {
+        let search_results = given_some_search_results();
+        let search_client = given_a_search_client(&search_results);
+        let response = when_we_get_the_first_page_of_documents(search_client);
+        then_we_have_expected_documents(&response, &search_results);
+        then_we_have_first_page(&response);
+    }
 }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -217,7 +217,7 @@ mod test {
         assert!(expected_names.eq(actual_names));
     }
 
-    fn then_we_have_first_page(documents_response: &Documents) {
+    fn then_we_are_on_first_page(documents_response: &Documents) {
         assert_eq!(1234, documents_response.total_count);
         let expected_page_info = PageInfo {
             has_previous_page: false,
@@ -228,7 +228,7 @@ mod test {
         assert_eq!(expected_page_info, documents_response.page_info);
     }
 
-    fn then_we_have_last_page(documents_response: &Documents) {
+    fn then_we_are_on_last_page(documents_response: &Documents) {
         assert_eq!(1234, documents_response.total_count);
         let expected_page_info = PageInfo {
             has_previous_page: true,
@@ -245,7 +245,7 @@ mod test {
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_first_page_of_documents(search_client);
         then_we_have_expected_documents(&response, &search_results);
-        then_we_have_first_page(&response);
+        then_we_are_on_first_page(&response);
     }
 
     #[test]
@@ -254,6 +254,6 @@ mod test {
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_last_page_of_documents(search_client);
         then_we_have_expected_documents(&response, &search_results);
-        then_we_have_last_page(&response);
+        then_we_are_on_last_page(&response);
     }
 }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -41,12 +41,8 @@ pub async fn get_documents(
     client: &impl Search,
     search: String,
     first: Option<i32>,
-    last: Option<i32>,
-    before: Option<String>,
     after: Option<String>,
 ) -> Result<Documents, anyhow::Error> {
-    // TODO: Do something with last and after.
-
     let offset = after.unwrap_or("-1".to_string()).parse::<i32>().unwrap() + 1;
     let result_count = first.unwrap_or(10);
 
@@ -191,19 +187,14 @@ mod test {
             "Search string".to_string(),
             None,
             None,
-            None,
-            None,
         ))
         .unwrap()
     }
-
 
     fn when_we_get_the_last_page_of_documents(search_client: impl Search) -> Documents {
         block_on(get_documents(
             &search_client,
             "Search string".to_string(),
-            None,
-            None,
             None,
             Some("1229".to_string()),
         ))

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -197,6 +197,19 @@ mod test {
         .unwrap()
     }
 
+
+    fn when_we_get_the_last_page_of_documents(search_client: impl Search) -> Documents {
+        block_on(get_documents(
+            &search_client,
+            "Search string".to_string(),
+            None,
+            None,
+            None,
+            Some("1229".to_string()),
+        ))
+        .unwrap()
+    }
+
     fn then_we_have_expected_documents(
         documents_response: &Documents,
         search_results: &Vec<IndexResult>,
@@ -223,6 +236,17 @@ mod test {
         assert_eq!(expected_page_info, documents_response.page_info);
     }
 
+    fn then_we_have_last_page(documents_response: &Documents) {
+        assert_eq!(1234, documents_response.total_count);
+        let expected_page_info = PageInfo {
+            has_previous_page: true,
+            has_next_page: false,
+            start_cursor: "1230".to_string(),
+            end_cursor: "1234".to_string(),
+        };
+        assert_eq!(expected_page_info, documents_response.page_info);
+    }
+
     #[test]
     fn test_get_documents_first_page() {
         let search_results = given_some_search_results();
@@ -230,5 +254,14 @@ mod test {
         let response = when_we_get_the_first_page_of_documents(search_client);
         then_we_have_expected_documents(&response, &search_results);
         then_we_have_first_page(&response);
+    }
+
+    #[test]
+    fn test_get_documents_last_page() {
+        let search_results = given_some_search_results();
+        let search_client = given_a_search_client(&search_results);
+        let response = when_we_get_the_last_page_of_documents(search_client);
+        then_we_have_expected_documents(&response, &search_results);
+        then_we_have_last_page(&response);
     }
 }

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -64,18 +64,16 @@ pub async fn get_documents(
         )
         .await?;
 
-    let mut cursor = offset.clone();
     let edges = azure_result
         .search_results
         .iter()
         .map(|search_result| Document::from(search_result.clone()))
-        .map(|document| {
-            let edge = DocumentEdge {
+        .enumerate()
+        .map(|(i, document)| {
+            DocumentEdge {
                 node: document,
-                cursor: base64::encode(cursor.to_string()),
-            };
-            cursor += 1;
-            return edge;
+                cursor: base64::encode((i as i32 + offset).to_string()),
+            }
         })
         .collect();
 

--- a/medicines/api/src/pagination.rs
+++ b/medicines/api/src/pagination.rs
@@ -1,7 +1,7 @@
 use juniper::GraphQLObject;
 
 // Based upon: https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
-#[derive(GraphQLObject)]
+#[derive(GraphQLObject, Debug, PartialEq)]
 pub struct PageInfo {
     pub has_previous_page: bool,
     pub has_next_page: bool,

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -56,7 +56,19 @@ impl QueryRoot {
         before: Option<String>,
         after: Option<String>,
     ) -> FieldResult<Documents> {
-        Ok(get_documents(&context.client, search, first, last, before, after).await)
+        get_documents(
+            &context.client,
+            search.unwrap_or(" ".to_string()),
+            first,
+            last,
+            before,
+            after,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Error fetching results from Azure search service: {:?}", e);
+            juniper::FieldError::new("Error fetching search results", juniper::Value::null())
+        })
     }
 }
 

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -52,16 +52,12 @@ impl QueryRoot {
         context: &AzureContext,
         search: Option<String>,
         first: Option<i32>,
-        last: Option<i32>,
-        before: Option<String>,
         after: Option<String>,
     ) -> FieldResult<Documents> {
         get_documents(
             &context.client,
             search.unwrap_or(" ".to_string()),
             first,
-            last,
-            before,
             after,
         )
         .await

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -20,8 +20,8 @@ pub struct AzureSearchClient {
 }
 
 pub struct AzurePagination {
-    pub result_count: u32,
-    pub offset: u32,
+    pub result_count: i32,
+    pub offset: i32,
 }
 
 impl Default for AzureSearchClient {


### PR DESCRIPTION
Hook up the document API with real, live data.

![](https://media.giphy.com/media/2tTijWcJ2fTOGoHxNN/giphy.gif)

Example of the API output:

<img width="1375" alt="Screenshot 2020-04-27 at 17 08 52" src="https://user-images.githubusercontent.com/76330/80394484-d4d80980-88a9-11ea-913e-07e06b9101a9.png">
