### PR TITLE
Basic GraphQl products page

### DIFF
--- a/medicines/web/src/components/search-results/index.tsx
+++ b/medicines/web/src/components/search-results/index.tsx
@@ -1,6 +1,8 @@
 import React, { MouseEvent } from 'react';
 import styled from 'styled-components';
 import { useLocalStorage, useSessionStorage } from '../../hooks';
+import { IDocument } from '../../model/substance';
+import { DocType } from '../../services/azure-search';
 import { mhraBlue80, mhraGray10, white } from '../../styles/colors';
 import {
   baseSpace,
@@ -12,9 +14,6 @@ import { baseFontSize, h2FontSize } from '../../styles/fonts';
 import Disclaimer from '../disclaimer';
 import SearchFilter from '../search-filter';
 import Pagination from './pagination';
-
-import { DocType } from '../../services/azure-search';
-import { IDocument } from '../../services/results-converter';
 
 const StyledDrugList = styled.div`
   .title {
@@ -174,6 +173,10 @@ const searchResultsNumberingInformation = (
 };
 
 const normalizeDescription = (description: string): string => {
+  if (!description) {
+    return description;
+  }
+
   const normalized = description
     .substr(0, 300) // Cut to 300 characters.
     .replace(/[^\w<>/\s…]/gi, '') // Remove non-word characters other than ellipsis & tags.

--- a/medicines/web/src/model/substance.ts
+++ b/medicines/web/src/model/substance.ts
@@ -14,3 +14,14 @@ export function isSubstance(obj: any): obj is ISubstance {
 export function isIndex(obj: any): obj is ISubstance {
   return obj.products === undefined && obj.count === undefined;
 }
+
+export interface IDocument {
+  activeSubstances: string[];
+  context: string;
+  created: string;
+  docType: string;
+  fileSize: string;
+  name: string;
+  product: string;
+  url: string;
+}

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -26,7 +26,7 @@ query ($productName: String) {
           highlights
           created
           docType
-          fileBytes
+          fileBytes: fileSizeInBytes
           name
           url
         }

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -13,7 +13,7 @@ interface IProductResponse {
 }
 
 const query = `
-query ($productName: String) {
+query ($productName: String!) {
   product(name: $productName) {
     name
     documents {

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -4,7 +4,7 @@ import { graphqlRequest } from './graphql';
 
 interface IDocuments {
   count: number;
-  edges: Array<{ node: IDocument }>;
+  edges: Array<{ node: IDocumentResponse }>;
 }
 
 interface IProductResponse {
@@ -12,6 +12,17 @@ interface IProductResponse {
     name: string;
     documents: IDocuments;
   };
+}
+
+interface IDocumentResponse {
+  product: string;
+  activeSubstances: string[];
+  highlights: string;
+  created: string;
+  docType: string;
+  fileBytes: number;
+  title: string;
+  url: string;
 }
 
 const query = `
@@ -22,7 +33,7 @@ query ($productName: String!, $first: Int, $skip: Int) {
       count: totalCount
       edges {
         node {
-          name: productName
+          product: productName
           activeSubstances
           highlights
           created
@@ -51,7 +62,24 @@ const convertResponseToProduct = ({
   return {
     name,
     count,
-    documents: edges.map(x => x.node),
+    documents: edges.map(convertDocumentResponseToDocument),
+  };
+};
+
+const convertDocumentResponseToDocument = ({
+  node: doc,
+}: {
+  node: IDocumentResponse;
+}): IDocument => {
+  return {
+    activeSubstances: doc.activeSubstances,
+    context: doc.highlights,
+    created: doc.created,
+    docType: doc.docType,
+    fileSize: Math.ceil(doc.fileBytes / 1000).toLocaleString('en-GB'),
+    name: doc.title,
+    product: doc.product,
+    url: doc.url,
   };
 };
 

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -8,8 +8,10 @@ interface IDocuments {
 }
 
 interface IProductResponse {
-  name: string;
-  documents: IDocuments;
+  product: {
+    name: string;
+    documents: IDocuments;
+  };
 }
 
 const query = `
@@ -20,14 +22,13 @@ query ($productName: String!, $first: Int, $skip: Int) {
       count: totalCount
       edges {
         node {
-          productName
+          name: productName
           activeSubstances
-          title
           highlights
           created
           docType
           fileBytes: fileSizeInBytes
-          name
+          title
           url
         }
       }
@@ -42,8 +43,10 @@ interface IProduct {
 }
 
 const convertResponseToProduct = ({
-  name,
-  documents: { count, edges },
+  product: {
+    name,
+    documents: { count, edges },
+  },
 }: IProductResponse): IProduct => {
   return {
     name,

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -1,0 +1,36 @@
+import DataLoader from 'dataloader';
+import { IDocument } from '../model/substance';
+
+const graphQlUrl = process.env.GRAPHQL_URL as string;
+
+const fetchFromGraphQl = (query: string): Promise<Response> => {
+  return fetch(graphQlUrl, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables: null }),
+  });
+};
+
+const getDocumentsForProduct = async (productName: any) => {
+  const query = `{ product(name: "${productName}") { documents {       productName
+    activeSubstances
+    title
+    highlights
+    created
+    docType
+    fileBytes
+    name
+    url } } }`;
+  const response = await fetchFromGraphQl(query);
+
+  return (await response.json()).data.product.documents;
+};
+
+export const documents = new DataLoader<string, IDocument[]>(
+  async productNames => {
+    return Promise.all(productNames.map(getDocumentsForProduct));
+  },
+);

--- a/medicines/web/src/services/results-converter.ts
+++ b/medicines/web/src/services/results-converter.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+import { IDocument } from '../model/substance';
 import { ISearchResult } from '../services/azure-search';
 
 const sanitizeTitle = (title: string | null): string => {
@@ -13,17 +14,6 @@ const sanitizeTitle = (title: string | null): string => {
   }
   return name;
 };
-
-export interface IDocument {
-  activeSubstances: string[];
-  context: string;
-  created: string;
-  docType: string;
-  fileSize: string;
-  name: string;
-  product: string;
-  url: string;
-}
 
 export const convertResults = (doc: ISearchResult): IDocument => {
   return {


### PR DESCRIPTION
# Hook up product page to GraphQL

Points our friend the Products Page to the graphql, behind feature flag.

Will resolve #401.

![existing product](https://media.giphy.com/media/3orieWnNYtkTr7P5fi/giphy.gif)

### Acceptance Criteria

- [x] Use graphQL optionally (query param flag) on the products page
- [x] Make pagination work for such pages on graphQL (enabled by #731)
- [ ] has DocType filtering even with the graphql

### Testing information

Go to a product page and set `useGraphQl=true` as a query parameter.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
