### PR TITLE
Fix subtances API for when products contain multiple substances

### DIFF
--- a/medicines/api/Cargo.lock
+++ b/medicines/api/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -381,15 +381,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
+checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -398,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
+checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -416,21 +416,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
 
 [[package]]
 name = "futures-util"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "indexmap",
  "itoa",

--- a/medicines/api/Cargo.lock
+++ b/medicines/api/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "juniper_subscriptions",
  "juniper_warp",
  "listenfd",
+ "pretty_assertions",
  "quote",
  "reqwest",
  "search_client",
@@ -241,6 +242,22 @@ name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
+name = "ctor"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -946,6 +963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1059,18 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "difference",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/medicines/api/Cargo.toml
+++ b/medicines/api/Cargo.toml
@@ -26,5 +26,6 @@ serde_json = "1.0.51"
 warp = "^0.2.2"
 
 [dev-dependencies]
-tokio-test = "0.2.0"
 async-trait = "0.1.24"
+pretty_assertions = "0.6.1"
+tokio-test = "0.2.0"

--- a/medicines/api/Cargo.toml
+++ b/medicines/api/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.28"
 base64 = "0.12.0"
-futures = "0.3.1"
+futures = "0.3.4"
 juniper = { git = "https://github.com/graphql-rust/juniper", branch = "master" }
 juniper_subscriptions = { git = "https://github.com/graphql-rust/juniper", branch = "master" }
 juniper_warp = { git = "https://github.com/graphql-rust/juniper", branch = "master" }
@@ -22,10 +22,10 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.5"
 serde = "^1.0.103"
 serde_derive = "^1.0.103"
-serde_json = "1.0.51"
+serde_json = "1.0.52"
 warp = "^0.2.2"
 
 [dev-dependencies]
-async-trait = "0.1.24"
+async-trait = "0.1.30"
 pretty_assertions = "0.6.1"
-tokio-test = "0.2.0"
+tokio-test = "0.2.1"

--- a/medicines/api/src/substance.rs
+++ b/medicines/api/src/substance.rs
@@ -2,7 +2,7 @@ use crate::{document::Document, product::Product};
 use search_client::{models::IndexResults, Search};
 use std::collections::BTreeMap;
 
-#[derive(Debug, juniper::GraphQLObject)]
+#[derive(Debug, PartialEq, juniper::GraphQLObject)]
 #[graphql(description = "An active ingredient found in medical products")]
 pub struct Substance {
     name: String,
@@ -36,9 +36,14 @@ fn format_search_results(results: IndexResults, letter: char) -> Vec<Substance> 
     results
         .search_results
         .iter()
-        .filter(|result| result.facets.first() == Some(&letter_string))
+        .filter(|result| result.facets.iter().any(|s| s == &letter_string))
         .filter_map(|result| {
-            let substance_name = result.substance_name.first()?.as_str();
+            let substance_name = result
+                .substance_name
+                .iter()
+                .find(|&s| s.starts_with(letter))?
+                .as_str();
+
             let product_name = result.product_name.as_ref()?.as_str();
 
             let doc: Document = result.clone().into();
@@ -74,4 +79,154 @@ fn format_search_results(results: IndexResults, letter: char) -> Vec<Substance> 
             Substance::new(substance.into(), products)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use search_client::models::{IndexResult, IndexResults};
+
+    fn index_result(product_name: &str, substance_name: &[&str], facets: &[&str]) -> IndexResult {
+        IndexResult {
+            doc_type: "Spc".into(),
+            file_name: "CON1587463572172".into(),
+            metadata_storage_name: "4e99070c7e5d3682675b2becd972ec44ef35b20c".into(),
+            metadata_storage_path: "https://mhraproductsnonprod.blob.core.windows.net/docs/4e99070c7e5d3682675b2becd972ec44ef35b20c".into(),
+            product_name: Some(product_name.into()),
+            substance_name: substance_name.iter().map(|&s|s.into()).collect(),
+            title: "spc-doc_PL 16363-0365.pdf".into(),
+            created: None,
+            facets: facets.iter().map(|&s|s.into()).collect(),
+            keywords: Some("".into()),
+            metadata_storage_size: 107842,
+            release_state: None,
+            rev_label: None,
+            suggestions: vec![],
+            score: 1.0,
+            highlights: None
+        }
+    }
+
+    #[test]
+    fn formats_search_results_containing_multiple_products() {
+        let letter = 'Z';
+
+        let zonismade_25mg = index_result(
+            "ZONISAMIDE ARISTO 25 MG HARD CAPSULES",
+            &["ZONISAMIDE"],
+            &[
+                "Z",
+                "Z, ZONISAMIDE",
+                "Z, ZONISAMIDE, ZONISAMIDE ARISTO 25 MG HARD CAPSULES",
+            ],
+        );
+        let zonismade_50mg = index_result(
+            "ZONISAMIDE ARISTO 50 MG HARD CAPSULES",
+            &["ZONISAMIDE"],
+            &[
+                "Z",
+                "Z, ZONISAMIDE",
+                "Z, ZONISAMIDE, ZONISAMIDE ARISTO 50 MG HARD CAPSULES",
+            ],
+        );
+        let zonismade_50mg_repeat = index_result(
+            "ZONISAMIDE ARISTO 50 MG HARD CAPSULES",
+            &["ZONISAMIDE"],
+            &[
+                "Z",
+                "Z, ZONISAMIDE",
+                "Z, ZONISAMIDE, ZONISAMIDE ARISTO 50 MG HARD CAPSULES",
+            ],
+        );
+        let zolmitriptan = index_result(
+            "ZOMIG RAPIMELT 2.5 MG ORODISPERSIBLE TABLETS",
+            &["ZOLMITRIPTAN"],
+            &[
+                "Z",
+                "Z, ZOLMITRIPTAN",
+                "Z, ZOLMITRIPTAN, ZOMIG RAPIMELT 2.5 MG ORODISPERSIBLE TABLETS",
+            ],
+        );
+
+        let results = IndexResults {
+            search_results: vec![
+                zonismade_25mg.clone(),
+                zonismade_50mg.clone(),
+                zonismade_50mg_repeat.clone(),
+                zolmitriptan.clone(),
+            ],
+            context: "https://mhraproductsnonprod.search.windows.net/indexes(\'products-index\')/$metadata#docs(*)".into(),
+            count: None
+        };
+
+        let formatted = format_search_results(results, letter);
+
+        let expected = vec![
+            Substance::new(
+                "ZOLMITRIPTAN".into(),
+                vec![Product::new(
+                    "ZOMIG RAPIMELT 2.5 MG ORODISPERSIBLE TABLETS".into(),
+                    vec![zolmitriptan.into()],
+                )],
+            ),
+            Substance::new(
+                "ZONISAMIDE".into(),
+                vec![
+                    Product::new(
+                        "ZONISAMIDE ARISTO 25 MG HARD CAPSULES".into(),
+                        vec![zonismade_25mg.into()],
+                    ),
+                    Product::new(
+                        "ZONISAMIDE ARISTO 50 MG HARD CAPSULES".into(),
+                        vec![zonismade_50mg.into(), zonismade_50mg_repeat.into()],
+                    ),
+                ],
+            ),
+        ];
+
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn formats_products_that_contain_multiple_substances() {
+        let letter = 'Z';
+
+        let index_result = index_result(
+            "LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS",
+            &["LAMIVUDINE", "ZIDOVUDINE"],
+            &[
+                "L",
+                "L, LAMIVUDINE",
+                "L, LAMIVUDINE, LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS",
+                "Z",
+                "Z, ZIDOVUDINE",
+                "Z, ZIDOVUDINE, LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS",
+            ],
+        );
+
+        let results = IndexResults {
+
+
+
+            search_results: vec![
+                index_result.clone(),
+
+            ],
+            context: "https://mhraproductsnonprod.search.windows.net/indexes(\'products-index\')/$metadata#docs(*)".into(),
+            count: None
+        };
+
+        let formatted = format_search_results(results, letter);
+
+        let expected = vec![Substance::new(
+            "ZIDOVUDINE".into(),
+            vec![Product::new(
+                "LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS".into(),
+                vec![index_result.into()],
+            )],
+        )];
+
+        assert_eq!(formatted, expected);
+    }
 }


### PR DESCRIPTION
Fixes [a bug](https://github.com/MHRA/products/issues/403#issuecomment-620698364) where if you searched for substances starting with the letter 'Z', "LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS" wouldn't show up even though it contains both LAMIVUDINE and ZIDOVUDINE.

This is because the API was just checking against the first facet returned from the search client ('L' in this case), not all of them.


![](https://media.giphy.com/media/xT1R9Wcq3cPa8BBgDC/giphy.gif)