### PR TITLE
Add document type filter to API interface

### DIFF
--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -53,6 +53,7 @@ impl QueryRoot {
         search: Option<String>,
         first: Option<i32>,
         after: Option<String>,
+        document_types: Option<Vec<String>>,
     ) -> FieldResult<Documents> {
         get_documents(
             &context.client,


### PR DESCRIPTION
Add a placeholder for document type filtering to the API.

Query will look like the following:

```
{
  documents(search:"Stuff", documentTypes:["SPC", "PAR"]) {
    totalCount
    pageInfo {
      hasNextPage
      hasPreviousPage
      endCursor
    }
    edges {
      node {
        name
        docType
      }
    }
  }
}
```

![](https://media.giphy.com/media/3o6MbiX7DNPwga0zq8/giphy.gif)
