### PR TITLE
Multi level filtering

### DIFF
--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -57,8 +57,8 @@ pub async fn get_documents(
         .search_with_pagination(
             &search,
             search_client::AzurePagination {
-                result_count: result_count,
-                offset: offset,
+                result_count,
+                offset,
             },
             true,
         )
@@ -69,11 +69,9 @@ pub async fn get_documents(
         .iter()
         .map(|search_result| Document::from(search_result.clone()))
         .enumerate()
-        .map(|(i, document)| {
-            DocumentEdge {
-                node: document,
-                cursor: base64::encode((i as i32 + offset).to_string()),
-            }
+        .map(|(i, document)| DocumentEdge {
+            node: document,
+            cursor: base64::encode((i as i32 + offset).to_string()),
         })
         .collect();
 
@@ -87,12 +85,12 @@ pub async fn get_documents(
 
     Ok(Documents {
         edges,
-        total_count: total_count,
+        total_count,
         page_info: PageInfo {
-            has_previous_page: has_previous_page,
-            has_next_page: has_next_page,
-            start_cursor: start_cursor,
-            end_cursor: end_cursor,
+            has_previous_page,
+            has_next_page,
+            start_cursor,
+            end_cursor,
         },
     })
 }

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -1,4 +1,7 @@
-use crate::{document::Document, substance::Substance};
+use crate::{
+    document::{get_document_edges, Document},
+    substance::Substance,
+};
 use search_client::{models::IndexResult, Search};
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -29,14 +32,21 @@ impl Product {
     fn name(&self) -> &str {
         &self.name
     }
-    fn documents(&self, first: i32) -> Vec<Document> {
-        let docs: Vec<Document> = self
-            .documents
-            .clone()
-            .into_iter()
-            .take(first as usize)
-            .collect();
-        docs
+    fn documents(&self, first: Option<i32>, skip: Option<i32>) -> crate::document::Documents {
+        let docs = self.documents.clone().into_iter();
+        let docs = match first {
+            Some(t) => docs.take(t as usize).collect(),
+            None => docs.collect(),
+        };
+
+        let offset = match skip {
+            Some(a) => a,
+            None => 0,
+        };
+
+        let edges = get_document_edges(docs, offset);
+
+        crate::document::get_documents_from_edges(edges, self.document_count, offset)
     }
 }
 

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -1,9 +1,7 @@
 use crate::{document::Document, substance::Substance};
-use juniper::GraphQLObject;
 use search_client::{models::IndexResult, Search};
 
-#[derive(GraphQLObject, Debug, Eq, Ord, PartialEq, PartialOrd)]
-#[graphql(description = "A medical product containing active ingredients")]
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Product {
     name: String,
     document_count: i32,
@@ -22,6 +20,23 @@ impl Product {
     pub fn add(&mut self, document: Document) {
         self.documents.push(document);
         self.document_count += 1;
+    }
+}
+
+#[juniper::graphql_object]
+#[graphql(description = "A medical product containing active ingredients")]
+impl Product {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn documents(&self, first: i32) -> Vec<Document> {
+        let docs: Vec<Document> = self
+            .documents
+            .clone()
+            .into_iter()
+            .take(first as usize)
+            .collect();
+        docs
     }
 }
 

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -1,5 +1,5 @@
 use crate::{
-    document::{get_document_edges, Document},
+    document::{self, get_documents_graph_from_documents_vector, Document},
     substance::Substance,
 };
 use search_client::{models::IndexResult, Search};
@@ -32,7 +32,7 @@ impl Product {
     fn name(&self) -> &str {
         &self.name
     }
-    fn documents(&self, first: Option<i32>, skip: Option<i32>) -> crate::document::Documents {
+    fn documents(&self, first: Option<i32>, skip: Option<i32>) -> document::Documents {
         let docs = self.documents.clone().into_iter();
         let docs = match first {
             Some(t) => docs.take(t as usize).collect(),
@@ -44,9 +44,7 @@ impl Product {
             None => 0,
         };
 
-        let edges = get_document_edges(docs, offset);
-
-        crate::document::get_documents_from_edges(edges, self.document_count, offset)
+        get_documents_graph_from_documents_vector(docs, offset, self.document_count)
     }
 }
 

--- a/medicines/api/src/substance.rs
+++ b/medicines/api/src/substance.rs
@@ -2,8 +2,7 @@ use crate::{document::Document, product::Product};
 use search_client::{models::IndexResults, Search};
 use std::collections::BTreeMap;
 
-#[derive(Debug, juniper::GraphQLObject)]
-#[graphql(description = "An active ingredient found in medical products")]
+#[derive(Debug)]
 pub struct Substance {
     name: String,
     products: Vec<Product>,
@@ -12,6 +11,17 @@ pub struct Substance {
 impl Substance {
     pub fn new(name: String, products: Vec<Product>) -> Self {
         Self { name, products }
+    }
+}
+
+#[juniper::graphql_object]
+#[graphql(description = "An active ingredient found in medical products")]
+impl Substance {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn products(&self) -> &Vec<Product> {
+        &self.products
     }
 }
 


### PR DESCRIPTION
# Unlocking pagination within results for Product

Carries on with #401 – gives us pagination! If you request documents for a product, you can optionally request fewer than the full result set. You can even request to skip some!

![Damn fine filtering](https://media.giphy.com/media/l1IY8onMgFEotIzew/giphy.gif)

### Acceptance Criteria

- [ ] Introduces the ability to request a certain number of documents for a product

### Testing information

Run `make`. Go to http://localhost:8000/graphiql.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
