### PR TITLE
Fix parsing Basic Auth creds

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "lazy_static",
  "md5",
  "net2",
+ "percent-encoding",
  "pretty_assertions",
  "redis",
  "regex",
@@ -444,6 +445,7 @@ dependencies = [
  "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
+ "url",
  "uuid",
  "warp",
 ]

--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -1484,9 +1484,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.4"
 hyper = "0.13"
 lazy_static = "1.4.0"
 md5 = "0.7.0"
+percent-encoding = "2.1.0"
 redis = { version = "0.15.1", features = ["tokio-rt-core"] }
 regex = "1.3.1"
 reqwest = { version = "0.10.4", features = ["json"] }
@@ -33,6 +34,7 @@ tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2.3"
 tracing-log = "0.1.1"
 tracing-subscriber = "0.2.3"
+url = "2.1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = { git = "https://github.com/m-doughty/warp", branch = "add-xml-support" }
 

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 md5 = "0.7.0"
 percent-encoding = "2.1.0"
 redis = { version = "0.15.1", features = ["tokio-rt-core"] }
-regex = "1.3.1"
+regex = "1.3.7"
 reqwest = { version = "0.10.4", features = ["json"] }
 search_client =  { path = "../search-client" }
 serde = "1.0.106"


### PR DESCRIPTION
fixes #728 

Rather than use a homegrown Regular Expression to parse username and password for `doc-index-updater`, it is safer to rely on the `url` crate to do this for us. We do, however, then use a Regex to reject non-printable characters.