### PR TITLE
Schema fixes in web

### DIFF
--- a/medicines/web/cypress/fixtures/graphql-substances.json
+++ b/medicines/web/cypress/fixtures/graphql-substances.json
@@ -5,11 +5,15 @@
       "products": [
         {
           "name": "PARACETAMOL TABLETS FROM GRAPHQL",
-          "documentCount": 1438
+          "documents": {
+            "count": 1438
+          }
         },
         {
           "name": "PARACETAMOL CAPSULES FROM GRAPHQL",
-          "documentCount": 1438
+          "documents": {
+            "count": 1438
+          }
         }
       ]
     }

--- a/medicines/web/src/services/substance-loader.ts
+++ b/medicines/web/src/services/substance-loader.ts
@@ -40,7 +40,7 @@ interface IResponse {
 
 interface IProductResponse {
   name: string;
-  count: number;
+  documents: { count: number };
 }
 
 const query = `
@@ -49,7 +49,9 @@ query ($letter: String!) {
     name
     products {
       name
-      count: documentCount
+      documents {
+        count: totalCount
+      }
     }
   }
 }`;
@@ -71,7 +73,7 @@ export const graphqlSubstanceLoader = new DataLoader<string, ISubstance[]>(
           return {
             name,
             count: documentsCount(products),
-            products: products.map(({ name, count }) => {
+            products: products.map(({ name, documents: { count } }) => {
               return { name, count };
             }),
           };
@@ -82,6 +84,9 @@ export const graphqlSubstanceLoader = new DataLoader<string, ISubstance[]>(
 );
 
 const documentsCount = (products: IProductResponse[]) =>
-  products.reduce((total: number, { count }) => total + count, 0);
+  products.reduce(
+    (total: number, { documents: { count } }) => total + count,
+    0,
+  );
 
 export default substanceLoader;


### PR DESCRIPTION
# Schema fixes for `products: documents: count`

Since #731, the website has been mismatched from the GraphQL schema. This corrects that mismatch.

![Mis-match](https://media.giphy.com/media/x9PceDKAdBouQ/giphy.gif)

### Acceptance Criteria

- [ ] graphQL queries for substance page match schema and receive results
- [ ] graphQL queries for drug index page match schema and receive results

### Testing information

Run `yarn dev`. Use the `useGraphQl=true` feature switch.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
