### PR TITLE
Document type filtering in API

### DIFF
--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -1,6 +1,6 @@
 use crate::{pagination, pagination::PageInfo};
 use juniper::GraphQLObject;
-use search_client::{models::IndexResult, Search};
+use search_client::{models::IndexResult, AzureFieldFilter, AzureFilterSet, Search};
 
 #[derive(GraphQLObject, Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 #[graphql(description = "A document")]
@@ -42,6 +42,7 @@ pub async fn get_documents(
     search: String,
     first: Option<i32>,
     after: Option<String>,
+    document_types: Option<Vec<String>>,
 ) -> Result<Documents, anyhow::Error> {
     let result_count = first.unwrap_or(10);
     let offset = match after {
@@ -52,15 +53,17 @@ pub async fn get_documents(
         }
         None => 0,
     };
+    let filter_set = build_document_types_filter_set(document_types);
 
     let azure_result = client
-        .search_with_pagination(
+        .search_with_pagination_and_filter(
             &search,
             search_client::AzurePagination {
-                result_count: result_count,
-                offset: offset,
+                result_count,
+                offset,
             },
             true,
+            filter_set,
         )
         .await?;
 
@@ -69,11 +72,9 @@ pub async fn get_documents(
         .iter()
         .map(|search_result| Document::from(search_result.clone()))
         .enumerate()
-        .map(|(i, document)| {
-            DocumentEdge {
-                node: document,
-                cursor: base64::encode((i as i32 + offset).to_string()),
-            }
+        .map(|(i, document)| DocumentEdge {
+            node: document,
+            cursor: base64::encode((i as i32 + offset).to_string()),
         })
         .collect();
 
@@ -87,25 +88,55 @@ pub async fn get_documents(
 
     Ok(Documents {
         edges,
-        total_count: total_count,
+        total_count,
         page_info: PageInfo {
-            has_previous_page: has_previous_page,
-            has_next_page: has_next_page,
-            start_cursor: start_cursor,
-            end_cursor: end_cursor,
+            has_previous_page,
+            has_next_page,
+            start_cursor,
+            end_cursor,
         },
     })
+}
+
+fn build_document_types_filter_set(document_types: Option<Vec<String>>) -> AzureFilterSet {
+    match document_types {
+        Some(document_types) => AzureFilterSet {
+            boolean_operator: "or".to_string(),
+            field_filters: document_types
+                .into_iter()
+                .map(|document_type| AzureFieldFilter {
+                    field_name: "doc_type".to_string(),
+                    operator: "eq".to_string(),
+                    field_value: format!(
+                        "{}{}",
+                        document_type[..1].to_uppercase(),
+                        document_type[1..].to_lowercase()
+                    ),
+                })
+                .collect(),
+        },
+        None => AzureFilterSet {
+            boolean_operator: "or".to_string(),
+            field_filters: vec![],
+        },
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use async_trait::async_trait;
-    use search_client::models::IndexResults;
+    use search_client::{models::IndexResults, AzureFilterSet};
     use tokio_test::block_on;
 
     struct TestAzureSearchClient {
         pub search_results: Vec<IndexResult>,
+    }
+
+    impl TestAzureSearchClient {
+        fn new(search_results: Vec<IndexResult>) -> Self {
+            Self { search_results }
+        }
     }
 
     #[async_trait]
@@ -119,11 +150,7 @@ mod test {
             _pagination: search_client::AzurePagination,
             _include_count: bool,
         ) -> Result<IndexResults, reqwest::Error> {
-            Ok(IndexResults {
-                search_results: self.search_results.clone(),
-                context: String::from(""),
-                count: Some(1234),
-            })
+            unimplemented!();
         }
         async fn search_with_pagination_and_filter(
             &self,
@@ -132,7 +159,11 @@ mod test {
             _include_count: bool,
             _filter: search_client::AzureFilterSet,
         ) -> Result<IndexResults, reqwest::Error> {
-            unimplemented!()
+            Ok(IndexResults {
+                search_results: self.search_results.clone(),
+                context: String::from(""),
+                count: Some(1234),
+            })
         }
         async fn filter_by_collection_field(
             &self,
@@ -195,16 +226,15 @@ mod test {
         ]
     }
 
-    fn given_a_search_client(search_results: &Vec<IndexResult>) -> impl Search {
-        TestAzureSearchClient {
-            search_results: search_results.clone(),
-        }
+    fn given_a_search_client(search_results: &Vec<IndexResult>) -> TestAzureSearchClient {
+        TestAzureSearchClient::new(search_results.clone())
     }
 
     fn when_we_get_the_first_page_of_documents(search_client: impl Search) -> Documents {
         block_on(get_documents(
             &search_client,
             "Search string".to_string(),
+            None,
             None,
             None,
         ))
@@ -217,6 +247,7 @@ mod test {
             "Search string".to_string(),
             None,
             Some(base64::encode("1229").to_string()),
+            None,
         ))
         .unwrap()
     }
@@ -276,5 +307,47 @@ mod test {
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_last_page_of_documents(search_client);
         then_we_have_the_last_page(&response);
+    }
+
+    #[test]
+    fn test_build_document_types_filter_set() {
+        let document_types = Some(vec![
+            "SPC".to_string(),
+            "pil".to_string(),
+            "PaR".to_string(),
+        ]);
+        let expected_filter_set = AzureFilterSet {
+            boolean_operator: "or".to_string(),
+            field_filters: vec![
+                AzureFieldFilter {
+                    field_name: "doc_type".to_string(),
+                    operator: "eq".to_string(),
+                    field_value: "Spc".to_string(),
+                },
+                AzureFieldFilter {
+                    field_name: "doc_type".to_string(),
+                    operator: "eq".to_string(),
+                    field_value: "Pil".to_string(),
+                },
+                AzureFieldFilter {
+                    field_name: "doc_type".to_string(),
+                    operator: "eq".to_string(),
+                    field_value: "Par".to_string(),
+                },
+            ],
+        };
+        let actual_filter_set = build_document_types_filter_set(document_types);
+        assert_eq!(expected_filter_set, actual_filter_set);
+    }
+
+    #[test]
+    fn test_build_empty_document_types_filter_set() {
+        let document_types = None;
+        let expected_filter_set = AzureFilterSet {
+            boolean_operator: "or".to_string(),
+            field_filters: vec![],
+        };
+        let actual_filter_set = build_document_types_filter_set(document_types);
+        assert_eq!(expected_filter_set, actual_filter_set);
     }
 }

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -57,9 +57,10 @@ impl QueryRoot {
     ) -> FieldResult<Documents> {
         get_documents(
             &context.client,
-            search.unwrap_or(" ".to_string()),
+            search.unwrap_or_else(|| " ".to_string()),
             first,
             after,
+            document_types,
         )
         .await
         .map_err(|e| {

--- a/medicines/api/src/substance.rs
+++ b/medicines/api/src/substance.rs
@@ -67,7 +67,7 @@ fn format_search_results(results: IndexResults, letter: char) -> Vec<Substance> 
         .iter()
         .map(|(&substance, prods)| {
             let products = prods
-                .into_iter()
+                .iter()
                 .map(|(&name, docs)| Product::new(name.into(), docs.clone()))
                 .collect();
 

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -24,11 +24,13 @@ pub struct AzurePagination {
     pub offset: i32,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AzureFilterSet {
     pub boolean_operator: String,
     pub field_filters: Vec<AzureFieldFilter>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AzureFieldFilter {
     pub field_name: String,
     pub operator: String,
@@ -194,7 +196,7 @@ trait AzureSearchRequestBuilder {
 
 impl AzureSearchRequestBuilder for reqwest::RequestBuilder {
     fn filter(self, filter_set: AzureFilterSet) -> Self {
-        if filter_set.field_filters.len() == 0 {
+        if filter_set.field_filters.is_empty() {
             return self;
         }
         let filter_strings = filter_set.field_filters.into_iter().map(|filter| {


### PR DESCRIPTION
Adds the ability to filter by document type in the API.

![](https://media.giphy.com/media/25J5rdcuQuOcEw4i5z/giphy.gif)

<img width="949" alt="Screenshot 2020-04-30 at 10 31 34" src="https://user-images.githubusercontent.com/76330/80695434-d3872680-8acd-11ea-8926-dd045cda8fff.png">
