### PR TITLE
Timlee/fix learning site deploy

### DIFF
--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -28,45 +28,38 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Run tests with coverage
         working-directory: learning/web
-        run: yarn run test:ci
+        run: yarn test:ci
 
       - name: Build
         working-directory: learning/web
-        run: yarn run build
+        run: yarn build
         env:
-          PATH_PREFIX: "/"
+          PATH_PREFIX: ""
 
-      # - name: Run cypress end-to-end tests
-      #   working-directory: learning/web
-      #   run: mkdir -p cypress/screenshots && yarn test-e2e
+      - name: Run cypress end-to-end tests
+        working-directory: learning/web
+        run: mkdir -p cypress/screenshots && yarn test-e2e
 
-      # - name: Upload cypress screenshots
-      #   uses: actions/upload-artifact@v1
-      #   if: failure()
-      #   with:
-      #     name: learning-cypress-screenshots
-      #     path: learning/web/cypress/screenshots
-
-      # - name: Upload cypress videos
-      #   uses: actions/upload-artifact@v1
-      #   if: always()
-      #   with:
-      #     name: learning-cypress-videos
-      #     path: learning/web/cypress/videos
-
-      # - name: Accessibility check
-      #   working-directory: learning/web
-      #   run: yarn run a11y
-      #   env:
-      #     ROOT_URL_DOMAIN: localhost
-
-      - name: Deploy learning web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+      - name: Upload cypress screenshots
+        uses: actions/upload-artifact@v1
+        if: failure()
         with:
-          enabled-static-website: true
-          folder: learning/web/public
-          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}
+          name: learning-cypress-screenshots
+          path: learning/web/cypress/screenshots
+
+      - name: Upload cypress videos
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: learning-cypress-videos
+          path: learning/web/cypress/videos
+
+      - name: Accessibility check
+        working-directory: learning/web
+        run: yarn a11y
+        env:
+          ROOT_URL_DOMAIN: localhost

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Run tests with coverage
         working-directory: learning/web
-        run: yarn test:ci
+        run: yarn run test:ci
 
       - name: Build
         working-directory: learning/web
-        run: yarn build
+        run: yarn run build
         env:
           PATH_PREFIX: ""
 
@@ -60,6 +60,13 @@ jobs:
 
       - name: Accessibility check
         working-directory: learning/web
-        run: yarn a11y
+        run: yarn run a11y
         env:
           ROOT_URL_DOMAIN: localhost
+
+      - name: Deploy learning web to static site in azure storage
+        uses: lauchacarro/Azure-Storage-Action@master
+        with:
+          enabled-static-website: true
+          folder: learning/web/public
+          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Run tests with coverage
         working-directory: learning/web
@@ -38,31 +38,31 @@ jobs:
         working-directory: learning/web
         run: yarn run build
         env:
-          PATH_PREFIX: ""
+          PATH_PREFIX: "/"
 
-      - name: Run cypress end-to-end tests
-        working-directory: learning/web
-        run: mkdir -p cypress/screenshots && yarn test-e2e
+      # - name: Run cypress end-to-end tests
+      #   working-directory: learning/web
+      #   run: mkdir -p cypress/screenshots && yarn test-e2e
 
-      - name: Upload cypress screenshots
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: learning-cypress-screenshots
-          path: learning/web/cypress/screenshots
+      # - name: Upload cypress screenshots
+      #   uses: actions/upload-artifact@v1
+      #   if: failure()
+      #   with:
+      #     name: learning-cypress-screenshots
+      #     path: learning/web/cypress/screenshots
 
-      - name: Upload cypress videos
-        uses: actions/upload-artifact@v1
-        if: always()
-        with:
-          name: learning-cypress-videos
-          path: learning/web/cypress/videos
+      # - name: Upload cypress videos
+      #   uses: actions/upload-artifact@v1
+      #   if: always()
+      #   with:
+      #     name: learning-cypress-videos
+      #     path: learning/web/cypress/videos
 
-      - name: Accessibility check
-        working-directory: learning/web
-        run: yarn run a11y
-        env:
-          ROOT_URL_DOMAIN: localhost
+      # - name: Accessibility check
+      #   working-directory: learning/web
+      #   run: yarn run a11y
+      #   env:
+      #     ROOT_URL_DOMAIN: localhost
 
       - name: Deploy learning web to static site in azure storage
         uses: lauchacarro/Azure-Storage-Action@master

--- a/.github/workflows/learning-web-master.yaml
+++ b/.github/workflows/learning-web-master.yaml
@@ -37,7 +37,7 @@ jobs:
         working-directory: learning/web
         run: yarn build
         env:
-          PATH_PREFIX: ""
+          PATH_PREFIX: "/"
 
       - name: Run cypress end-to-end tests
         working-directory: learning/web

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -34,7 +34,7 @@ jobs:
         working-directory: learning/web
         run: yarn build
         env:
-          PATH_PREFIX: ""
+          PATH_PREFIX: "/"
 
       - name: Run cypress end-to-end tests
         working-directory: learning/web


### PR DESCRIPTION
# Fix learning site master and release workflows
Add slash to path prefix for learning site build in master and release workflows.

Without this, the site does not build a proper production build.

![](https://media.giphy.com/media/vArNfZSyp8v6/giphy.gif)

### Acceptance Criteria

- [ ] The site loads

### Testing information

Does the site load?

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
