### PR TITLE
Support filtering by doc type using GraphQL

### DIFF
--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -131,7 +131,7 @@ pub async fn get_documents(
                 offset,
             },
             true,
-            build_filter(document_types, product_name.as_deref()).as_deref(),
+            build_filter(document_types, product_name).as_deref(),
         )
         .await?;
 

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -108,9 +108,9 @@ pub async fn get_documents(
     search: &str,
     first: Option<i32>,
     skip: Option<i32>,
-    after: Option<String>,
+    after: Option<&str>,
     document_types: Option<Vec<DocumentType>>,
-    product_name: Option<String>,
+    product_name: Option<&str>,
 ) -> Result<Documents, anyhow::Error> {
     let result_count = first.unwrap_or(10);
     let offset = match (after, skip) {
@@ -326,7 +326,7 @@ mod test {
             "Search string",
             None,
             None,
-            Some(base64::encode("1229".to_string())),
+            Some(&base64::encode("1229".to_string())),
             None,
             None,
         ))

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -35,9 +35,9 @@ impl Product {
             "",
             first,
             skip,
-            after,
+            after.as_deref(),
             document_types,
-            Some(self.name.clone()),
+            Some(&self.name),
         )
         .await
         .map_err(|e| {

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -61,7 +61,7 @@ impl QueryRoot {
             search.as_deref().unwrap_or(" "),
             first,
             skip,
-            after,
+            after.as_deref(),
             document_types,
             None,
         )

--- a/medicines/web/src/components/search-filter/index.tsx
+++ b/medicines/web/src/components/search-filter/index.tsx
@@ -43,9 +43,12 @@ const DocTypeCheckbox: React.FC<IDocTypeCheckboxProps> = props => {
     toggleDocType,
     currentlyEnabledDocTypes,
   } = props;
+
   const toggleDocTypeForThisCheckbox = () =>
     toggleDocType(docTypeForThisCheckbox);
+
   const id = `filter-${docTypeForThisCheckbox.toLowerCase()}`;
+
   return (
     <div className="checkbox-row">
       <div className="checkbox">
@@ -66,15 +69,10 @@ const DocTypeCheckbox: React.FC<IDocTypeCheckboxProps> = props => {
 };
 
 const SearchFilter: React.FC<ISearchFilterProps> = props => {
-  const generateCheckboxFor = (docType: DocType, name: string) => {
-    return (
-      <DocTypeCheckbox
-        {...props}
-        docTypeForThisCheckbox={docType}
-        name={name}
-      />
-    );
-  };
+  const generateCheckboxFor = (docType: DocType, name: string) => (
+    <DocTypeCheckbox {...props} docTypeForThisCheckbox={docType} name={name} />
+  );
+
   return (
     <StyledSearchFilter>
       <h2>Filter documents by</h2>

--- a/medicines/web/src/pages/product/index.tsx
+++ b/medicines/web/src/pages/product/index.tsx
@@ -7,12 +7,8 @@ import SearchResults from '../../components/search-results';
 import SearchWrapper from '../../components/search-wrapper';
 import { DrugStructuredData } from '../../components/structured-data';
 import { useLocalStorage } from '../../hooks';
-import { IDocument, IProduct } from '../../model/substance';
-import {
-  docSearch,
-  DocType,
-  ISearchResults,
-} from '../../services/azure-search';
+import { IDocument } from '../../model/substance';
+import { docSearch, DocType } from '../../services/azure-search';
 import { documents } from '../../services/documents-loader';
 import Events from '../../services/events';
 import {
@@ -63,8 +59,9 @@ const azureDocumentsLoader = async ({
 const graphQlProductLoader = async ({
   name,
   page,
+  docTypes,
 }: IProductPageInfo): Promise<IProductResult> => {
-  return documents.load({ name, page, pageSize });
+  return documents.load({ name, page, pageSize, docTypes });
 };
 
 const App: NextPage = () => {
@@ -154,7 +151,7 @@ const App: NextPage = () => {
     });
   };
 
-  const handleToggleDocType = async (docTypeToToggle: DocType) => {
+  const handleToggleDocType = (docTypeToToggle: DocType) => {
     const enabledDocTypes = Array.from(docTypes);
     if (enabledDocTypes.includes(docTypeToToggle)) {
       const docTypeIndex = enabledDocTypes.indexOf(docTypeToToggle);

--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader';
 import { IDocument } from '../model/substance';
+import { DocType } from './azure-search';
 import { graphqlRequest } from './graphql';
 
 interface IDocuments {
@@ -26,10 +27,10 @@ interface IDocumentResponse {
 }
 
 const query = `
-query ($productName: String!, $first: Int, $skip: Int) {
+query ($productName: String!, $first: Int, $skip: Int, $docTypes: [DocumentType!]) {
   product(name: $productName) {
     name
-    documents(first: $first, skip: $skip) {
+    documents(first: $first, skip: $skip, documentTypes: $docTypes) {
       count: totalCount
       edges {
         node {
@@ -87,12 +88,15 @@ const getDocumentsForProduct = async ({
   name,
   page,
   pageSize,
+  docTypes,
 }: IProductPageInfo) => {
   const variables = {
     productName: name,
     first: pageSize,
     skip: calculatePageStartRecord(page, pageSize),
+    docTypes: docTypes.map(s => s.toUpperCase()),
   };
+
   const { data } = await graphqlRequest<IProductResponse, typeof variables>({
     query,
     variables,
@@ -105,6 +109,7 @@ interface IProductPageInfo {
   name: string;
   page: number;
   pageSize: number;
+  docTypes: DocType[];
 }
 
 const calculatePageStartRecord = (page: number, pageSize: number): number =>


### PR DESCRIPTION
Adds support for filtering by document type when the `useGraphQl=true` feature flag is set

Closes #401.

![](https://media.giphy.com/media/3orifaQEOagjYJ1EXe/giphy.gif)

- [x] with the `useGraphQl=true` feature flag is set, filtering by doc type