### PR TITLE
Reduce Azure calls in the API

### DIFF
--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -288,8 +288,8 @@ mod test {
         ]
     }
 
-    fn given_a_search_client(search_results: &Vec<IndexResult>) -> TestAzureSearchClient {
-        TestAzureSearchClient::new(search_results.clone())
+    fn given_a_search_client(search_results: &[IndexResult]) -> TestAzureSearchClient {
+        TestAzureSearchClient::new(search_results.to_owned())
     }
 
     fn when_we_get_the_first_page_of_documents(search_client: impl Search) -> Documents {
@@ -325,7 +325,7 @@ mod test {
         ];
         let edges = &documents_response.edges;
         let actual_names = edges
-            .into_iter()
+            .iter()
             .map(|edge| edge.node.product_name.as_ref().unwrap());
         assert!(actual_names.eq(expected_names));
 
@@ -344,7 +344,7 @@ mod test {
         let expected_names = vec!["fourth last", "third last", "second last", "last"];
         let edges = &documents_response.edges;
         let actual_names = edges
-            .into_iter()
+            .iter()
             .map(|edge| edge.node.product_name.as_ref().unwrap());
 
         assert!(actual_names.eq(expected_names));

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -107,21 +107,11 @@ pub async fn get_documents(
     client: &impl Search,
     search: &str,
     first: Option<i32>,
-    skip: Option<i32>,
-    after: Option<String>,
+    offset: i32,
     document_types: Option<Vec<DocumentType>>,
     product_name: Option<String>,
 ) -> Result<Documents, anyhow::Error> {
     let result_count = first.unwrap_or(10);
-    let offset = match (after, skip) {
-        (Some(encoded), _) => {
-            let bytes = base64::decode(encoded)?;
-            let string = std::str::from_utf8(&bytes)?;
-            string.parse::<i32>()? + 1
-        }
-        (None, Some(offset)) => offset,
-        _ => 0,
-    };
 
     let azure_result = client
         .search_with_pagination_and_filter(
@@ -295,8 +285,7 @@ mod test {
             &search_client,
             "Search string",
             None,
-            None,
-            None,
+            0,
             None,
             None,
         ))
@@ -308,21 +297,7 @@ mod test {
             &search_client,
             "Search string",
             None,
-            Some(1230),
-            None,
-            None,
-            None,
-        ))
-        .unwrap()
-    }
-
-    fn when_we_get_the_last_page_of_documents_using_after(search_client: impl Search) -> Documents {
-        block_on(get_documents(
-            &search_client,
-            "Search string",
-            None,
-            None,
-            Some(base64::encode("1229".to_string())),
+            1230,
             None,
             None,
         ))
@@ -383,14 +358,6 @@ mod test {
         let search_results = given_last_page_of_search_results();
         let search_client = given_a_search_client(&search_results);
         let response = when_we_get_the_last_page_of_documents(search_client);
-        then_we_have_the_last_page(&response);
-    }
-
-    #[test]
-    fn test_get_documents_last_page_using_after() {
-        let search_results = given_last_page_of_search_results();
-        let search_client = given_a_search_client(&search_results);
-        let response = when_we_get_the_last_page_of_documents_using_after(search_client);
         then_we_have_the_last_page(&response);
     }
 

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -103,6 +103,18 @@ pub fn get_documents_graph_from_documents_vector(
     get_documents_from_edges(edges, offset, total_count)
 }
 
+pub struct AzureDocumentResult {
+    docs: Vec<Document>,
+    offset: i32,
+    total_count: i32,
+}
+
+impl Into<Documents> for AzureDocumentResult {
+    fn into(self) -> Documents {
+        get_documents_graph_from_documents_vector(self.docs, self.offset, self.total_count)
+    }
+}
+
 pub async fn get_documents(
     client: &impl Search,
     search: &str,
@@ -110,7 +122,7 @@ pub async fn get_documents(
     offset: i32,
     document_types: Option<Vec<DocumentType>>,
     product_name: Option<String>,
-) -> Result<Documents, anyhow::Error> {
+) -> Result<AzureDocumentResult, anyhow::Error> {
     let result_count = first.unwrap_or(10);
 
     let azure_result = client
@@ -133,11 +145,11 @@ pub async fn get_documents(
 
     let total_count = azure_result.count.unwrap_or(0);
 
-    Ok(get_documents_graph_from_documents_vector(
+    Ok(AzureDocumentResult {
         docs,
-        offset,
         total_count,
-    ))
+        offset,
+    })
 }
 
 fn build_filter(
@@ -290,6 +302,7 @@ mod test {
             None,
         ))
         .unwrap()
+        .into()
     }
 
     fn when_we_get_the_last_page_of_documents(search_client: impl Search) -> Documents {
@@ -302,6 +315,7 @@ mod test {
             None,
         ))
         .unwrap()
+        .into()
     }
 
     fn then_we_have_the_first_page(documents_response: &Documents) {

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -55,21 +55,11 @@ fn get_document_edges(docs: Vec<Document>, offset: i32) -> Vec<DocumentEdge> {
 
 fn get_documents_from_edges(edges: Vec<DocumentEdge>, offset: i32, total_count: i32) -> Documents {
     let result_count = edges.len() as i32;
-    let has_previous_page = offset != 0;
-    let has_next_page = offset + result_count < total_count;
-    let start_cursor = base64::encode(offset.to_string());
-    let end_cursor =
-        base64::encode(std::cmp::min(total_count, offset + result_count - 1).to_string());
 
     Documents {
         edges,
         total_count,
-        page_info: PageInfo {
-            has_previous_page,
-            has_next_page,
-            start_cursor,
-            end_cursor,
-        },
+        page_info: PageInfo::build(offset, result_count, total_count),
     }
 }
 

--- a/medicines/api/src/document.rs
+++ b/medicines/api/src/document.rs
@@ -16,6 +16,12 @@ pub struct Document {
     url: Option<String>,
 }
 
+impl Document {
+    pub fn is_doc_type(&self, doc_type: &DocumentType) -> bool {
+        self.doc_type == Some(doc_type.to_search_str().to_owned())
+    }
+}
+
 impl From<IndexResult> for Document {
     fn from(r: IndexResult) -> Self {
         Self {

--- a/medicines/api/src/pagination.rs
+++ b/medicines/api/src/pagination.rs
@@ -9,6 +9,23 @@ pub struct PageInfo {
     pub end_cursor: String,
 }
 
+impl PageInfo {
+    pub fn build(offset: i32, result_count: i32, total_count: i32) -> Self {
+        let has_previous_page = offset != 0;
+        let has_next_page = offset + result_count < total_count;
+        let start_cursor = base64::encode(offset.to_string());
+        let end_cursor =
+            base64::encode(std::cmp::min(total_count, offset + result_count - 1).to_string());
+
+        PageInfo {
+            has_previous_page,
+            has_next_page,
+            start_cursor,
+            end_cursor,
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! pagination {
     ($name:ident, $edgename:ident, $type:ty) => {
@@ -53,4 +70,19 @@ macro_rules! pagination {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_page_info() {
+        let page_info = PageInfo::build(0, 10, 15);
+
+        assert_eq!(true, page_info.has_next_page);
+        assert_eq!(false, page_info.has_previous_page);
+        assert_eq!("MA==", page_info.start_cursor);
+        assert_eq!("OQ==", page_info.end_cursor);
+    }
 }

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -37,9 +37,14 @@ impl Product {
     async fn documents(
         &self,
         first: Option<i32>,
-        offset: i32,
+        offset: Option<i32>,
         document_types: Option<Vec<DocumentType>>,
     ) -> FieldResult<document::Documents> {
+        let offset = match offset {
+            Some(a) => a,
+            None => 0,
+        };
+
         if let Some(docs) = self.documents.clone() {
             let docs = match document_types {
                 Some(document_types) => docs

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -1,5 +1,5 @@
 use crate::{
-    document::{self, get_documents, DocumentType},
+    document::{self, get_documents, Document, DocumentType},
     substance::Substance,
 };
 use juniper::FieldResult;
@@ -29,7 +29,7 @@ impl Product {
         offset: i32,
         document_types: Option<Vec<DocumentType>>,
     ) -> FieldResult<document::Documents> {
-        get_documents(
+        let docs = get_documents(
             &search_client::AzureSearchClient::new(),
             "",
             first,
@@ -44,7 +44,9 @@ impl Product {
                 e
             );
             juniper::FieldError::new("Error fetching documents", juniper::Value::null())
-        })
+        })?
+        .into();
+        Ok(docs)
     }
 }
 

--- a/medicines/api/src/product.rs
+++ b/medicines/api/src/product.rs
@@ -26,16 +26,14 @@ impl Product {
     async fn documents(
         &self,
         first: Option<i32>,
-        skip: Option<i32>,
-        after: Option<String>,
+        offset: i32,
         document_types: Option<Vec<DocumentType>>,
     ) -> FieldResult<document::Documents> {
         get_documents(
             &search_client::AzureSearchClient::new(),
             "",
             first,
-            skip,
-            after,
+            offset,
             document_types,
             Some(self.name.clone()),
         )

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -58,7 +58,7 @@ impl QueryRoot {
     ) -> FieldResult<Documents> {
         let offset = get_offset_or_default(skip, after, 0);
 
-        get_documents(
+        let docs = get_documents(
             &context.client,
             search.as_deref().unwrap_or(" "),
             first,
@@ -70,7 +70,10 @@ impl QueryRoot {
         .map_err(|e| {
             tracing::error!("Error fetching results from Azure search service: {:?}", e);
             juniper::FieldError::new("Error fetching search results", juniper::Value::null())
-        })
+        })?
+        .into();
+
+        Ok(docs)
     }
 }
 

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -116,10 +116,25 @@ mod test {
 
     use test_case::test_case;
 
-    #[test_case("LTE=".to_string(), 0)]
-    #[test_case("MA==".to_string(), 1)]
-    #[test_case(base64::encode("1229".to_string()), 1230)]
+    #[test_case("LTE=".to_string(), 0; "for the first page of results")]
+    #[test_case("MA==".to_string(), 1; "for grabbing the second result onwards")]
+    #[test_case("OQ==".to_string(), 10; "for the second page of results when pagesize is 10")]
+    #[test_case(base64::encode("1229".to_string()), 1230; "for as late as page 124")]
     fn test_convert_after_to_offset(encoded: String, expected: i32) {
         assert_eq!(convert_after_to_offset(encoded).unwrap(), expected);
+    }
+
+    #[test_case(Some(10), Some("LTE=".to_string()), 15, 0; "matches after when only after is provided")]
+    #[test_case(Some(10), None, 15, 10; "matches skip when only skip is provided")]
+    #[test_case(None, Some("LTE=".to_string()), 15, 0; "matches after when both are provided")]
+    #[test_case(None, None, 10, 10; "matches default when neither are provided")]
+    fn test_get_offset_or_default(
+        skip: Option<i32>,
+        after: Option<String>,
+        default: i32,
+        expected: i32,
+    ) {
+        let offset = get_offset_or_default(skip, after, default);
+        assert_eq!(offset, expected);
     }
 }

--- a/medicines/api/src/substance.rs
+++ b/medicines/api/src/substance.rs
@@ -83,7 +83,7 @@ fn format_search_results(results: IndexResults, letter: char) -> Vec<Substance> 
         .map(|(&substance, prods)| {
             let products = prods
                 .iter()
-                .map(|(&name, _docs)| Product::new(name.into()))
+                .map(|(&name, docs)| Product::new(name.into(), Some(docs.to_owned())))
                 .collect();
 
             Substance::new(substance.into(), products)
@@ -161,10 +161,10 @@ mod tests {
 
         let results = IndexResults {
             search_results: vec![
-                zonismade_25mg.clone(),
-                zonismade_50mg.clone(),
-                zonismade_50mg_repeat.clone(),
-                zolmitriptan.clone(),
+                zonismade_25mg,
+                zonismade_50mg,
+                zonismade_50mg_repeat,
+                zolmitriptan,
             ],
             context: "https://mhraproductsnonprod.search.windows.net/indexes(\'products-index\')/$metadata#docs(*)".into(),
             count: None
@@ -177,13 +177,14 @@ mod tests {
                 "ZOLMITRIPTAN".into(),
                 vec![Product::new(
                     "ZOMIG RAPIMELT 2.5 MG ORODISPERSIBLE TABLETS".into(),
+                    None,
                 )],
             ),
             Substance::new(
                 "ZONISAMIDE".into(),
                 vec![
-                    Product::new("ZONISAMIDE ARISTO 25 MG HARD CAPSULES".into()),
-                    Product::new("ZONISAMIDE ARISTO 50 MG HARD CAPSULES".into()),
+                    Product::new("ZONISAMIDE ARISTO 25 MG HARD CAPSULES".into(), None),
+                    Product::new("ZONISAMIDE ARISTO 50 MG HARD CAPSULES".into(), None),
                 ],
             ),
         ];
@@ -210,8 +211,7 @@ mod tests {
 
         let results = IndexResults {
             search_results: vec![
-                index_result.clone(),
-
+                index_result,
             ],
             context: "https://mhraproductsnonprod.search.windows.net/indexes(\'products-index\')/$metadata#docs(*)".into(),
             count: None
@@ -223,6 +223,7 @@ mod tests {
             "ZIDOVUDINE".into(),
             vec![Product::new(
                 "LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS".into(),
+                None,
             )],
         )];
 

--- a/medicines/api/src/substance.rs
+++ b/medicines/api/src/substance.rs
@@ -161,14 +161,18 @@ mod tests {
 
         let results = IndexResults {
             search_results: vec![
-                zonismade_25mg,
-                zonismade_50mg,
-                zonismade_50mg_repeat,
-                zolmitriptan,
+                zonismade_25mg.clone(),
+                zonismade_50mg.clone(),
+                zonismade_50mg_repeat.clone(),
+                zolmitriptan.clone(),
             ],
             context: "https://mhraproductsnonprod.search.windows.net/indexes(\'products-index\')/$metadata#docs(*)".into(),
             count: None
         };
+
+        let zon50: Vec<Document> = vec![zonismade_50mg.into(), zonismade_50mg_repeat.into()];
+        let zon25: Vec<Document> = vec![zonismade_25mg.into()];
+        let zol: Vec<Document> = vec![zolmitriptan.into()];
 
         let formatted = format_search_results(results, letter);
 
@@ -177,14 +181,14 @@ mod tests {
                 "ZOLMITRIPTAN".into(),
                 vec![Product::new(
                     "ZOMIG RAPIMELT 2.5 MG ORODISPERSIBLE TABLETS".into(),
-                    None,
+                    Some(zol),
                 )],
             ),
             Substance::new(
                 "ZONISAMIDE".into(),
                 vec![
-                    Product::new("ZONISAMIDE ARISTO 25 MG HARD CAPSULES".into(), None),
-                    Product::new("ZONISAMIDE ARISTO 50 MG HARD CAPSULES".into(), None),
+                    Product::new("ZONISAMIDE ARISTO 25 MG HARD CAPSULES".into(), Some(zon25)),
+                    Product::new("ZONISAMIDE ARISTO 50 MG HARD CAPSULES".into(), Some(zon50)),
                 ],
             ),
         ];
@@ -208,6 +212,7 @@ mod tests {
                 "Z, ZIDOVUDINE, LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS",
             ],
         );
+        let document: Document = index_result.clone().into();
 
         let results = IndexResults {
             search_results: vec![
@@ -223,7 +228,7 @@ mod tests {
             "ZIDOVUDINE".into(),
             vec![Product::new(
                 "LAMIVUDINE/ZIDOVUDINE 150 MG/300 MG FILM-COATED TABLETS".into(),
-                None,
+                Some(vec![document]),
             )],
         )];
 

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -147,6 +147,7 @@ impl Search for AzureSearchClient {
             &self.config,
         )?;
 
+        tracing::debug!("Requesting from URL: {}", &request.url());
         self.client
             .execute(request)
             .await?


### PR DESCRIPTION
# Fewer calls for a faster API

Let's use as few calls as possible to Azure. The goal is 0 per API request, but I'd settle for 1 for now.

Fixes extra calls since #743.

![Making calls](https://media.giphy.com/media/3ofT5LuXujqb4gz77a/giphy.gif)

### Acceptance Criteria

- [ ] fewer calls are made than without this PR
- [ ] calls to Azure get a tracing::debug message (otherwise how can we see how few we make)

### Testing information

Run the API, hit it, watch how many calls it makes to Azure.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
