### PR TITLE
Timlee/learning deploy still broken

### DIFF
--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install --frozen-lockfile
+        run: yarn run install --frozen-lockfile
 
       # - name: Run tests with coverage
       #   working-directory: learning/web
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build
         working-directory: learning/web
-        run: yarn build
+        run: yarn run build
         env:
           PATH_PREFIX: "/"
 

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -65,8 +65,8 @@ jobs:
       #     ROOT_URL_DOMAIN: localhost
 
       - name: Deploy learning web to static site in azure storage
-      uses: lauchacarro/Azure-Storage-Action@master
-      with:
-        enabled-static-website: true
-        folder: learning/web/public
-        connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}
+        uses: lauchacarro/Azure-Storage-Action@master
+        with:
+          enabled-static-website: true
+          folder: learning/web/public
+          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn run install --frozen-lockfile
+        run: yarn install
 
       # - name: Run tests with coverage
       #   working-directory: learning/web
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build
         working-directory: learning/web
-        run: yarn run build
+        run: yarn build
         env:
           PATH_PREFIX: "/"
 

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -30,36 +30,43 @@ jobs:
         working-directory: learning/web
         run: yarn install --frozen-lockfile
 
-      - name: Run tests with coverage
-        working-directory: learning/web
-        run: yarn test:ci
+      # - name: Run tests with coverage
+      #   working-directory: learning/web
+      #   run: yarn test:ci
 
       - name: Build
         working-directory: learning/web
         run: yarn build
         env:
-          PATH_PREFIX: ""
+          PATH_PREFIX: "/"
 
-      - name: Run cypress end-to-end tests
-        working-directory: learning/web
-        run: mkdir -p cypress/screenshots && yarn test-e2e
+      # - name: Run cypress end-to-end tests
+      #   working-directory: learning/web
+      #   run: mkdir -p cypress/screenshots && yarn test-e2e
 
-      - name: Upload cypress screenshots
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: learning-cypress-screenshots
-          path: learning/web/cypress/screenshots
+      # - name: Upload cypress screenshots
+      #   uses: actions/upload-artifact@v1
+      #   if: failure()
+      #   with:
+      #     name: learning-cypress-screenshots
+      #     path: learning/web/cypress/screenshots
 
-      - name: Upload cypress videos
-        uses: actions/upload-artifact@v1
-        if: always()
-        with:
-          name: learning-cypress-videos
-          path: learning/web/cypress/videos
+      # - name: Upload cypress videos
+      #   uses: actions/upload-artifact@v1
+      #   if: always()
+      #   with:
+      #     name: learning-cypress-videos
+      #     path: learning/web/cypress/videos
 
-      - name: Accessibility check
-        working-directory: learning/web
-        run: yarn a11y
-        env:
-          ROOT_URL_DOMAIN: localhost
+      # - name: Accessibility check
+      #   working-directory: learning/web
+      #   run: yarn a11y
+      #   env:
+      #     ROOT_URL_DOMAIN: localhost
+
+      - name: Deploy learning web to static site in azure storage
+      uses: lauchacarro/Azure-Storage-Action@master
+      with:
+        enabled-static-website: true
+        folder: learning/web/public
+        connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -28,17 +28,11 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Run tests with coverage
         working-directory: learning/web
         run: yarn test:ci
-
-      - name: Build
-        working-directory: learning/web
-        run: yarn build
-        env:
-          PATH_PREFIX: "/"
 
       - name: Run cypress end-to-end tests
         working-directory: learning/web
@@ -63,3 +57,16 @@ jobs:
         run: yarn a11y
         env:
           ROOT_URL_DOMAIN: localhost
+
+      - name: Build
+        working-directory: learning/web
+        run: yarn build
+        env:
+          PATH_PREFIX: "/"
+
+      - name: Deploy learning web to static site in azure storage
+        uses: lauchacarro/Azure-Storage-Action@master
+        with:
+          enabled-static-website: true
+          folder: learning/web/public
+          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -63,10 +63,3 @@ jobs:
         run: yarn build
         env:
           PATH_PREFIX: "/"
-
-      - name: Deploy learning web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
-        with:
-          enabled-static-website: true
-          folder: learning/web/public
-          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -30,9 +30,9 @@ jobs:
         working-directory: learning/web
         run: yarn install
 
-      # - name: Run tests with coverage
-      #   working-directory: learning/web
-      #   run: yarn test:ci
+      - name: Run tests with coverage
+        working-directory: learning/web
+        run: yarn test:ci
 
       - name: Build
         working-directory: learning/web
@@ -40,33 +40,26 @@ jobs:
         env:
           PATH_PREFIX: "/"
 
-      # - name: Run cypress end-to-end tests
-      #   working-directory: learning/web
-      #   run: mkdir -p cypress/screenshots && yarn test-e2e
+      - name: Run cypress end-to-end tests
+        working-directory: learning/web
+        run: mkdir -p cypress/screenshots && yarn test-e2e
 
-      # - name: Upload cypress screenshots
-      #   uses: actions/upload-artifact@v1
-      #   if: failure()
-      #   with:
-      #     name: learning-cypress-screenshots
-      #     path: learning/web/cypress/screenshots
-
-      # - name: Upload cypress videos
-      #   uses: actions/upload-artifact@v1
-      #   if: always()
-      #   with:
-      #     name: learning-cypress-videos
-      #     path: learning/web/cypress/videos
-
-      # - name: Accessibility check
-      #   working-directory: learning/web
-      #   run: yarn a11y
-      #   env:
-      #     ROOT_URL_DOMAIN: localhost
-
-      - name: Deploy learning web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+      - name: Upload cypress screenshots
+        uses: actions/upload-artifact@v1
+        if: failure()
         with:
-          enabled-static-website: true
-          folder: learning/web/public
-          connection-string: ${{ secrets.AZURE_STORAGE_LEARNING_WEB_CONNECTION_STRING }}
+          name: learning-cypress-screenshots
+          path: learning/web/cypress/screenshots
+
+      - name: Upload cypress videos
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: learning-cypress-videos
+          path: learning/web/cypress/videos
+
+      - name: Accessibility check
+        working-directory: learning/web
+        run: yarn a11y
+        env:
+          ROOT_URL_DOMAIN: localhost

--- a/.github/workflows/learning-web-master.yaml
+++ b/.github/workflows/learning-web-master.yaml
@@ -27,17 +27,11 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Run tests with coverage
         working-directory: learning/web
         run: yarn test:ci
-
-      - name: Build
-        working-directory: learning/web
-        run: yarn build
-        env:
-          PATH_PREFIX: "/"
 
       - name: Run cypress end-to-end tests
         working-directory: learning/web
@@ -62,6 +56,12 @@ jobs:
         run: yarn a11y
         env:
           ROOT_URL_DOMAIN: localhost
+
+      - name: Build
+        working-directory: learning/web
+        run: yarn build
+        env:
+          PATH_PREFIX: "/"
 
       - name: Deploy learning web to static site in azure storage
         uses: lauchacarro/Azure-Storage-Action@master

--- a/.github/workflows/learning-web-master.yaml
+++ b/.github/workflows/learning-web-master.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Run tests with coverage
         working-directory: learning/web

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -24,17 +24,11 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Run tests with coverage
         working-directory: learning/web
         run: yarn test:ci
-
-      - name: Build
-        working-directory: learning/web
-        run: yarn build
-        env:
-          PATH_PREFIX: "/"
 
       - name: Run cypress end-to-end tests
         working-directory: learning/web
@@ -59,6 +53,12 @@ jobs:
         run: yarn a11y
         env:
           ROOT_URL_DOMAIN: localhost
+
+      - name: Build
+        working-directory: learning/web
+        run: yarn build
+        env:
+          PATH_PREFIX: "/"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install modules
         working-directory: learning/web
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Run tests with coverage
         working-directory: learning/web


### PR DESCRIPTION
# Remove frozen lockfile argument

Site wasn't building properly - had previously thought this was due to unspecified path prefix in build step, but was actually the frozen lockfile flag that was causing issues, so removing across all learning site workflows.

### Acceptance Criteria

- [ ] _The first thing this PR must achieve_
- [ ] _The second thing this PR must achieve_
- [ ] _etc_

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
