### PR TITLE
DocumentType in search results graphql variable

### DIFF
--- a/medicines/web/src/services/search-results-loader.ts
+++ b/medicines/web/src/services/search-results-loader.ts
@@ -24,7 +24,7 @@ interface IDocumentResponse {
 }
 
 const query = `
-query($searchTerm: String, $first: Int, $after: String, $documentTypes: [String!]) {
+query($searchTerm: String, $first: Int, $after: String, $documentTypes: [DocumentType!]) {
   documents(search: $searchTerm, first: $first, after: $after, documentTypes: $documentTypes) {
     count: totalCount
     edges {


### PR DESCRIPTION
Fixes bug found in #621.

> Results fail to load when using GraphQl
> 
> @majikandy   9:24 AM
> https://mhraproductsnonprod.z33.web.core.windows.net/search/?search=caffeine&page=1&useGraphQl=true
> 400 bad request for the graphql call
> 
> @rjkerrison  9:25 AM
> `{"errors":[{"message":"Variable \"documentTypes\" of type \"[String!]\" used in position expecting type \"[DocumentType!]\"","locations":[{"line":2,"column":57},{"line":3,"column":79}]}]}`
> 
> Suggest when we fix we add some kind of protection for the contract between web and api.

### Acceptance Criteria

- [ ] `DocumentType` is given as type of docType parameter, to match the schema

### Testing information

Run `yarn dev`.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
