### PR TITLE
GraphQl drift fixes

### DIFF
--- a/medicines/web/src/services/documents-loader.ts
+++ b/medicines/web/src/services/documents-loader.ts
@@ -30,7 +30,7 @@ const query = `
 query ($productName: String!, $first: Int, $skip: Int, $docTypes: [DocumentType!]) {
   product(name: $productName) {
     name
-    documents(first: $first, skip: $skip, documentTypes: $docTypes) {
+    documents(first: $first, offset: $skip, documentTypes: $docTypes) {
       count: totalCount
       edges {
         node {

--- a/medicines/web/src/services/search-results-loader.ts
+++ b/medicines/web/src/services/search-results-loader.ts
@@ -84,7 +84,7 @@ const getDocumentsForProduct = async ({
     searchTerm,
     first: pageSize,
     after: makeCursor(page, pageSize),
-    documentTypes: docTypes,
+    documentTypes: docTypes.map(s => s.toUpperCase()),
   };
   const { data } = await graphqlRequest<ISearchPageResponse, typeof variables>({
     query,


### PR DESCRIPTION
API schema has drifted from the website in a few contexts

![drifting](https://media.giphy.com/media/kbpaLPO0qXEzu/giphy.gif)

- [ ] rename `skip` to `offset` in `product { documents }`
- [ ] uppercase all the doctypes for graphql variables in the Search Results loader