### PR TITLE
Terraform updates

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.2.0"
+  version = "=2.8.0"
   features {}
 }
 
@@ -75,7 +75,7 @@ resource "azurerm_virtual_network" "cluster" {
 
 resource "azurerm_subnet" "load_balancer" {
   name                 = "adarz-spoke-products-dev-sn-01"
-  address_prefix       = "10.5.65.128/26"
+  address_prefixes     = ["10.5.65.128/26"]
   resource_group_name  = azurerm_virtual_network.cluster.resource_group_name
   virtual_network_name = azurerm_virtual_network.cluster.name
 }

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.2.0"
+  version = "=2.8.0"
   features {}
 }
 
@@ -68,7 +68,7 @@ data "azurerm_virtual_network" "cluster" {
 
 resource "azurerm_subnet" "load_balancer" {
   name                 = "adarz-spoke-products-sn-01"
-  address_prefix       = "10.5.65.0/26"
+  address_prefixes     = ["10.5.65.0/26"]
   resource_group_name  = data.azurerm_virtual_network.cluster.resource_group_name
   virtual_network_name = data.azurerm_virtual_network.cluster.name
 }

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.2.0"
+  version = "=2.8.0"
   features {}
 }
 

--- a/infrastructure/modules/cluster/main.tf
+++ b/infrastructure/modules/cluster/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_public_ip" "products_ip" {
 resource "azurerm_subnet" "cluster" {
   name                 = var.cluster_subnet_name
   resource_group_name  = var.vnet_resource_group
-  address_prefix       = var.cluster_subnet_cidr
+  address_prefixes     = [var.cluster_subnet_cidr]
   virtual_network_name = var.vnet_name
 }
 


### PR DESCRIPTION
- Updates [azure provider to 2.8.0](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/CHANGELOG.md#280-april-30-2020)
- Switches to using [`address_prefixes`](https://www.terraform.io/docs/providers/azurerm/r/subnet.html#argument-reference) instead of the now deprecated `address_prefix` argument for subnets
- Fixes bootstrapping issue where it seems the latest version of terraform is too clever for it's own good and knows what the value of `azurerm_kubernetes_cluster.cluster.default_node_pool[0].vnet_subnet_id` is before it's even created `azurerm_kubernetes_cluster.cluster` (because we tell it what the `vnet_subnet_id` should be). I've had to add a bit more indirection to get terraform to wait until the cluster is created before trying to read its `route_table_id`.