### PR TITLE
Use repo digest 1 to target prod

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG
           make docker-push image=$PROD_IMAGE tag=$TAG
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${PROD_IMAGE}:${TAG})"
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 1}}' ${PROD_IMAGE}:${TAG})"
           echo ::set-env name=DIGEST::$DIGEST
 
       - name: Create Release


### PR DESCRIPTION
# Use repo digest 1 to target prod
The workflow targets the digest of the image at index 0 - this is currently the nonprod digest, since the image is initially pulled from the nonprod registry. The digest at index 1 is for production, which is the one we want to reference.

![changing a 1 to a 0](https://thumbs.gfycat.com/ForthrightDifferentAnaconda-size_restricted.gif)

### Acceptance Criteria

- [ ] Inserts the correct sha for production during a deployment


### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
