### PR TITLE
Add graphql env to workflow

### DIFF
--- a/.github/workflows/medicines-web-release.yaml
+++ b/.github/workflows/medicines-web-release.yaml
@@ -17,6 +17,7 @@ env:
   GOOGLE_TRACKING_ID: UA-6838115-13
   GOOGLE_USE_DEBUG: false
   ROOT_URL_DOMAIN: .windows.net
+  GRAPHQL_URL: https://medicines.api.mhra.gov.uk/graphql
 
 jobs:
   build:


### PR DESCRIPTION
# Add graphql env to workflow

The GraphQL env was missing from the prod release workflow - it had been added to the 
`Write variables to .env` step but was missing from the `env` part of the config, so was causing the GraphQL cypress test to fail.

![](https://media.giphy.com/media/l2JehQ2GitHGdVG9y/giphy.gif)

### Acceptance Criteria

- [ ] Cypress tests pass


### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
