### PR TITLE
Remove curl from docker build for api

### DIFF
--- a/medicines/api/Dockerfile
+++ b/medicines/api/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update && apt-get install -y \
   tini \
   libssl-dev \
   openssl \
-  curl \
   ;
 
 RUN useradd svc


### PR DESCRIPTION
# Remove curl from docker build for api

Curl isn't needed in the production image and it's safer to have it removed. This PR removes it.

![](https://media.giphy.com/media/3oFzms14TXDvrIazxC/giphy.gif)

### Acceptance Criteria

- [ ] Curl not accessible from within a shell session on the API pod

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
