### PR TITLE
Bump react-schemaorg to v1.0.2

### DIFF
--- a/medicines/web/package.json
+++ b/medicines/web/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.12.0",
     "react-ga": "^2.7.0",
     "react-gtm-module": "^2.0.8",
-    "react-schemaorg": "^1.0.0",
+    "react-schemaorg": "^1.0.2",
     "schema-dts": "^0.4.5",
     "styled-components": "^4.4.1",
     "styled-normalize": "^8.0.6",

--- a/medicines/web/yarn.lock
+++ b/medicines/web/yarn.lock
@@ -8466,10 +8466,10 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
-react-schemaorg@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-schemaorg/-/react-schemaorg-1.0.1.tgz#c8865a81861f424181efaa2f5919164287c920c4"
-  integrity sha512-nt/37U4yORyYL5y2ZL4f5mtVtuchqo9I2vMSVPEHkV9cPsqQJLsYrhHkPkJmecN7DTqHue9D3v2gnPoVmFp0DQ==
+react-schemaorg@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-schemaorg/-/react-schemaorg-1.0.2.tgz#3ae275f8033084441ba48809e0f0d73590e7a6ac"
+  integrity sha512-V3+7QNOsKW5I8eaTxfpaFMVCnODcv42mg6t9n+R2Sc10nzaHqmSlIIMv5HgJ7mRw4UionHnHRL4z7Vs0YQmwlg==
 
 react-test-renderer@^16.0.0-0:
   version "16.13.0"


### PR DESCRIPTION
# Update react-schemaorg version

Fixes #778

![](https://media.giphy.com/media/QWkuGmMgphvmE/giphy.gif)

### Acceptance Criteria

- [ ] Allows substance and drug pages to load and work as expected on IE11 and other main browsers (no regression)

### Testing information

- Open IE11
- Click on substance index letter on home page of site
- Does page load? 

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
