### PR TITLE
Add ca-certificates to docker image so HTTPS requests work

### DIFF
--- a/medicines/api/Dockerfile
+++ b/medicines/api/Dockerfile
@@ -43,6 +43,7 @@ FROM debian:buster-slim AS release
 
 RUN apt-get update && apt-get install -y \
   tini \
+  ca-certificates \
   libssl-dev \
   openssl \
   ;


### PR DESCRIPTION
The API throws these errors when making requests to the Azure search service:

```json
{"timestamp":"2020-05-14T14:11:49.906806176+00:00","level":"ERROR","target":"api::product","fields":{"message":"Error fetching documents from Azure search service: error sending request for url (https://mhraproductsnonprod.search.windows.net/indexes/products-index/docs?api-version=2017-11-11&highlight=content&queryType=full&search=&scoringProfile=preferKeywords&%24count=true&%24filter=%28product_name+eq+%27ZONISAMIDE+ARISTO+25+MG+HARD+CAPSULES%27%29&%24top=10&%24skip=0): error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1915: (unable to get local issuer certificate)\n\nCaused by:\n    0: error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1915: (unable to get local issuer certificate)\n    1: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1915: (unable to get local issuer certificate)"}}
```

Adding ca-certificates fixes it :)
