### PR TITLE
Point upload to storage github workflow action to specific commit

### DIFF
--- a/.github/workflows/learning-web-master.yaml
+++ b/.github/workflows/learning-web-master.yaml
@@ -64,7 +64,7 @@ jobs:
           PATH_PREFIX: "/"
 
       - name: Deploy learning web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+        uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true
           folder: learning/web/public

--- a/.github/workflows/learning-web-master.yaml
+++ b/.github/workflows/learning-web-master.yaml
@@ -64,6 +64,7 @@ jobs:
           PATH_PREFIX: "/"
 
       - name: Deploy learning web to static site in azure storage
+        # master causes this step to fail so pointing to last working commit until fixed
         uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -74,6 +74,7 @@ jobs:
           prerelease: false
 
       - name: Deploy learning web to static site in azure storage
+        # master causes this step to fail so pointing to last working commit until fixed
         uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true

--- a/.github/workflows/learning-web-release.yaml
+++ b/.github/workflows/learning-web-release.yaml
@@ -74,7 +74,7 @@ jobs:
           prerelease: false
 
       - name: Deploy learning web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+        uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true
           folder: learning/web/public

--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -84,7 +84,7 @@ jobs:
           ROOT_URL_DOMAIN: localhost
 
       - name: Deploy products web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+        uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true
           folder: medicines/web/dist

--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -84,6 +84,7 @@ jobs:
           ROOT_URL_DOMAIN: localhost
 
       - name: Deploy products web to static site in azure storage
+        # master causes this step to fail so pointing to last working commit until fixed
         uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true

--- a/.github/workflows/medicines-web-release.yaml
+++ b/.github/workflows/medicines-web-release.yaml
@@ -94,6 +94,7 @@ jobs:
           prerelease: false
 
       - name: Deploy products web to static site in azure storage
+        # master causes this step to fail so pointing to last working commit until fixed
         uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true

--- a/.github/workflows/medicines-web-release.yaml
+++ b/.github/workflows/medicines-web-release.yaml
@@ -94,8 +94,8 @@ jobs:
           prerelease: false
 
       - name: Deploy products web to static site in azure storage
-        uses: lauchacarro/Azure-Storage-Action@master
+        uses: lauchacarro/Azure-Storage-Action@9225056
         with:
           enabled-static-website: true
           folder: medicines/web/dist
-          connection-string: ${{ secrets.AZURE_STORAGE_PROD_PRODUCTS_WEB_CONNECTION_STRING }}
+          connection-string: ${{ secrets. AZURE_STORAGE_PROD_PRODUCTS_WEB_CONNECTION_STRING }}

--- a/.github/workflows/medicines-web-release.yaml
+++ b/.github/workflows/medicines-web-release.yaml
@@ -99,4 +99,4 @@ jobs:
         with:
           enabled-static-website: true
           folder: medicines/web/dist
-          connection-string: ${{ secrets. AZURE_STORAGE_PROD_PRODUCTS_WEB_CONNECTION_STRING }}
+          connection-string: ${{ secrets.AZURE_STORAGE_PROD_PRODUCTS_WEB_CONNECTION_STRING }}


### PR DESCRIPTION
# Point upload to storage github workflow action to specific commit

The code for this broke some time after commit 9225056 in the last few days - we were seeing the upload step fail in our workflows with a `InvalidXmlNodeValue` error.

![image](https://user-images.githubusercontent.com/6436551/82044512-61a20600-96a5-11ea-8d76-384abc8eb522.png)

Pointing to the last working commit resolves the issue.

![](https://media.giphy.com/media/9cpVJ0qiBB3eE/giphy.gif)

### Acceptance Criteria

- [ ] Fixes master build for website products

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
