### PR TITLE
Sftp client refactor

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/retrieve.rs
+++ b/medicines/doc-index-updater/src/create_manager/retrieve.rs
@@ -1,0 +1,14 @@
+use crate::{
+    models::FileSource,
+    storage_client::{models::StorageClientError, AzureBlobStorage, GetBlob, SftpClient},
+};
+
+pub async fn retrieve(source: FileSource, filepath: String) -> Result<Vec<u8>, StorageClientError> {
+    let a = match source {
+        FileSource::Sentinel => SftpClient::sentinel().await.get_blob(&filepath).await?,
+        FileSource::TemporaryAzureBlobStorage => {
+            AzureBlobStorage::temporary().get_blob(&filepath).await?
+        }
+    };
+    Ok(a.data)
+}

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -392,7 +392,7 @@ mod test {
                     e.to_string(),
                     ProcessMessageError::FailedDeletingBlob(
                         "storage_name".to_string(),
-                        "ClientError { message: \"blob could not be deleted\" }".to_string()
+                        "Generic(blob could not be deleted)".to_string()
                     )
                     .to_string()
                 );

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    create_manager::SftpError,
     get_env_or_default,
     models::{JobStatus, Message},
     state_manager::{JobStatusClient, StateManager},
+    storage_client::models::StorageClientError,
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -99,7 +99,7 @@ where
 #[derive(Error, Debug)]
 pub enum ProcessMessageError {
     #[error(transparent)]
-    SftpError(#[from] SftpError),
+    StorageClientError(#[from] StorageClientError),
     #[error("Cannot find document with ID {0}")]
     DocumentNotFoundInIndex(String),
     #[error("Cannot delete blob with ID {0}: {1}")]

--- a/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
+++ b/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
@@ -55,17 +55,16 @@ impl AzureBlobStorage {
         match base64::decode(&self.master_key) {
             Ok(_) => Ok(
                 Client::new(&self.storage_account, &self.master_key).map_err(|e| {
-                    StorageClientError::ClientError {
-                        message: format!("Couldn't create storage client: {:?}", e),
-                    }
+                    StorageClientError::ClientError(format!(
+                        "Couldn't create storage client: {:?}",
+                        e
+                    ))
                 })?,
             ),
-            Err(e) => Err(StorageClientError::ClientError {
-                message: format!(
-                    "Couldn't decode master key to create storage client: {:?}",
-                    e
-                ),
-            }),
+            Err(e) => Err(StorageClientError::ClientError(format!(
+                "Couldn't decode master key to create storage client: {:?}",
+                e
+            ))),
         }
     }
 }
@@ -94,9 +93,7 @@ impl StorageClient for AzureBlobStorage {
             .await
             .map_err(|e| {
                 tracing::error!("Error uploading file to blob storage: {:?}", e);
-                StorageClientError::UploadError {
-                    message: format!("Couldn't create blob: {:?}", e),
-                }
+                StorageClientError::UploadError(format!("Couldn't create blob: {:?}", e))
             })?;
 
         let path = format!(
@@ -112,9 +109,7 @@ impl StorageClient for AzureBlobStorage {
             .await
             .map_err(|e| {
                 tracing::error!("Error retrieving file from blob storage: {:?}", e);
-                StorageClientError::RetrievalError {
-                    message: format!("Couldn't retrieve blob: {:?}", e),
-                }
+                StorageClientError::RetrievalError(format!("Couldn't retrieve blob: {:?}", e))
             })?
             .data;
 

--- a/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
+++ b/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
@@ -52,20 +52,10 @@ impl AzureBlobStorage {
     }
 
     pub fn get_azure_client(&self) -> Result<Client, StorageClientError> {
-        match base64::decode(&self.master_key) {
-            Ok(_) => Ok(
-                Client::new(&self.storage_account, &self.master_key).map_err(|e| {
-                    StorageClientError::ClientError(format!(
-                        "Couldn't create storage client: {:?}",
-                        e
-                    ))
-                })?,
-            ),
-            Err(e) => Err(StorageClientError::ClientError(format!(
-                "Couldn't decode master key to create storage client: {:?}",
-                e
-            ))),
-        }
+        let client = base64::decode(&self.master_key)
+            .map(|_| Client::new(&self.storage_account, &self.master_key))?;
+
+        Ok(client?)
     }
 }
 

--- a/medicines/doc-index-updater/src/storage_client/mod.rs
+++ b/medicines/doc-index-updater/src/storage_client/mod.rs
@@ -2,12 +2,14 @@ pub use azure_blob_client::AzureBlobStorage;
 pub use client::StorageClient;
 pub use delete::DeleteBlob;
 pub use get::GetBlob;
+pub use sftp_client::SftpClient;
 
 mod azure_blob_client;
 mod client;
 mod delete;
 mod get;
 pub mod models;
+mod sftp_client;
 
 #[cfg(test)]
 pub mod test {
@@ -25,9 +27,9 @@ pub mod test {
             if self.can_delete_blob {
                 Ok(())
             } else {
-                Err(StorageClientError::ClientError {
-                    message: "blob could not be deleted".to_string(),
-                })
+                Err(StorageClientError::Generic(anyhow::anyhow!(
+                    "blob could not be deleted".to_string()
+                )))
             }
         }
     }

--- a/medicines/doc-index-updater/src/storage_client/models.rs
+++ b/medicines/doc-index-updater/src/storage_client/models.rs
@@ -1,4 +1,5 @@
 use azure_sdk_core::errors::AzureError;
+use base64::DecodeError;
 use thiserror::Error;
 
 pub struct StorageFile {
@@ -17,6 +18,8 @@ pub enum StorageClientError {
     #[error("Could not create client: {0}")]
     ClientError(String),
 
+    #[error(transparent)]
+    DecodeError(#[from] DecodeError),
     #[error(transparent)]
     OtherAzureError(#[from] AzureError),
     #[error(transparent)]

--- a/medicines/doc-index-updater/src/storage_client/models.rs
+++ b/medicines/doc-index-updater/src/storage_client/models.rs
@@ -1,26 +1,41 @@
 use azure_sdk_core::errors::AzureError;
+use thiserror::Error;
 
 pub struct StorageFile {
     pub name: String,
     pub path: String,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum StorageClientError {
-    RetrievalError { message: String },
-    UploadError { message: String },
-    ClientError { message: String },
-}
+    #[error(transparent)]
+    SftpError(#[from] SftpError),
+    #[error("Could not retrieve: {0}")]
+    RetrievalError(String),
+    #[error("Could not upload: {0}")]
+    UploadError(String),
+    #[error("Could not create client: {0}")]
+    ClientError(String),
 
-impl From<AzureError> for StorageClientError {
-    fn from(e: AzureError) -> Self {
-        Self::ClientError {
-            message: format!("Azure error: {:?}", e),
-        }
-    }
+    #[error(transparent)]
+    OtherAzureError(#[from] AzureError),
+    #[error(transparent)]
+    Generic(#[from] anyhow::Error),
 }
 
 pub struct BlobResponse {
     pub blob_name: String,
     pub data: Vec<u8>,
+}
+
+#[derive(Error, Debug)]
+pub enum SftpError {
+    #[error("A TCP error connecting to server. ({0:?})")]
+    TcpError(#[from] std::io::Error),
+    #[error("An SSH error connecting to server. ({0:?})")]
+    Ssh2Error(#[from] async_ssh2::Error),
+    #[error("File could not be retrieved on server")]
+    CouldNotRetrieveFile,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }

--- a/medicines/doc-index-updater/src/storage_client/sftp_client.rs
+++ b/medicines/doc-index-updater/src/storage_client/sftp_client.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use std::net::TcpStream;
 use tokio::io::AsyncReadExt;
 
-struct SftpInfo {
+struct SftpConfig {
     server: String,
     user: String,
     public_key_path: String,
@@ -17,13 +17,13 @@ struct SftpInfo {
 }
 
 async fn sentinel_sftp_factory(
-    SftpInfo {
+    SftpConfig {
         server,
         user,
         public_key_path,
         private_key_path,
         private_key_password,
-    }: &SftpInfo,
+    }: &SftpConfig,
 ) -> Result<Sftp, SftpError> {
     tracing::debug!(
         message = format!(
@@ -105,7 +105,7 @@ async fn retrieve_file_from_sftp(
 }
 
 pub struct SftpClient {
-    sftp_info: SftpInfo,
+    sftp_info: SftpConfig,
 }
 
 impl SftpClient {
@@ -117,7 +117,7 @@ impl SftpClient {
         let private_key_password = get_env_fail_fast("SENTINEL_PRIVATE_KEY_PASSWORD").await;
 
         Self {
-            sftp_info: SftpInfo {
+            sftp_info: SftpConfig {
                 server,
                 user,
                 public_key_path,


### PR DESCRIPTION
# Refactors the Sentinel SFTP Client

Sentinel's SFTP client isn't special; it's just a way of grabbing a file from temporary storage.

This refactor aligns it with the temporary blob storage from Azure, decoupling the create_manager from how the files are retrieved.

_n.b. could probably do a bit better, go a bit more **strategy pattern** with this, but not right now_

### Acceptance Criteria

- [ ] Refactor SFTP client to move it away from create_manager
- [ ] Rely on storage_client trait to get blobs from temporary clients
