### PR TITLE
Add diagnostic logging on cluster in production

### DIFF
--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -71,6 +71,8 @@ module cluster {
   lb_route_table_id                     = data.azurerm_route_table.load_balancer.id
   default_node_count                    = "3"
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
+  log_cluster_diagnostics               = true
+  diagnostic_setting_name               = "production-cluster-diagnostics"
 }
 
 # Service Bus

--- a/infrastructure/modules/cluster/diagnostics.tf
+++ b/infrastructure/modules/cluster/diagnostics.tf
@@ -1,0 +1,43 @@
+resource "azurerm_storage_account" "logs" {
+  count                    = var.log_cluster_diagnostics ? 1 : 0
+  name                     = "logs"
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "RAGRS"
+  access_tier              = "Cool"
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+variable "diagnostic_log_types" {
+  description = "Set of log types to create configuration for"
+  type        = list(string)
+  default = ["kube-apiserver",
+    "kube-audit",
+    "kube-controller-manager",
+    "kube-scheduler",
+  "cluster-autoscaler"]
+}
+
+resource "azurerm_monitor_diagnostic_setting" "cluster" {
+  count              = var.log_cluster_diagnostics ? 1 : 0
+  name               = var.diagnostic_setting_name
+  target_resource_id = "${azurerm_kubernetes_cluster.cluster.id}"
+  storage_account_id = "${azurerm_storage_account.logs[0].id}"
+
+  dynamic "log" {
+    for_each = var.diagnostic_log_types
+
+    content {
+      category = log.value
+      retention_policy {
+        enabled = true
+        days    = 0
+      }
+    }
+  }
+}

--- a/infrastructure/modules/cluster/diagnostics.tf
+++ b/infrastructure/modules/cluster/diagnostics.tf
@@ -13,16 +13,6 @@ resource "azurerm_storage_account" "logs" {
   }
 }
 
-variable "diagnostic_log_types" {
-  description = "Set of log types to create configuration for"
-  type        = list(string)
-  default = ["kube-apiserver",
-    "kube-audit",
-    "kube-controller-manager",
-    "kube-scheduler",
-  "cluster-autoscaler"]
-}
-
 resource "azurerm_monitor_diagnostic_setting" "cluster" {
   count              = var.log_cluster_diagnostics ? 1 : 0
   name               = var.diagnostic_setting_name

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -59,3 +59,14 @@ variable "default_node_count" {
 variable "support_email_addresses" {
   description = "A list of email addresses for first line support alerts to be sent to."
 }
+
+variable "log_cluster_diagnostics" {
+  type        = bool
+  description = "Whether diagnostics from the cluster should be logged to a storage container"
+  default     = false
+}
+
+variable "diagnostic_setting_name" {
+  description = "Name of the diagnostic collection setting that saves auditable logs from the cluster"
+  default     = ""
+}

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -70,3 +70,13 @@ variable "diagnostic_setting_name" {
   description = "Name of the diagnostic collection setting that saves auditable logs from the cluster"
   default     = ""
 }
+
+variable "diagnostic_log_types" {
+  description = "Set of log types to create configuration for"
+  type        = list(string)
+  default = ["kube-apiserver",
+    "kube-audit",
+    "kube-controller-manager",
+    "kube-scheduler",
+  "cluster-autoscaler"]
+}


### PR DESCRIPTION
# Add diagnostic logging on cluster in production

Enables auditable log backup to a new "cool" (cheaper) storage account in production.

Will generate about 2TB (back of envelope calculation) data in logs each year using append blobs. A "cool" (as apposed to a "hot") access tier should help reduce costs incurred for this long term data storage.

![](https://media.giphy.com/media/l1J3MKIlqmX5CfcnS/giphy.gif)

### Acceptance Criteria

- [ ] Creates logs in storage containers within new storage account in production

### Testing information

- Enable diagnostic logs in lower environment and apply to cluster (`log_cluster_diagnostics = true`)
- Observe new storage account created, being populated with logs from cluster
- Check logs to ensure no secrets being written

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
