### PR TITLE
Auto populate reply urls to the CDN address

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -44,12 +44,12 @@ data "azurerm_resource_group" "keyvault" {
 module "products" {
   source = "../../modules/products"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  namespace           = local.namespace
-  pars_namespace      = local.pars_namespace
-  resource_group_name = azurerm_resource_group.products.name
-  pars_reply_urls     = var.PARS_REPLY_URLS
+  environment              = var.ENVIRONMENT
+  location                 = var.REGION
+  namespace                = local.namespace
+  pars_namespace           = local.pars_namespace
+  resource_group_name      = azurerm_resource_group.products.name
+  add_local_pars_reply_url = true
 }
 
 # website

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -56,9 +56,3 @@ variable "KEYVAULT_RESOURCE_GROUP" {
   description = "Name of resource group where keyvault is deployed"
   default     = "adazr-rg-1001"
 }
-
-variable "PARS_REPLY_URLS" {
-  type        = list(string)
-  default     = ["http://localhost:3000", "https://mhraparsdev.azureedge.net"]
-  description = "The reply urls configured in the azure app registration."
-}

--- a/infrastructure/environments/non-prod/Makefile
+++ b/infrastructure/environments/non-prod/Makefile
@@ -5,7 +5,7 @@ help: ## Display this help screen
 .PHONY: get-env
 get-env: ## Gets the environment variables from azure keyvault into .env file
 	az keyvault secret show \
-	  --vault-name mhra-non-prod \
+	  --vault-name mhra-non-prod-02 \
 	  --name infrastructure-non-prod-env \
 	  --query value \
 	  --output tsv | sort | sed '/^$$/d' > .env
@@ -13,7 +13,7 @@ get-env: ## Gets the environment variables from azure keyvault into .env file
 .PHONY: set-env
 set-env: ## Takes your current .env file and replaces the keyvault value with the contents of the file
 	az keyvault secret set \
-	--vault-name mhra-non-prod \
+	--vault-name mhra-non-prod-02 \
 	--name infrastructure-non-prod-env \
 	--file .env
 

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -49,7 +49,6 @@ module "products" {
   namespace           = local.namespace
   pars_namespace      = local.pars_namespace
   resource_group_name = azurerm_resource_group.products.name
-  pars_reply_urls     = var.PARS_REPLY_URLS
 }
 
 # website

--- a/infrastructure/environments/non-prod/variables.tf
+++ b/infrastructure/environments/non-prod/variables.tf
@@ -58,9 +58,3 @@ variable "KEYVAULT_RESOURCE_GROUP" {
   description = "Name of resource group where keyvault is deployed"
   default     = "adazr-rg-1001"
 }
-
-variable "PARS_REPLY_URLS" {
-  type        = list(string)
-  default     = ["TBD"]
-  description = "The reply urls configured in the azure app registration."
-}

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -45,7 +45,6 @@ module "products" {
   pars_namespace      = local.pars_namespace
   resource_group_name = data.azurerm_resource_group.products.name
   search_sku          = "standard"
-  pars_reply_urls     = var.PARS_REPLY_URLS
 }
 
 data "azurerm_route_table" "load_balancer" {

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -58,9 +58,3 @@ variable "KEYVAULT_RESOURCE_GROUP" {
   description = "Name of resource group where keyvault is deployed"
   default     = "prod-secrets"
 }
-
-variable "PARS_REPLY_URLS" {
-  type        = list(string)
-  default     = ["TBD"]
-  description = "The reply urls configured in the azure app registration."
-}

--- a/infrastructure/modules/cluster/diagnostics.tf
+++ b/infrastructure/modules/cluster/diagnostics.tf
@@ -16,8 +16,8 @@ resource "azurerm_storage_account" "logs" {
 resource "azurerm_monitor_diagnostic_setting" "cluster" {
   count              = var.log_cluster_diagnostics ? 1 : 0
   name               = var.diagnostic_setting_name
-  target_resource_id = "${azurerm_kubernetes_cluster.cluster.id}"
-  storage_account_id = "${azurerm_storage_account.logs[0].id}"
+  target_resource_id = azurerm_kubernetes_cluster.cluster.id
+  storage_account_id = azurerm_storage_account.logs[0].id
 
   dynamic "log" {
     for_each = var.diagnostic_log_types

--- a/infrastructure/modules/keyvault/main.tf
+++ b/infrastructure/modules/keyvault/main.tf
@@ -2,7 +2,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "secrets_vault" {
   name                = var.name
-  location            = var.location
+  location            = "uksouth"
   resource_group_name = var.resource_group_name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   soft_delete_enabled = true

--- a/infrastructure/modules/products/app-registrations.tf
+++ b/infrastructure/modules/products/app-registrations.tf
@@ -2,7 +2,7 @@ resource "azuread_application" "pars-upload" {
   name                    = "pars-upload-${var.environment}"
   reply_urls              = concat(["https://${azurerm_cdn_endpoint.pars.host_name}"], var.add_local_pars_reply_url ? ["http://localhost:3000"] : [])
   group_membership_claims = "All"
-  homepage                = "http://pars-upload-${var.namespace}" #don't think we need this
+  homepage                = "https://${azurerm_cdn_endpoint.pars.host_name}" #don't think we need this
 
   app_role {
     allowed_member_types = [

--- a/infrastructure/modules/products/app-registrations.tf
+++ b/infrastructure/modules/products/app-registrations.tf
@@ -1,6 +1,6 @@
 resource "azuread_application" "pars-upload" {
   name                    = "pars-upload-${var.namespace}"
-  reply_urls              = var.pars_reply_urls
+  reply_urls              = concat(["https://${azurerm_cdn_endpoint.pars.host_name}"], var.add_local_pars_reply_url ? ["http://localhost:3000"] : [])
   group_membership_claims = "All"
   homepage                = "http://pars-upload-${var.namespace}" #don't think we need this
 

--- a/infrastructure/modules/products/app-registrations.tf
+++ b/infrastructure/modules/products/app-registrations.tf
@@ -1,5 +1,5 @@
 resource "azuread_application" "pars-upload" {
-  name                    = "pars-upload-${var.namespace}"
+  name                    = "pars-upload-${var.environment}"
   reply_urls              = concat(["https://${azurerm_cdn_endpoint.pars.host_name}"], var.add_local_pars_reply_url ? ["http://localhost:3000"] : [])
   group_membership_claims = "All"
   homepage                = "http://pars-upload-${var.namespace}" #don't think we need this

--- a/infrastructure/modules/products/pars.tf
+++ b/infrastructure/modules/products/pars.tf
@@ -18,7 +18,7 @@ resource "azurerm_storage_account" "pars" {
 
 resource "azurerm_cdn_profile" "pars" {
   name                = "mhrapars${var.environment}"
-  location            = var.location
+  location            = "westeurope"
   resource_group_name = var.resource_group_name
   sku                 = "Standard_Microsoft"
 }

--- a/infrastructure/modules/products/variables.tf
+++ b/infrastructure/modules/products/variables.tf
@@ -23,6 +23,7 @@ variable "search_sku" {
   default     = "basic"
 }
 
-variable "pars_reply_urls" {
-  description = "The reply urls configured in the azure app registration"
+variable "add_local_pars_reply_url" {
+  description = "Whether to add http://localhost:3000 to allowable redirect urls"
+  default     = false
 }


### PR DESCRIPTION

 - Automatically get the CDN url for the reply address for non prod and prod. Prod will also need the dns name when we get it.
 - Add localhost:3000 for dev but nowhere else

![](https://media.giphy.com/media/12T06oyfpXSoNy/giphy.gif)
