### PR TITLE
Push to non prod and dev on pars upload master not branch

### DIFF
--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -3,8 +3,7 @@ name: pars-upload-branch
 on:
   push:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/pars-upload/**
       - .github/workflows/pars-upload-branch.yaml
@@ -77,3 +76,43 @@ jobs:
       - name: Accessibility check
         working-directory: medicines/pars-upload
         run: yarn a11y
+
+      - name: DEV - Create .env file
+        working-directory: medicines/pars-upload
+        run: |
+          echo NEXT_PUBLIC_CLIENT_ID=26f95b21-63b2-475f-8a35-d39cea4cfd61 >> .env
+          echo NEXT_PUBLIC_AUTHORITY_URL=https://login.microsoftonline.com/e527ea5c-6258-4cd2-a27f-8bd237ec4c26 >> .env
+          echo NEXT_PUBLIC_REDIRECT_URI=https://mhraparsdev.azureedge.net >> .env
+          echo NEXT_PUBLIC_DISABLE_AUTH=false >> .env
+
+      - name: DEV - Build static site
+        working-directory: medicines/pars-upload
+        run: yarn export
+
+      - name: DEV - Deploy pars upload website to static site in azure storage 
+        # master causes this step to fail so pointing to last working commit until fixed
+        uses: lauchacarro/Azure-Storage-Action@9225056
+        with:
+          enabled-static-website: true
+          folder: medicines/pars-upload/out
+          connection-string: ${{ secrets.AZURE_STORAGE_PARS_WEB_CONNECTION_STRING_DEV }}
+      
+      - name: NON-PROD - Create .env file
+        working-directory: medicines/pars-upload
+        run: |
+          echo NEXT_PUBLIC_CLIENT_ID=ac2b59e9-77ca-4d39-8186-b96d305c9aae >> .env
+          echo NEXT_PUBLIC_AUTHORITY_URL=https://login.microsoftonline.com/e527ea5c-6258-4cd2-a27f-8bd237ec4c26 >> .env
+          echo NEXT_PUBLIC_REDIRECT_URI=https://mhraparsnon-prod.azureedge.net >> .env
+          echo NEXT_PUBLIC_DISABLE_AUTH=false >> .env
+
+      - name: NON-PROD - Build static site
+        working-directory: medicines/pars-upload
+        run: yarn export
+
+      - name: NON-PROD - Deploy pars upload website to static site in azure storage 
+        # master causes this step to fail so pointing to last working commit until fixed
+        uses: lauchacarro/Azure-Storage-Action@9225056
+        with:
+          enabled-static-website: true
+          folder: medicines/pars-upload/out
+          connection-string: ${{ secrets.AZURE_STORAGE_PARS_WEB_CONNECTION_STRING_NON_PROD }}


### PR DESCRIPTION
_Continuously deploys pars upload website to non prod and dev on merge to master._

![](https://media.giphy.com/media/hWGQrCrfcT0GdHSZx5/giphy.gif)

### Acceptance Criteria

- [ ] _No longer deploys to dev on branch build_
- [ ] _Deploys master to dev and non prod_
### Testing information

check 
 http://mhraparsdev.azureedge.net 
 http://mhraparsnon-prod.azureedge.net 
are both the latest code on merge to master.

Might take a little while for the CDN to propagate the latest code.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
