### PR TITLE
Restrict access to Redis cache to cluster

### DIFF
--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -109,6 +109,11 @@ module cpd {
   resource_group_name = azurerm_resource_group.products.name
 }
 
+data "azurerm_public_ip" "external" {
+  name                = split("/", module.cluster.load_balancer_public_outbound_ip_id)[8]
+  resource_group_name = split("/", module.cluster.load_balancer_public_outbound_ip_id)[4]
+}
+
 # Service Bus
 module service_bus {
   source = "../../modules/service-bus"
@@ -117,6 +122,8 @@ module service_bus {
   location            = var.REGION
   name                = local.service_bus_name
   resource_group_name = azurerm_resource_group.products.name
+  redis_use_firewall  = true
+  redis_firewall_ip   = data.azurerm_public_ip.external.ip_address
 }
 
 # Key vault

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -87,6 +87,11 @@ module cluster {
   diagnostic_setting_name               = "production-cluster-diagnostics"
 }
 
+data "azurerm_public_ip" "external" {
+  name                = split("/", module.cluster.load_balancer_public_outbound_ip_id)[8]
+  resource_group_name = split("/", module.cluster.load_balancer_public_outbound_ip_id)[4]
+}
+
 # Service Bus
 module service_bus {
   source = "../../modules/service-bus"
@@ -95,6 +100,8 @@ module service_bus {
   location            = var.REGION
   name                = local.service_bus_name
   resource_group_name = data.azurerm_resource_group.products.name
+  redis_use_firewall  = true
+  redis_firewall_ip   = data.azurerm_public_ip.external.ip_address
 }
 
 # Key vault

--- a/infrastructure/modules/cluster/main.tf
+++ b/infrastructure/modules/cluster/main.tf
@@ -42,6 +42,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
   network_profile {
     network_plugin = "kubenet"
+    outbound_type  = "loadBalancer"
   }
 
   addon_profile {

--- a/infrastructure/modules/cluster/outputs.tf
+++ b/infrastructure/modules/cluster/outputs.tf
@@ -17,3 +17,7 @@ output "host" {
 output "resource_group_name" {
   value = azurerm_kubernetes_cluster.cluster.resource_group_name
 }
+
+output "load_balancer_public_outbound_ip_id" {
+  value = tolist(azurerm_kubernetes_cluster.cluster.network_profile[0].load_balancer_profile[0].effective_outbound_ips)[0]
+}

--- a/infrastructure/modules/service-bus/main.tf
+++ b/infrastructure/modules/service-bus/main.tf
@@ -54,3 +54,11 @@ resource "azurerm_redis_cache" "doc_index_updater_redis" {
   resource_group_name = var.resource_group_name
   sku_name            = "Standard"
 }
+
+resource "azurerm_redis_firewall_rule" "example" {
+  name                = "someIPrange"
+  redis_cache_name    = azurerm_redis_cache.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  start_ip            = var.redis_start_ip
+  end_ip              = var.redis_end_ip
+}

--- a/infrastructure/modules/service-bus/main.tf
+++ b/infrastructure/modules/service-bus/main.tf
@@ -55,10 +55,11 @@ resource "azurerm_redis_cache" "doc_index_updater_redis" {
   sku_name            = "Standard"
 }
 
-resource "azurerm_redis_firewall_rule" "example" {
-  name                = "someIPrange"
-  redis_cache_name    = azurerm_redis_cache.example.name
-  resource_group_name = azurerm_resource_group.example.name
-  start_ip            = var.redis_start_ip
-  end_ip              = var.redis_end_ip
+resource "azurerm_redis_firewall_rule" "cluster" {
+  count               = var.redis_use_firewall ? 1 : 0
+  name                = "cluster_ip_range"
+  redis_cache_name    = azurerm_redis_cache.doc_index_updater_redis.name
+  resource_group_name = var.resource_group_name
+  start_ip            = var.redis_firewall_ip
+  end_ip              = var.redis_firewall_ip
 }

--- a/infrastructure/modules/service-bus/variables.tf
+++ b/infrastructure/modules/service-bus/variables.tf
@@ -14,10 +14,12 @@ variable "name" {
   description = "name for the service bus namespace"
 }
 
-variable "redis_start_ip" {
-  description = "First IP in allowed IP range"
+variable "redis_use_firewall" {
+  type        = bool
+  description = "Whether to apply a firewall rule for Redis"
+  default     = false
 }
 
-variable "redis_end_ip" {
-  description = "Last IP in allowed IP range"
+variable "redis_firewall_ip" {
+  description = "IP allowed to access Redis Cache"
 }

--- a/infrastructure/modules/service-bus/variables.tf
+++ b/infrastructure/modules/service-bus/variables.tf
@@ -13,3 +13,11 @@ variable "environment" {
 variable "name" {
   description = "name for the service bus namespace"
 }
+
+variable "redis_start_ip" {
+  description = "First IP in allowed IP range"
+}
+
+variable "redis_end_ip" {
+  description = "Last IP in allowed IP range"
+}

--- a/infrastructure/modules/service-bus/variables.tf
+++ b/infrastructure/modules/service-bus/variables.tf
@@ -22,4 +22,5 @@ variable "redis_use_firewall" {
 
 variable "redis_firewall_ip" {
   description = "IP allowed to access Redis Cache"
+  default     = ""
 }


### PR DESCRIPTION
# Restrict access to Redis cache to cluster

Addresses #800 

Restricts to public outbound IP of the cluster. This IP is automatically created when the public load balancer is provisioned, as part of provisioning the cluster. The terraform config pulls this from the output of the cluster module.

![](https://media.giphy.com/media/3o7ZeKClWydvqn29mE/giphy.gif)

### Acceptance Criteria

- [ ] Access to Redis cache is allowed by the cluster
- [ ] Access to Redis cache is not allowed from outside the cluster

### Testing information

- Implement firewall rule (this has been provisioned in non-prod so far)
- Try to connect to Redis cache, observe failure
- Make request to doc-index-updater that uses the Redis cache (e.g. get job status), observe success

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
