### PR TITLE
Workflows for Pull Requests

### DIFF
--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -1,10 +1,9 @@
 name: doc-index-updater-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/doc-index-updater/**
       - medicines/search-client/**

--- a/.github/workflows/learning-web-branch.yaml
+++ b/.github/workflows/learning-web-branch.yaml
@@ -1,10 +1,9 @@
 name: learning-web-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - learning/web/**
       - .github/workflows/learning-web-branch.yaml

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -1,10 +1,9 @@
 name: medicines-api-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/api/**
       - medicines/search-client/**

--- a/.github/workflows/medicines-web-branch.yaml
+++ b/.github/workflows/medicines-web-branch.yaml
@@ -1,10 +1,9 @@
 name: medicines-web-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/web/**
       - .github/workflows/medicines-web-branch.yaml

--- a/.github/workflows/pars-upload-branch.yaml
+++ b/.github/workflows/pars-upload-branch.yaml
@@ -1,7 +1,7 @@
 name: pars-upload-branch
 
 on:
-  push:
+  pull_request:
     branches:
       - "**"
       - "!master"

--- a/.github/workflows/pars-upload-branch.yaml
+++ b/.github/workflows/pars-upload-branch.yaml
@@ -3,8 +3,7 @@ name: pars-upload-branch
 on:
   pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/pars-upload/**
       - .github/workflows/pars-upload-branch.yaml

--- a/.github/workflows/search-client-branch.yaml
+++ b/.github/workflows/search-client-branch.yaml
@@ -1,10 +1,9 @@
 name: search-client-branch
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
-      - "!master"
+      - "master"
     paths:
       - medicines/search-client/**
       - .github/workflows/search-client-branch.yaml


### PR DESCRIPTION
# Workflows run for PRs

We have an issue with the `push` PRs only evaluating the last push, so in effect many broken builds could be included in a PR.

We'd like to run workflows for PRs instead, so that if any commit introduced by a PR has touched a certain file, the relevant workflows are run, and any failing build blocks the PR form merging.

![a flag for PR](https://media.giphy.com/media/3o72F6bEMcAt03nnAQ/giphy.gif)

### Acceptance Criteria

- [ ] Workflows run based on the changeset in a PR
- [ ] As an example, this PR has checks for all the workflows changed, not just those in the most recent push

### Testing information

Check the workflow checks below.
