### PR TITLE
Add immutable, environment specific log storage account

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -92,7 +92,7 @@ module logs {
 
   environment         = var.ENVIRONMENT
   location            = var.REGION
-  resource_group_name = data.azurerm_resource_group.keyvault.name
+  resource_group_name = data.azurerm_resource_group.products.name
 }
 
 # AKS

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -86,6 +86,15 @@ resource "azurerm_subnet" "load_balancer" {
   virtual_network_name = azurerm_virtual_network.cluster.name
 }
 
+# Logs
+module logs {
+  source = "../../modules/logs"
+
+  environment         = var.ENVIRONMENT
+  location            = var.REGION
+  resource_group_name = data.azurerm_resource_group.keyvault.name
+}
+
 # AKS
 module cluster {
   source = "../../modules/cluster"
@@ -104,6 +113,8 @@ module cluster {
   cluster_route_next_hop                = var.CLUSTER_ROUTE_NEXT_HOP
   lb_route_table_id                     = azurerm_route_table.load_balancer.id
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
+  log_cluster_diagnostics               = false
+  logs_storage_account_id               = module.logs.logs_resource_group_id
 }
 
 # Service Bus

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -92,7 +92,7 @@ module logs {
 
   environment         = var.ENVIRONMENT
   location            = var.REGION
-  resource_group_name = data.azurerm_resource_group.products.name
+  resource_group_name = azurerm_resource_group.products.name
 }
 
 # AKS

--- a/infrastructure/environments/dev/outputs.tf
+++ b/infrastructure/environments/dev/outputs.tf
@@ -54,3 +54,11 @@ output "storage_account_name" {
 output "storage_master_key" {
   value = module.products.storage_access_key
 }
+
+output "logs_resource_group_id" {
+  value = module.logs.logs_resource_group_id
+}
+
+output "logs_primary_access_key" {
+  value = module.logs.logs_primary_access_key
+}

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -78,6 +78,15 @@ resource "azurerm_subnet" "load_balancer" {
   virtual_network_name = data.azurerm_virtual_network.cluster.name
 }
 
+# Logs
+module logs {
+  source = "../../modules/logs"
+
+  environment         = var.ENVIRONMENT
+  location            = var.REGION
+  resource_group_name = data.azurerm_resource_group.keyvault.name
+}
+
 # AKS
 module cluster {
   source = "../../modules/cluster"
@@ -96,6 +105,8 @@ module cluster {
   cluster_route_next_hop                = var.CLUSTER_ROUTE_NEXT_HOP
   lb_route_table_id                     = data.azurerm_route_table.load_balancer.id
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
+  log_cluster_diagnostics               = false
+  logs_storage_account_id               = module.logs.logs_resource_group_id
 }
 
 # CPD

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -84,7 +84,7 @@ module logs {
 
   environment         = var.ENVIRONMENT
   location            = var.REGION
-  resource_group_name = data.azurerm_resource_group.products.name
+  resource_group_name = azurerm_resource_group.products.name
 }
 
 # AKS

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -84,7 +84,7 @@ module logs {
 
   environment         = var.ENVIRONMENT
   location            = var.REGION
-  resource_group_name = data.azurerm_resource_group.keyvault.name
+  resource_group_name = data.azurerm_resource_group.products.name
 }
 
 # AKS

--- a/infrastructure/environments/non-prod/outputs.tf
+++ b/infrastructure/environments/non-prod/outputs.tf
@@ -26,6 +26,14 @@ output "products_static_web_url" {
   value = module.products.products_static_web_url
 }
 
+output "logs_resource_group_id" {
+  value = module.logs.logs_resource_group_id
+}
+
+output "logs_primary_access_key" {
+  value = module.logs.logs_primary_access_key
+}
+
 output "search_admin_key" {
   value = module.products.search_admin_key
 }

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -69,7 +69,7 @@ module logs {
 
   environment         = var.ENVIRONMENT
   location            = var.REGION
-  resource_group_name = data.azurerm_resource_group.keyvault.name
+  resource_group_name = data.azurerm_resource_group.products.name
 }
 
 # AKS
@@ -92,7 +92,7 @@ module cluster {
   default_node_count                    = "3"
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
   log_cluster_diagnostics               = true
-  logs_storage_account_id               = azurerm_storage_account.logs.id
+  logs_storage_account_id               = module.logs.logs_resource_group_id
 }
 
 # Service Bus

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -63,6 +63,15 @@ data "azurerm_subnet" "load_balancer" {
   virtual_network_name = data.azurerm_virtual_network.cluster.name
 }
 
+# Logs
+module logs {
+  source = "../../modules/logs"
+
+  environment         = var.ENVIRONMENT
+  location            = var.REGION
+  resource_group_name = data.azurerm_resource_group.keyvault.name
+}
+
 # AKS
 module cluster {
   source = "../../modules/cluster"
@@ -83,7 +92,7 @@ module cluster {
   default_node_count                    = "3"
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
   log_cluster_diagnostics               = true
-  diagnostic_setting_name               = "production-cluster-diagnostics"
+  logs_storage_account_id               = azurerm_storage_account.logs.id
 }
 
 # Service Bus

--- a/infrastructure/environments/prod/outputs.tf
+++ b/infrastructure/environments/prod/outputs.tf
@@ -53,3 +53,11 @@ output "storage_account_name" {
 output "storage_master_key" {
   value = module.products.storage_access_key
 }
+
+output "logs_resource_group_id" {
+  value = module.logs.logs_resource_group_id
+}
+
+output "logs_primary_access_key" {
+  value = module.logs.logs_primary_access_key
+}

--- a/infrastructure/modules/cluster/diagnostics.tf
+++ b/infrastructure/modules/cluster/diagnostics.tf
@@ -1,23 +1,8 @@
-resource "azurerm_storage_account" "logs" {
-  count                    = var.log_cluster_diagnostics ? 1 : 0
-  name                     = "logs"
-  resource_group_name      = var.resource_group_name
-  location                 = var.location
-  account_kind             = "StorageV2"
-  account_tier             = "Standard"
-  account_replication_type = "RAGRS"
-  access_tier              = "Cool"
-
-  tags = {
-    environment = var.environment
-  }
-}
-
 resource "azurerm_monitor_diagnostic_setting" "cluster" {
   count              = var.log_cluster_diagnostics ? 1 : 0
-  name               = var.diagnostic_setting_name
+  name               = "cluster-diagnostics-${var.environment}"
   target_resource_id = azurerm_kubernetes_cluster.cluster.id
-  storage_account_id = azurerm_storage_account.logs[0].id
+  storage_account_id = var.logs_storage_account_id
 
   dynamic "log" {
     for_each = var.diagnostic_log_types

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -66,11 +66,6 @@ variable "log_cluster_diagnostics" {
   default     = false
 }
 
-variable "diagnostic_setting_name" {
-  description = "Name of the diagnostic collection setting that saves auditable logs from the cluster"
-  default     = ""
-}
-
 variable "diagnostic_log_types" {
   description = "Set of log types to create configuration for"
   type        = list(string)
@@ -79,4 +74,9 @@ variable "diagnostic_log_types" {
     "kube-controller-manager",
     "kube-scheduler",
   "cluster-autoscaler"]
+}
+
+variable "logs_storage_account_id" {
+  description = "ID of the immutable storage account used for logs"
+  default     = ""
 }

--- a/infrastructure/modules/logs/main.tf
+++ b/infrastructure/modules/logs/main.tf
@@ -1,0 +1,36 @@
+resource "azurerm_storage_account" "logs" {
+  name                     = replace("logs${var.environment}", "-", "")
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "RAGRS"
+
+  tags = {
+    environment = var.environment
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_storage_container" "transaction_logs" {
+  name                  = "transaction-logs"
+  storage_account_name  = azurerm_storage_account.logs.name
+  container_access_type = "container"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_storage_container" "docs_snapshot_logs" {
+  name                  = "transaction-logs"
+  storage_account_name  = azurerm_storage_account.logs.name
+  container_access_type = "container"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infrastructure/modules/logs/output.tf
+++ b/infrastructure/modules/logs/output.tf
@@ -1,0 +1,7 @@
+output "logs_primary_access_key" {
+  value = azurerm_storage_account.logs.primary_access_key
+}
+
+output "logs_resource_group_id" {
+  value = azurerm_storage_account.logs.id
+}

--- a/infrastructure/modules/logs/variables.tf
+++ b/infrastructure/modules/logs/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {
+  description = "Resource group name"
+}
+variable "location" {
+  description = "Resource group location"
+}
+variable "environment" {
+  description = "Environment name to use as a tag"
+}


### PR DESCRIPTION
# Add immutable, environment specific log storage account

Adds logging-specific storage account as a separate module, with delete protection to ensure it's immutable.

This will allow a single, centralised place to store cluster logs, audit logs and docs snapshots (the latter 2 are on the way).

![](https://media.giphy.com/media/3orif7jbVVhqy0ba1O/giphy.gif)

### Acceptance Criteria

- [ ] Unique and distinguishable log storage account created per environment
- [ ] Protection to prevent accidental deletion

### Testing information

- `terraform init`
- `terraform plan`
- storage account resource identified for creation

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
