### PR TITLE
Implict workflow in app reg in order to use getToken

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -50,6 +50,7 @@ module "products" {
   pars_namespace           = local.pars_namespace
   resource_group_name      = azurerm_resource_group.products.name
   add_local_pars_reply_url = true
+  app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
 # website

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -49,6 +49,7 @@ module "products" {
   namespace           = local.namespace
   pars_namespace      = local.pars_namespace
   resource_group_name = azurerm_resource_group.products.name
+  app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
 # website

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -45,6 +45,7 @@ module "products" {
   pars_namespace      = local.pars_namespace
   resource_group_name = data.azurerm_resource_group.products.name
   search_sku          = "standard"
+  app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
 data "azurerm_route_table" "load_balancer" {

--- a/infrastructure/modules/products/app-registrations.tf
+++ b/infrastructure/modules/products/app-registrations.tf
@@ -4,6 +4,7 @@ resource "azuread_application" "pars-upload" {
   group_membership_claims = "SecurityGroup"
   homepage                = "https://${azurerm_cdn_endpoint.pars.host_name}" #don't think we need this
   oauth2_allow_implicit_flow = true
+  owners = var.app_registration_owners
   app_role {
     allowed_member_types = [
       "User",

--- a/infrastructure/modules/products/app-registrations.tf
+++ b/infrastructure/modules/products/app-registrations.tf
@@ -1,9 +1,9 @@
 resource "azuread_application" "pars-upload" {
   name                    = "pars-upload-${var.environment}"
   reply_urls              = concat(["https://${azurerm_cdn_endpoint.pars.host_name}"], var.add_local_pars_reply_url ? ["http://localhost:3000"] : [])
-  group_membership_claims = "All"
+  group_membership_claims = "SecurityGroup"
   homepage                = "https://${azurerm_cdn_endpoint.pars.host_name}" #don't think we need this
-
+  oauth2_allow_implicit_flow = true
   app_role {
     allowed_member_types = [
       "User",

--- a/infrastructure/modules/products/variables.tf
+++ b/infrastructure/modules/products/variables.tf
@@ -27,3 +27,7 @@ variable "add_local_pars_reply_url" {
   description = "Whether to add http://localhost:3000 to allowable redirect urls"
   default     = false
 }
+
+variable "app_registration_owners" {
+  description = "Users who can update the app registration settings"
+}

--- a/medicines/pars-upload/src/auth/authPopup.js
+++ b/medicines/pars-upload/src/auth/authPopup.js
@@ -6,14 +6,7 @@ export async function getAccount() {
   const account = msalInstance.getAccount()
 
   if (account) {
-    // TODO:
-    //
-    // Temporary hack whilst we wait for implicit granting of ID tokens to be
-    // enabled by MHRA admins so we get an access token in the proper way:
-    // https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-core#3-get-an-access-token-to-call-an-api
-
-    const token = window.sessionStorage['msal.idtoken']
-    // const token = await getToken(msalInstance)
+    const token = await getToken(msalInstance)
 
     return {
       account,


### PR DESCRIPTION
This allows the app registration to use the implicit workflow as per microsoft recommendations.

It enables the code @sgrowe left in to use, and removes the direct call to session storage.

It also adds ownership of the app registration to all the developers so that they don't get 403 errors when running terraform apply.

![](https://media.giphy.com/media/QZ7VjdCalspZZYNQM1/giphy.gif)