### PR TITLE
access token

### DIFF
--- a/medicines/pars-upload/src/auth/authPopup.js
+++ b/medicines/pars-upload/src/auth/authPopup.js
@@ -6,7 +6,8 @@ export async function getAccount() {
   const account = msalInstance.getAccount()
 
   if (account) {
-    const token = await getToken(msalInstance)
+    const token = (await getToken(msalInstance)).accessToken
+    console.log({ token })
 
     return {
       account,


### PR DESCRIPTION
# Use the access token

Previously we were sending a `Bearer [object Object]` as the token. That's not right.