### PR TITLE
westeurope cdn location for cpd

### DIFF
--- a/infrastructure/modules/cpd/main.tf
+++ b/infrastructure/modules/cpd/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_storage_container" "cpd_website" {
 
 resource "azurerm_cdn_profile" "cpd" {
   name                = "mhracpd${var.environment}"
-  location            = var.location
+  location            = var.cdn_region
   resource_group_name = var.resource_group_name
   sku                 = "Standard_Microsoft"
 }

--- a/infrastructure/modules/cpd/variables.tf
+++ b/infrastructure/modules/cpd/variables.tf
@@ -10,3 +10,7 @@ variable "environment" {
 variable "namespace" {
   description = "Namespace to use on cluster and storage"
 }
+variable "cdn_region" {
+  description = "Region where the CDN profile should be deployed"
+  default     = "westeurope" # uksouth is not a valid option currently for cdn profiles
+}


### PR DESCRIPTION
# westeurope cdn location for cpd

`uksouth` is not a valid location for a CDN
