### PR TITLE
Pars upload release

### DIFF
--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -10,6 +10,7 @@ env:
   PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
   # above is for cypress, below is for next.js
   NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
+  NEXT_PUBLIC_REDIRECT_URI: "https://mhraparsproduction.azureedge.net"
 
 jobs:
   build:
@@ -86,7 +87,7 @@ jobs:
           {
             echo "NEXT_PUBLIC_CLIENT_ID=26f95b21-63b2-475f-8a35-d39cea4cfd61"
             echo "NEXT_PUBLIC_AUTHORITY_URL=https://login.microsoftonline.com/e527ea5c-6258-4cd2-a27f-8bd237ec4c26"
-            echo "NEXT_PUBLIC_REDIRECT_URI=https://mhraparsproduction.azureedge.net"
+            echo "NEXT_PUBLIC_REDIRECT_URI=\"$NEXT_PUBLIC_REDIRECT_URI\"""
             echo "NEXT_PUBLIC_DISABLE_AUTH=\"$NEXT_PUBLIC_DISABLE_AUTH\""
             echo "NEXT_PUBLIC_PARS_UPLOAD_URL=\"$NEXT_PUBLIC_PARS_UPLOAD_URL\""
             echo "PARS_UPLOAD_URL=\"$PARS_UPLOAD_URL\""

--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -1,0 +1,105 @@
+name: pars-upload-release
+
+on:
+  push:
+    tags:
+      - parsupload.v*
+
+env:
+  NEXT_PUBLIC_DISABLE_AUTH: false
+  PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
+  # above is for cypress, below is for next.js
+  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
+
+jobs:
+  build:
+    name: Build, test, create release and deploy to prodcution and check pars-upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "13.11"
+
+      # Based on https://github.com/actions/cache/blob/master/examples.md#node---yarn
+      - name: Get yarn cache path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        name: Cache yarn dependencies
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('medicines/pars-upload/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # See: https://github.com/zeit/next.js/blob/master/errors/no-cache.md
+      - uses: actions/cache@v1
+        name: Cache Next.js cache folder
+        with:
+          path: medicines/pars-upload/.next/cache
+          key: ${{ runner.os }}-next-js-${{ hashFiles('medicines/pars-upload/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-next-js-
+
+      - name: Install modules
+        working-directory: medicines/pars-upload
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests with coverage
+        working-directory: medicines/pars-upload
+        run: yarn test:ci
+
+      - name: Build
+        working-directory: medicines/pars-upload
+        run: yarn build
+
+      - name: Run cypress end-to-end tests
+        working-directory: medicines/pars-upload
+        run: make e2e
+
+      - name: Upload cypress screenshots
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: medicines-cypress-screenshots
+          path: medicines/pars-upload/cypress/screenshots
+
+      - name: Upload cypress videos
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: medicines-cypress-videos
+          path: medicines/pars-upload/cypress/videos
+
+      - name: Accessibility check
+        working-directory: medicines/pars-upload
+        run: yarn a11y
+
+      - name: PRODUCTION - Create .env file
+        working-directory: medicines/pars-upload
+        run: |
+          {
+            echo "NEXT_PUBLIC_CLIENT_ID=26f95b21-63b2-475f-8a35-d39cea4cfd61"
+            echo "NEXT_PUBLIC_AUTHORITY_URL=https://login.microsoftonline.com/e527ea5c-6258-4cd2-a27f-8bd237ec4c26"
+            echo "NEXT_PUBLIC_REDIRECT_URI=https://mhraparsproduction.azureedge.net"
+            echo "NEXT_PUBLIC_DISABLE_AUTH=\"$NEXT_PUBLIC_DISABLE_AUTH\""
+            echo "NEXT_PUBLIC_PARS_UPLOAD_URL=\"$NEXT_PUBLIC_PARS_UPLOAD_URL\""
+            echo "PARS_UPLOAD_URL=\"$PARS_UPLOAD_URL\""
+          } > .env
+
+      - name: PRODUCTION - Build static site
+        working-directory: medicines/pars-upload
+        run: yarn export
+
+      - name: PRODUCTION - Deploy pars upload website to static site in azure storage
+        # master causes this step to fail so pointing to last working commit until fixed
+        uses: lauchacarro/Azure-Storage-Action@9225056
+        with:
+          enabled-static-website: true
+          folder: medicines/pars-upload/out
+          connection-string: ${{ secrets.AZURE_STORAGE_PARS_WEB_CONNECTION_STRING_PRODUCTION }}

--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -97,6 +97,19 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn export
 
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: PARs Upload form website release ${{ github.ref }}
+          body: |
+            Release of internal PARs Upload form website
+          draft: false
+          prerelease: false
+
       - name: PRODUCTION - Deploy pars upload website to static site in azure storage
         # master causes this step to fail so pointing to last working commit until fixed
         uses: lauchacarro/Azure-Storage-Action@9225056


### PR DESCRIPTION
# PARS upload release

Workflow for getting pars out in the world.

- [x] trigger is creation of a tag like `parsupload.v*`
- [x] checks and tests are run
- [x] github release is created
- [x] pars-upload push to production private blob container
- [ ] purges the production cache of the CDN (unnecessary if we have HTML cache off) (we're not doing this for the products.mhra.gov.uk website – do we really need it?)

Currently:

- [x] *reply URL used is the CDN one*, not the public DNS one

I'm not sure we can change this to the external DNS .gov.uk yet. I certainly don't know what it is.