### PR TITLE
Fix second submission of the form errorring

### DIFF
--- a/medicines/pars-upload/src/review_submission.js
+++ b/medicines/pars-upload/src/review_submission.js
@@ -63,7 +63,12 @@ export const ReviewSubmission = ({
         }
       })}
 
-      <Button type="button" onClick={submit}>
+      <Button
+        type="button"
+        onClick={() => {
+          submit(null)
+        }}
+      >
         Accept and send
       </Button>
     </Layout>


### PR DESCRIPTION
When you click “Accept and Send” on the review page the click event handler mistakenly sets the click event as the “data” for that page, so when you hit send again it tries to include the click event in the form data and throws a `TypeError`