### PR TITLE
Add logs namespace

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -20,6 +20,7 @@ locals {
   namespace        = "mhraproductsdevelopment"
   pars_namespace   = "mhraparsdevelopment"
   service_bus_name = "doc-index-updater-${var.ENVIRONMENT}"
+  logs_namespace   = "mhralogs${var.ENVIRONMENT}"
 }
 
 resource "azurerm_resource_group" "products" {
@@ -50,7 +51,7 @@ module "products" {
   pars_namespace           = local.pars_namespace
   resource_group_name      = azurerm_resource_group.products.name
   add_local_pars_reply_url = true
-  app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
+  app_registration_owners  = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
 # website
@@ -91,6 +92,7 @@ resource "azurerm_subnet" "load_balancer" {
 module logs {
   source = "../../modules/logs"
 
+  namespace           = local.logs_namespace
   environment         = var.ENVIRONMENT
   location            = var.REGION
   resource_group_name = azurerm_resource_group.products.name

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -20,6 +20,7 @@ locals {
   namespace        = "mhraproductsnonprod"
   pars_namespace   = "mhraparsnonprod"
   service_bus_name = "doc-index-updater-${var.ENVIRONMENT}"
+  logs_namespace   = replace("mhralogs${var.ENVIRONMENT}", "-", "")
 }
 
 resource "azurerm_resource_group" "products" {
@@ -44,11 +45,11 @@ resource "azurerm_subnet_route_table_association" "load_balancer" {
 module "products" {
   source = "../../modules/products"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  namespace           = local.namespace
-  pars_namespace      = local.pars_namespace
-  resource_group_name = azurerm_resource_group.products.name
+  environment             = var.ENVIRONMENT
+  location                = var.REGION
+  namespace               = local.namespace
+  pars_namespace          = local.pars_namespace
+  resource_group_name     = azurerm_resource_group.products.name
   app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
@@ -83,6 +84,7 @@ resource "azurerm_subnet" "load_balancer" {
 module logs {
   source = "../../modules/logs"
 
+  namespace           = local.logs_namespace
   environment         = var.ENVIRONMENT
   location            = var.REGION
   resource_group_name = azurerm_resource_group.products.name

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -20,6 +20,7 @@ locals {
   namespace        = "mhraproducts${var.ENVIRONMENT}"
   pars_namespace   = "mhrapars${var.ENVIRONMENT}"
   service_bus_name = "doc-index-updater-${var.ENVIRONMENT}"
+  logs_namespace   = "mhralogs${var.ENVIRONMENT}"
 }
 
 data "azurerm_resource_group" "products" {
@@ -39,12 +40,12 @@ resource "azurerm_resource_group" "keyvault" {
 module "products" {
   source = "../../modules/products"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  namespace           = local.namespace
-  pars_namespace      = local.pars_namespace
-  resource_group_name = data.azurerm_resource_group.products.name
-  search_sku          = "standard"
+  environment             = var.ENVIRONMENT
+  location                = var.REGION
+  namespace               = local.namespace
+  pars_namespace          = local.pars_namespace
+  resource_group_name     = data.azurerm_resource_group.products.name
+  search_sku              = "standard"
   app_registration_owners = var.KEYVAULT_AUTHORISED_PERSON_IDS
 }
 
@@ -68,6 +69,7 @@ data "azurerm_subnet" "load_balancer" {
 module logs {
   source = "../../modules/logs"
 
+  namespace           = local.logs_namespace
   environment         = var.ENVIRONMENT
   location            = var.REGION
   resource_group_name = data.azurerm_resource_group.products.name

--- a/infrastructure/modules/cpd/variables.tf
+++ b/infrastructure/modules/cpd/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
   description = "Environment name to use as a tag"
 }
 variable "namespace" {
-  description = "Namespace to use on cluster and storage"
+  description = "Namespace to use on resources"
 }
 variable "cdn_region" {
   description = "Region where the CDN profile should be deployed"

--- a/infrastructure/modules/logs/main.tf
+++ b/infrastructure/modules/logs/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "logs" {
-  name                     = replace("logs${var.environment}", "-", "")
+  name                     = var.namespace
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_kind             = "StorageV2"

--- a/infrastructure/modules/logs/variables.tf
+++ b/infrastructure/modules/logs/variables.tf
@@ -7,3 +7,6 @@ variable "location" {
 variable "environment" {
   description = "Environment name to use as a tag"
 }
+variable "namespace" {
+  description = "Namespace to use on resources"
+}


### PR DESCRIPTION
# Add logs namespace

Currently the logs storage account is configured to be named e.g. `logsproduction` or `logsdev` - `terraform apply` fails because these are not unique in Azure. This PR adds a log namespace featuring `logsmhra` and the environment to make the name unique.

![](https://media.giphy.com/media/l0HlTy9x8FZo0XO1i/giphy.gif)

### Acceptance Criteria

- [ ] Can terraform apply without complaint.

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
