### PR TITLE
Remove check for authorization header for update pars path

### DIFF
--- a/medicines/doc-index-updater/src/pars_upload.rs
+++ b/medicines/doc-index-updater/src/pars_upload.rs
@@ -31,7 +31,7 @@ pub fn update_handler(
         // Max upload size is set to a very high limit here as the actual limit should be managed using istio
         .and(warp::multipart::form().max_length(1000 * 1024 * 1024))
         .and(with_state(state_manager))
-        .and(warp::header("Authorization"))
+        .and(warp::header("username"))
         .and_then(update_pars_handler)
         .with(cors)
 }


### PR DESCRIPTION
# Remove check for authorization header for update pars path

Update to the upload handler was not added to the update handler.
The authorization header is stripped by Istio so we check the username header instead.

### Acceptance Criteria

- [ ] _The first thing this PR must achieve_
- [ ] _The second thing this PR must achieve_
- [ ] _etc_

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
