### PR TITLE
Timlee/par file remains

### DIFF
--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -136,7 +136,38 @@ describe('PARs upload', () => {
       uploadData.brand
     )
   })
+  it('shows the uploaded file when going back to upload file page', () => {
+    cy.visit('/new-par')
+    let uploadData = {
+      brand: 'Ibuprofen pills',
+      strength: 'Really powerful stuff',
+      doseForm: 'some form',
+      substances: ['Ibuprofen', 'Paracetamol'],
+      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
+    }
+    completeUploadForm(uploadData)
 
+    const fileName = 'rabbit-anti-human-stuff.pdf'
+    completeUploadFile(fileName)
+
+    cy.findByText('Document')
+      .parent()
+      .within(() => {
+        cy.findAllByText('Change').last().click()
+      })
+
+    cy.findByText(`Current file`).should('exist')
+    cy.findByText(`Upload new file instead`).should('exist')
+    cy.findByText(fileName).should('exist')
+
+    cy.findAllByText('Continue').last().click()
+    cy.findByText('Current file').should('exist')
+
+    cy.findAllByText('Continue').first().click()
+    cy.findAllByText('Check your answers before sending the report')
+      .not('title')
+      .should('have.length', 1)
+  })
   it('can submit the form sucessfully', () => {
     if (parsUrl) {
       cy.log('Mocking form submissions endpoint')

--- a/medicines/pars-upload/cypress/integration/update-par.js
+++ b/medicines/pars-upload/cypress/integration/update-par.js
@@ -145,7 +145,38 @@ describe('PARs update', () => {
       uploadData.brand
     )
   })
+  it('shows the uploaded file when going back to upload file page', () => {
+    cy.visit('/new-par')
+    let uploadData = {
+      brand: 'Ibuprofen pills',
+      strength: 'Really powerful stuff',
+      doseForm: 'some form',
+      substances: ['Ibuprofen', 'Paracetamol'],
+      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
+    }
+    completeUploadForm(uploadData)
 
+    const fileName = 'rabbit-anti-human-stuff.pdf'
+    completeUploadFile(fileName)
+
+    cy.findByText('Document')
+      .parent()
+      .within(() => {
+        cy.findAllByText('Change').last().click()
+      })
+
+    cy.findByText(`Current file`).should('exist')
+    cy.findByText(`Upload new file instead`).should('exist')
+    cy.findByText(fileName).should('exist')
+
+    cy.findAllByText('Continue').last().click()
+    cy.findByText('Current file').should('exist')
+
+    cy.findAllByText('Continue').first().click()
+    cy.findAllByText('Check your answers before sending the report')
+      .not('title')
+      .should('have.length', 1)
+  })
   it('can submit the form sucessfully', () => {
     let parToUpdateId = 'aso1901290udkldf901'
 

--- a/medicines/pars-upload/src/field.js
+++ b/medicines/pars-upload/src/field.js
@@ -19,7 +19,8 @@ export const Field = ({
 
   const defaultValue =
     (formData && formData.getAll(name)[index || 0]) || undefined
-
+  console.log('Rendering field with value')
+  console.log(defaultValue)
   const labelEl = (
     <label className="govuk-label" htmlFor={id}>
       {label}

--- a/medicines/pars-upload/src/field.js
+++ b/medicines/pars-upload/src/field.js
@@ -19,8 +19,6 @@ export const Field = ({
 
   const defaultValue =
     (formData && formData.getAll(name)[index || 0]) || undefined
-  console.log('Rendering field with value')
-  console.log(defaultValue)
   const labelEl = (
     <label className="govuk-label" htmlFor={id}>
       {label}

--- a/medicines/pars-upload/src/get_par_to_update.js
+++ b/medicines/pars-upload/src/get_par_to_update.js
@@ -5,7 +5,7 @@ import { Field } from './field'
 import { Button } from './button'
 import { FormGroup } from './form'
 
-export const GetParToUpdate = ({ goBack, submit }) => {
+export const GetParToUpdate = ({ currentStepData, goBack, submit }) => {
   const onSubmit = (event) => {
     event.preventDefault()
     const formData = new FormData(event.target)
@@ -26,6 +26,7 @@ export const GetParToUpdate = ({ goBack, submit }) => {
             pattern="https:\/\/[a-zA-Z0-9.]+\/docs\/[a-zA-Z0-9]+"
             name="par_url"
             label="Please insert URL"
+            formData={currentStepData}
             helpContents={
               <span>
                 In order to find the right document, please search for the

--- a/medicines/pars-upload/src/upload_pdf.js
+++ b/medicines/pars-upload/src/upload_pdf.js
@@ -1,14 +1,21 @@
 import { Layout } from './layout'
-import { H1 } from './typography'
+import { H1, H2 } from './typography'
 import { BackLink } from './back-link'
 import { Field } from './field'
 import { Button } from './button'
+import { SummaryListWithoutActions } from './summary_list'
 
-export const UploadPdf = ({ goBack, submit }) => {
+export const UploadPdf = ({ currentStepData, goBack, submit }) => {
   const onSubmit = (event) => {
     event.preventDefault()
+
     const formData = new FormData(event.target)
+
     submit(formData)
+  }
+
+  const onContinue = () => {
+    submit(currentStepData)
   }
 
   const goToPrevPage = (event) => {
@@ -22,7 +29,15 @@ export const UploadPdf = ({ goBack, submit }) => {
       intro={<BackLink href="/" onClick={goToPrevPage} />}
     >
       <H1>Upload your PDF</H1>
-
+      {currentStepData && (
+        <>
+          <CurrentlyUploadedFile
+            file={currentStepData.get('file')}
+            continueAction={onContinue}
+          />
+          <H2>Upload new file instead</H2>
+        </>
+      )}
       <form onSubmit={onSubmit}>
         <Field name="file" label="File" type="file" />
 
@@ -31,3 +46,18 @@ export const UploadPdf = ({ goBack, submit }) => {
     </Layout>
   )
 }
+
+const CurrentlyUploadedFile = ({ file, continueAction }) => (
+  <div>
+    <H2>Current file</H2>
+    <SummaryListWithoutActions
+      items={[
+        {
+          key: 'Document name',
+          value: file.name,
+        },
+      ]}
+    />
+    <Button onClick={continueAction}>Continue</Button>
+  </div>
+)


### PR DESCRIPTION
# PAR file remains

Addresses #885 

When going back to PAR upload file step, the currently uploaded document shows and the user can continue without having to upload the same document again.

### Acceptance Criteria

- [ ] User sees "upload file" the first time going through the form
- [ ] When coming back to the step, the user sees their currently uploaded file and can continue without submitting a new one
- [ ] User can optionally add a new file if they wanted to replace it

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
