### PR TITLE
Add resiliency by checking page rendered

### DIFF
--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -15,10 +15,10 @@ on:
       - .github/workflows/pars-upload-master.yaml
 
 env:
-  NEXT_PUBLIC_DISABLE_AUTH: false
-  PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
+  NEXT_PUBLIC_DISABLE_AUTH: true
+  PARS_UPLOAD_URL: "https://doc-index-updater-dev.test.mhra.gov.uk/pars"
   # above is for cypress, below is for next.js
-  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
+  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater-dev.test.mhra.gov.uk/pars"
   NONPROD_PARS_APP_ID: ac2b59e9-77ca-4d39-8186-b96d305c9aae
 
 jobs:

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -60,6 +60,10 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn install --frozen-lockfile
 
+        - name: Build
+        working-directory: medicines/pars-upload
+        run: yarn build
+
       - name: Run tests with coverage
         working-directory: medicines/pars-upload
         run: yarn test:ci
@@ -68,9 +72,9 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn lint
 
-      - name: Build
+        - name: Accessibility check
         working-directory: medicines/pars-upload
-        run: yarn build
+        run: yarn a11y
 
       - name: Run cypress end-to-end tests
         working-directory: medicines/pars-upload
@@ -90,9 +94,6 @@ jobs:
           name: medicines-cypress-videos
           path: medicines/pars-upload/cypress/videos
 
-      - name: Accessibility check
-        working-directory: medicines/pars-upload
-        run: yarn a11y
 
       - name: NON-PROD - Create .env file
         working-directory: medicines/pars-upload

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -7,6 +7,12 @@ on:
     paths:
       - medicines/pars-upload/**
       - .github/workflows/pars-upload-master.yaml
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - medicines/pars-upload/**
+      - .github/workflows/pars-upload-master.yaml
 
 env:
   NEXT_PUBLIC_DISABLE_AUTH: false

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -15,10 +15,10 @@ on:
       - .github/workflows/pars-upload-master.yaml
 
 env:
-  NEXT_PUBLIC_DISABLE_AUTH: true
-  PARS_UPLOAD_URL: "https://doc-index-updater-dev.test.mhra.gov.uk/pars"
+  NEXT_PUBLIC_DISABLE_AUTH: false
+  PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
   # above is for cypress, below is for next.js
-  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater-dev.test.mhra.gov.uk/pars"
+  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
   NONPROD_PARS_APP_ID: ac2b59e9-77ca-4d39-8186-b96d305c9aae
 
 jobs:

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn lint
 
-        - name: Accessibility check
+      - name: Accessibility check
         working-directory: medicines/pars-upload
         run: yarn a11y
 
@@ -93,7 +93,6 @@ jobs:
         with:
           name: medicines-cypress-videos
           path: medicines/pars-upload/cypress/videos
-
 
       - name: NON-PROD - Create .env file
         working-directory: medicines/pars-upload

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -60,7 +60,7 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn install --frozen-lockfile
 
-        - name: Build
+      - name: Build
         working-directory: medicines/pars-upload
         run: yarn build
 

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -7,12 +7,6 @@ on:
     paths:
       - medicines/pars-upload/**
       - .github/workflows/pars-upload-master.yaml
-  pull_request:
-    branches:
-      - "master"
-    paths:
-      - medicines/pars-upload/**
-      - .github/workflows/pars-upload-master.yaml
 
 env:
   NEXT_PUBLIC_DISABLE_AUTH: false

--- a/medicines/pars-upload/cypress/integration/home.js
+++ b/medicines/pars-upload/cypress/integration/home.js
@@ -12,6 +12,8 @@ describe('Home page', () => {
 
     cy.visit('/')
 
+    cy.findAllByText('What are you doing today?').should('exist')
+
     cy.findByText('Upload a new document').click()
 
     cy.findByText('Continue').click()
@@ -24,6 +26,8 @@ describe('Home page', () => {
       cy.server()
 
       cy.visit('/')
+
+      cy.findAllByText('What are you doing today?').should('exist')
 
       cy.findByText('Update an existing document').click()
 

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -28,7 +28,8 @@ describe('PARs upload', () => {
       substance2: 'Paracetamol',
       substance3: 'Temazepam',
     }
-    addAndDeleteSubstances(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    addAndDeleteSubstances(uploadData, uploadPageTitle)
   })
 
   it('can add and delete multiple products', () => {
@@ -41,7 +42,8 @@ describe('PARs upload', () => {
       substance2: 'Paracetamol',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    addAndDeleteProducts(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    addAndDeleteProducts(uploadData, uploadPageTitle)
   })
   it('duplicate licence numbers are not allowed', () => {
     cy.visit('/new-par')
@@ -54,8 +56,8 @@ describe('PARs upload', () => {
       substance2: 'Paracetamol',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-
-    addDuplicateLicenceNumbers(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
   })
   it('upload field only accepts PDFs', () => {
     cy.visit('/new-par')
@@ -67,7 +69,8 @@ describe('PARs upload', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.txt'
     const expectedTitle = 'Upload your PDF'
@@ -88,7 +91,8 @@ describe('PARs upload', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload your PDF'
@@ -168,7 +172,8 @@ describe('PARs upload', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload your PDF'
@@ -210,7 +215,8 @@ describe('PARs upload', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'New Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload your PDF'

--- a/medicines/pars-upload/cypress/integration/update-par.js
+++ b/medicines/pars-upload/cypress/integration/update-par.js
@@ -31,7 +31,8 @@ describe('PARs update', () => {
       substance2: 'Paracetamol',
       substance3: 'Temazepam',
     }
-    addAndDeleteSubstances(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    addAndDeleteSubstances(uploadData, uploadPageTitle)
   })
 
   it('can add and delete multiple products', () => {
@@ -46,7 +47,8 @@ describe('PARs update', () => {
       substance2: 'Paracetamol',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    addAndDeleteProducts(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    addAndDeleteProducts(uploadData, uploadPageTitle)
   })
 
   it('duplicate licence numbers are not allowed', () => {
@@ -61,7 +63,8 @@ describe('PARs update', () => {
       substance2: 'Paracetamol',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    addDuplicateLicenceNumbers(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
   })
   it('upload field only accepts PDFs', () => {
     cy.visit('/update-par')
@@ -74,7 +77,8 @@ describe('PARs update', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.txt'
     const expectedTitle = 'Upload a replacement PDF'
@@ -97,7 +101,8 @@ describe('PARs update', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload a replacement PDF'
@@ -179,7 +184,8 @@ describe('PARs update', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload a replacement PDF'
@@ -225,7 +231,8 @@ describe('PARs update', () => {
       substances: ['Ibuprofen', 'Paracetamol'],
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
-    completeUploadForm(uploadData)
+    let uploadPageTitle = 'Updated Public Assessment Report'
+    completeUploadForm(uploadData, uploadPageTitle)
 
     const fileName = 'rabbit-anti-human-stuff.pdf'
     const expectedTitle = 'Upload a replacement PDF'

--- a/medicines/pars-upload/cypress/support/shared.js
+++ b/medicines/pars-upload/cypress/support/shared.js
@@ -49,11 +49,16 @@ export const mockSuccessfulSubmission = (baseUrl, url) => {
 }
 
 export const completeFindParToUpdateStep = (parUrl) => {
+  cy.findAllByText('Search for an existing Public Assessment Report')
+    .not('title')
+    .should('exist')
   cy.findByLabelText('Please insert URL').type(parUrl)
   cy.findByText('Continue').click()
 }
 
-export const addAndDeleteSubstances = (uploadData) => {
+export const addAndDeleteSubstances = (uploadData, expectedTitle) => {
+  cy.findAllByText(expectedTitle).not('title').should('exist')
+
   cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
   cy.findByLabelText('Strength').type(uploadData.strength)
@@ -89,7 +94,9 @@ export const addAndDeleteSubstances = (uploadData) => {
     .should('have.value', uploadData.substance3)
 }
 
-export const addAndDeleteProducts = (uploadData) => {
+export const addAndDeleteProducts = (uploadData, expectedTitle) => {
+  cy.findAllByText(expectedTitle).not('title').should('exist')
+
   cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
   cy.findByLabelText('Strength').type(uploadData.strength)
@@ -141,7 +148,9 @@ export const addAndDeleteProducts = (uploadData) => {
   cy.findByLabelText('Brand/Generic name').should('have.value', '')
 }
 
-export const addDuplicateLicenceNumbers = (uploadData) => {
+export const addDuplicateLicenceNumbers = (uploadData, expectedTitle) => {
+  cy.findAllByText(expectedTitle).not('title').should('exist')
+
   for (let i = 0; i < 2; i++) {
     cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
@@ -191,7 +200,9 @@ export const addDuplicateLicenceNumbers = (uploadData) => {
     })
 }
 
-export const completeUploadForm = (uploadData) => {
+export const completeUploadForm = (uploadData, expectedTitle) => {
+  cy.findAllByText(expectedTitle).not('title').should('exist')
+
   cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
   cy.findByLabelText('Strength').type(uploadData.strength)
@@ -221,7 +232,7 @@ export const completeUploadForm = (uploadData) => {
 }
 
 export const completeUploadFile = (fileName, expectedTitle) => {
-  cy.findAllByText(expectedTitle).not('title').should('have.length', 1)
+  cy.findAllByText(expectedTitle).not('title').should('exist')
 
   cy.fixture(fileName).then((fileContent) => {
     // The `upload` method is provided by https://github.com/abramenal/cypress-file-upload/tree/v3.5.3


### PR DESCRIPTION
# Add resiliency by checking page rendered

Currently seeing flakey cypress tests in CI - on master build but not branch build.

By adding more assertions around page render (text can be found) before continuing, aiming to make the tests more resilient.

Also, moving the master build workflow steps to match the same order as the dev workflow for consistency.

### Acceptance Criteria

- [ ] Consistently passing CI tests

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
