### PR TITLE
Add formdata compatibility for ie11

### DIFF
--- a/medicines/pars-upload/src/layout.js
+++ b/medicines/pars-upload/src/layout.js
@@ -4,6 +4,7 @@ export const Layout = ({ title, intro = null, children }) => (
   <div className="govuk-width-container">
     <Head>
       <title>{title}</title>
+      <meta httpEquiv="X-UA-Compatible" content="IE=edge"></meta>
     </Head>
 
     {intro}


### PR DESCRIPTION
# Add formdata compatibility for ie11

This metadata tag should allow IE11 to properly use formdata.

### Acceptance Criteria

- [ ] Formdata works for IE11

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
