### PR TITLE
Update PARs release workflow to match master workflow

### DIFF
--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -59,6 +59,14 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn test:ci
 
+      - name: Lint
+        working-directory: medicines/pars-upload
+        run: yarn lint
+
+      - name: Accessibility check
+        working-directory: medicines/pars-upload
+        run: yarn a11y
+
       - name: Run cypress end-to-end tests
         working-directory: medicines/pars-upload
         run: make e2e
@@ -76,10 +84,6 @@ jobs:
         with:
           name: medicines-cypress-videos
           path: medicines/pars-upload/cypress/videos
-
-      - name: Accessibility check
-        working-directory: medicines/pars-upload
-        run: yarn a11y
 
       - name: PRODUCTION - Create .env file
         working-directory: medicines/pars-upload

--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -51,13 +51,13 @@ jobs:
         working-directory: medicines/pars-upload
         run: yarn install --frozen-lockfile
 
-      - name: Run tests with coverage
-        working-directory: medicines/pars-upload
-        run: yarn test:ci
-
       - name: Build
         working-directory: medicines/pars-upload
         run: yarn build
+
+      - name: Run tests with coverage
+        working-directory: medicines/pars-upload
+        run: yarn test:ci
 
       - name: Run cypress end-to-end tests
         working-directory: medicines/pars-upload


### PR DESCRIPTION
# Update PARs release workflow to match master workflow 

Move build step to before test step to avoid known issue with first cypress test failing if run straight after build (still to be understood).

Also add in missing lint and accessibility checks.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
