### PR TITLE
Replace piper with async-dup

### DIFF
--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c13101a3224fb178860ae372a031ce350bbd92d39968518f016744dde0bf7"
+checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -115,12 +115,12 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "azure_sdk_core"
-version = "0.43.3"
+version = "0.43.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22bd912108bf1708b26c8b0b5a214dc22c61a142f44d7d2c9172df3a412c3cfa"
+checksum = "ccfd83685edb91d2ad9fc102a7bffacecc9af4626b36f202a5ce16a3f4a86240"
 dependencies = [
  "RustyXML",
- "base64 0.12.1",
+ "base64 0.12.2",
  "bytes",
  "chrono",
  "failure",
@@ -145,7 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2966221be0c9b2c8e6494834f8ab1813ceb82f51c3e68fdde998db126e184572"
 dependencies = [
  "azure_sdk_core",
- "base64 0.12.1",
+ "base64 0.12.2",
  "chrono",
  "hyper",
  "hyper-rustls",
@@ -163,7 +163,7 @@ dependencies = [
  "RustyXML",
  "azure_sdk_core",
  "azure_sdk_storage_core",
- "base64 0.12.1",
+ "base64 0.12.2",
  "chrono",
  "futures",
  "http",
@@ -184,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7649196fa43d671e80976ae4280d746005c8fd7d95a1eb9d29b6b455f0739f4"
 dependencies = [
  "azure_sdk_core",
- "base64 0.12.1",
+ "base64 0.12.2",
  "bytes",
  "chrono",
  "futures",
@@ -232,9 +232,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
 
 [[package]]
 name = "bitflags"
@@ -457,7 +457,7 @@ dependencies = [
  "azure_sdk_service_bus",
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",
- "base64 0.12.1",
+ "base64 0.12.2",
  "bytes",
  "chrono",
  "futures",
@@ -753,7 +753,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.2",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1656,7 +1656,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1850,9 +1850,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
 ]
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.110"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa199410fc9763cda6edb0d85d4c4ba7c1723024cddc7d129d14a2fc9f2a5e6"
+checksum = "d326d93a77b25d5516844911b9df1d02375405a5b2671c1d23b0fbd9ac7af4f3"
 dependencies = [
  "serde",
 ]
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "smol"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845f5e7db6b614a8f4f59e565c3035f0fab2f71c9537ff0119eddb60d866cae3"
+checksum = "afcf8beb4aa23cc616e3351e49585153b462637c8fec929163b54d88e522b3b0"
 dependencies = [
  "async-task",
  "crossbeam-deque",
@@ -2126,18 +2126,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/medicines/doc-index-updater/Cargo.lock
+++ b/medicines/doc-index-updater/Cargo.lock
@@ -40,6 +40,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "async-dup"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690ccbfa536b3c383403caf52a707cbc2c2f06155b3f7390fee92c7b755300db"
+dependencies = [
+ "futures-io",
+ "simple-mutex",
+]
+
+[[package]]
 name = "async-ssh2"
 version = "0.1.1-beta"
 source = "git+https://github.com/spebern/async-ssh2.git#787e2bc0ad966c2307db0ce444c2ba77d59bc7fe"
@@ -440,6 +450,7 @@ name = "doc_index_updater"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-dup",
  "async-ssh2",
  "async-trait",
  "azure_sdk_core",
@@ -455,7 +466,6 @@ dependencies = [
  "md5",
  "net2",
  "percent-encoding",
- "piper",
  "pretty_assertions",
  "redis",
  "regex",
@@ -496,6 +506,12 @@ checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3e266baec5d96df9ce33c5a20dba54ca460a16f577c41391203f9415ffd3ec"
 
 [[package]]
 name = "failure"
@@ -1921,6 +1937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "simple-mutex"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
+dependencies = [
+ "event-listener",
 ]
 
 [[package]]

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -25,12 +25,12 @@ redis = { version = "0.16.0", features = ["tokio-rt-core"] }
 regex = "1.3.9"
 reqwest = { version = "0.10.6", features = ["json"] }
 search_client =  { path = "../search-client" }
-serde = "1.0.111"
-serde_derive = "1.0.111"
+serde = "1.0.112"
+serde_derive = "1.0.112"
 serde_json = "1.0"
 sha1 = "0.6.0"
-smol = "0.1.11"
-thiserror = "1.0.19"
+smol = "0.1.12"
+thiserror = "1.0.20"
 time = "0.1.43"
 tokio = { version = "0.2", features = ["macros", "time"] }
 tracing = { version = "0.1", features = ["attributes"] }
@@ -38,14 +38,14 @@ tracing-futures = "0.2.4"
 tracing-log = "0.1.1"
 tracing-subscriber = "0.2.5"
 url = "2.1.1"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
 warp = { git = "https://github.com/m-doughty/warp", branch = "add-xml-support" }
 
 [dev-dependencies]
 net2 = "0.2.34"
 pretty_assertions = "0.6.1"
-serde_json = "1.0.53"
-serde_test = "1.0.110"
+serde_json = "1.0.55"
+serde_test = "1.0.112"
 serde-xml-rs = "0.4.0"
 test-case = "1.0.0"
 tokio-test = "0.2.1"

--- a/medicines/doc-index-updater/Cargo.toml
+++ b/medicines/doc-index-updater/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.31"
+async-dup = "1.0.1"
 async-ssh2 = { version = "0.1.1-beta", git = "https://github.com/spebern/async-ssh2.git" }
 async-trait = "0.1.33"
 azure_sdk_core = "0.43.3"
@@ -20,7 +21,6 @@ hyper = "0.13"
 lazy_static = "1.4.0"
 md5 = "0.7.0"
 percent-encoding = "2.1.0"
-piper = "0.1.3"
 redis = { version = "0.16.0", features = ["tokio-rt-core"] }
 regex = "1.3.9"
 reqwest = { version = "0.10.6", features = ["json"] }

--- a/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
+++ b/medicines/doc-index-updater/src/storage_client/azure_blob_client.rs
@@ -84,7 +84,7 @@ impl StorageClient for AzureBlobStorage {
     ) -> Result<StorageFile, StorageClientError> {
         let storage_client = self.get_azure_client()?;
 
-        let file_digest = md5::compute(&file_data[..]);
+        let file_digest = md5::compute(file_data);
         let name = format!("{}{}", &self.prefix, file_name(licence_number, file_data));
 
         storage_client
@@ -93,7 +93,7 @@ impl StorageClient for AzureBlobStorage {
             .with_blob_name(&name)
             .with_content_type("application/pdf")
             .with_metadata(&metadata_ref)
-            .with_body(&file_data[..])
+            .with_body(file_data)
             .with_content_md5(&file_digest[..])
             .finalize()
             .await

--- a/medicines/doc-index-updater/src/storage_client/sftp_client.rs
+++ b/medicines/doc-index-updater/src/storage_client/sftp_client.rs
@@ -3,9 +3,9 @@ use super::{
     GetBlob,
 };
 use anyhow::anyhow;
+use async_dup::Mutex;
 use async_ssh2::{Session, Sftp};
 use async_trait::async_trait;
-use piper::Mutex;
 use smol::Async;
 use std::net::TcpStream;
 


### PR DESCRIPTION
- [x] replace `piper` with the newer `async-dup` crate
- [x] instead of passing in a new slice with the full range`[..]`, pass in the original borrowed array