### PR TITLE
Space out footnote links for mobile users

### DIFF
--- a/learning/import/test_learning_importer.py
+++ b/learning/import/test_learning_importer.py
@@ -15,6 +15,25 @@ def html_to_markdown(html):
     return md_converter.convert(html)
 
 
+def test_table_footnotes():
+    """Test table footnotes."""
+    result = html_to_markdown(
+        '<table><tr><td>Content[^1]</td></tr></table>'
+    )
+    assert '<a class="footnote-ref" href="#fn-1">' in result
+    assert '<div class="collected-footnotes">' in result
+
+
+def test_expander_footnotes():
+    """Test table footnotes."""
+    result = html_to_markdown(
+        '<Expander title="Click for good times"><div><p>Content[^1]</p></div></Expander>'
+    )
+
+    assert '<a class="footnote-ref" href="#fn-1">' in result
+    assert '<div class="collected-footnotes">' in result
+
+
 def test_glossary_link():
     """Test glossary links."""
     result = html_to_markdown(
@@ -128,13 +147,15 @@ def test_web_layout_url_src():
         "<img src=\"[!--$ssWeblayoutUrl('ab/cd/xyz789.jpg')--]\" />"
     )
     assert '![ABC 123](/asset/abc123.jpg "Image for ABC 123")' in result
-    assert md_converter.stellent_assets_to_download == set(["abc123", "xyz789"])
+    assert md_converter.stellent_assets_to_download == set(
+        ["abc123", "xyz789"])
 
 
 @pytest.mark.parametrize("con_code", ["CON0", "CON123", "CON9999999999999"])
 def test_valid_con_code(con_code):
     """Test valid CON codes."""
-    assert con_code == learning_importer.validate_con_code(None, None, con_code)
+    assert con_code == learning_importer.validate_con_code(
+        None, None, con_code)
 
 
 @pytest.mark.parametrize("con_code", ["NOTCON123", "CON", "CON-1", "con123"])

--- a/learning/web/content/modules/antipsychotics/CON155606_12.mdx
+++ b/learning/web/content/modules/antipsychotics/CON155606_12.mdx
@@ -46,7 +46,28 @@ Acute dystonias respond readily to antimuscarinic (anticholinergic) medicines su
  </p>
 </Expander>
 
-[^4] [^5] [^6] [^7]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-5">
+      5
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-6">
+      6
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-7">
+      7
+    </a>
+  </sup>
+</div>
 
 
 

--- a/learning/web/content/modules/antipsychotics/CON155606_31.mdx
+++ b/learning/web/content/modules/antipsychotics/CON155606_31.mdx
@@ -541,9 +541,83 @@ Consult summaries of product characteristics and other sources of information on
  </tr>
 </table>
 
-
-[^1] [^2] [^3] [^4] [^5] [^6] [^7] [^8] [^9] [^10] [^11] [^12] [^13] [^14] [^15]
-
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-1">
+      1
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-5">
+      5
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-6">
+      6
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-7">
+      7
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-8">
+      8
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-9">
+      9
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-10">
+      10
+    </a>
+  </sup>
+    <sup>
+    <a class="footnote-ref" href="#fn-11">
+      11
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-12">
+      12
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-13">
+      13
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-14">
+      14
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-15">
+      15
+    </a>
+  </sup>
+</div>
 
 
 [^1]: A substance that binds to a receptor but produces no effect and inhibits an agonist from binding to the receptor

--- a/learning/web/content/modules/benzodiazepines/CON234573_10.mdx
+++ b/learning/web/content/modules/benzodiazepines/CON234573_10.mdx
@@ -65,7 +65,23 @@ Paradoxical effects may be accompanied by amnesia (transient global amnesia)—a
  </p>
 </Expander>
 
-[^2] [^3] [^4]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+</div>
 
 
 

--- a/learning/web/content/modules/benzodiazepines/CON234573_13.mdx
+++ b/learning/web/content/modules/benzodiazepines/CON234573_13.mdx
@@ -301,7 +301,28 @@ Consult summaries of product characteristics and other sources of information on
  </tr>
 </table>
 
-[^1] [^2] [^3] [^4]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-1">
+      1
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+</div>
 
 
 

--- a/learning/web/content/modules/benzodiazepines/CON234573_2.mdx
+++ b/learning/web/content/modules/benzodiazepines/CON234573_2.mdx
@@ -36,7 +36,23 @@ The non-benzodiazepine hypnotics zaleplon, zolpidem and zopiclone, share many ph
  </p>
 </Expander>
 
-[^9] [^10] [^11]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-9">
+      9
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-10">
+      10
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-11">
+      11
+    </a>
+  </sup>
+</div>
 
 
 

--- a/learning/web/content/modules/benzodiazepines/CON234573_6.mdx
+++ b/learning/web/content/modules/benzodiazepines/CON234573_6.mdx
@@ -97,7 +97,18 @@ Can you think of the costs (to society and to the individual) associated with lo
  </ol>
 </Expander>
 
-[^9] [^10]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-9">
+      9
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-10">
+      10
+    </a>
+  </sup>
+</div>
 
 
 

--- a/learning/web/content/modules/opioids/CON143740_17.mdx
+++ b/learning/web/content/modules/opioids/CON143740_17.mdx
@@ -90,7 +90,23 @@ We suggest you note down the correct answers and when you’ve finished, click o
   </p>
 </Expander>
 
-[^2] [^3] [^4]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+</div>
 
 [**Review the module notes**](/opioids/CON143740_3)
 
@@ -157,7 +173,18 @@ We suggest you note down the correct answers and when you’ve finished, click o
   </p>
 </Expander>
 
-[^5] [^6]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-5">
+      5
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-6">
+      6
+    </a>
+  </sup>
+</div>
 
 [**Review the module notes**](/opioids/CON143740_6)
 
@@ -246,7 +273,19 @@ We suggest you note down the correct answers and when you’ve finished, click o
  </p>
 </Expander>
 
-[^8] [^9]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-8">
+      8
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-9">
+      9
+    </a>
+  </sup>
+</div>
+
 
 <Expander title="Verapamil injection and dexamethasone injection">
  <p>

--- a/learning/web/content/modules/ssri/CON146583_21.mdx
+++ b/learning/web/content/modules/ssri/CON146583_21.mdx
@@ -257,8 +257,48 @@ SSRIs inhibit the activity of cytochrome P450 isoenzymes but the inhibitory effe
  </tr>
 </table>
 
-[^2] [^3] [^4] [^5] [^6] [^7] [^8] [^9]
-
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-4">
+      4
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-5">
+      5
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-6">
+      6
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-7">
+      7
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-8">
+      8
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-9">
+      9
+    </a>
+  </sup>
+</div>
 
 
 [^1]: A chemical agent (or synapse) that produces its effects via the serotonin transmitter system.

--- a/learning/web/content/modules/ssri/CON146583_3.mdx
+++ b/learning/web/content/modules/ssri/CON146583_3.mdx
@@ -2,332 +2,286 @@
 title: 2. Class members and licensed uses
 ---
 
-import Expander from '../../../src/components/Expander'
+import Expander from "../../../src/components/Expander"
 
 ### Consult the summary of product characteristics for details of authorised indications of each SSRI.
 
 ### SSRIs: Approved names, common proprietary names and licensed indications
 
-
-
 <table>
- <tr>
-  <th>
-  </th>
-  <th>
-   <p>
-    Citalopram
-   </p>
-  </th>
-  <th>
-   <p>
-    Escital-opram
-    <br/>
-    (enantiomer
-    <sup>
-     <a class="footnote-ref" href="#fn-1">
-      1
-     </a>
-    </sup>
-    of citalopram)
-   </p>
-  </th>
-  <th>
-   <p>
-    <strong>
-     Fluoxetine
-    </strong>
-   </p>
-  </th>
-  <th>
-   <p>
-    <strong>
-     Fluvoxamine
-    </strong>
-   </p>
-  </th>
-  <th>
-   <p>
-    <strong>
-     Paroxetine
-    </strong>
-   </p>
-  </th>
-  <th>
-   <p>
-    <strong>
-     Sertraline
-    </strong>
-   </p>
-  </th>
- </tr>
- <tr>
-  <td>
-   <p>
-    Common proprietory names
-   </p>
-  </td>
-  <td>
-   <p>
-    Cipramil
-   </p>
-  </td>
-  <td>
-   <p>
-    Cipralex
-   </p>
-  </td>
-  <td>
-   <p>
-    Prozac
-   </p>
-  </td>
-  <td>
-   <p>
-    Faverin
-   </p>
-  </td>
-  <td>
-   <p>
-    Seroxat
-   </p>
-  </td>
-  <td>
-   <p>
-    Lustral
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Depressive illness
-    <sup>
-     <a class="footnote-ref" href="#fn-2">
-      2
-     </a>
-    </sup>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Generalised anxiety disorder
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Obsessive–compulsive disorder
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Panic disorder with or without agoraphobia
-    <sup>
-     <a class="footnote-ref" href="#fn-3">
-      3
-     </a>
-    </sup>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Social anxiety disorder (social phobia)
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Post-traumatic stress disorder
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
- </tr>
- <tr>
-  <td>
-   <p>
-    Bulimia nervosa
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-   <p>
-    <img alt="Tickbox" src="../../assets/con126283.jpg"/>
-   </p>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
-  <td>
-  </td>
- </tr>
+  <tr>
+    <th></th>
+    <th>
+      <p>Citalopram</p>
+    </th>
+    <th>
+      <p>
+        Escital-opram
+        <br />
+        (enantiomer
+        <sup>
+          <a class="footnote-ref" href="#fn-1">
+            1
+          </a>
+        </sup>
+        of citalopram)
+      </p>
+    </th>
+    <th>
+      <p>
+        <strong>Fluoxetine</strong>
+      </p>
+    </th>
+    <th>
+      <p>
+        <strong>Fluvoxamine</strong>
+      </p>
+    </th>
+    <th>
+      <p>
+        <strong>Paroxetine</strong>
+      </p>
+    </th>
+    <th>
+      <p>
+        <strong>Sertraline</strong>
+      </p>
+    </th>
+  </tr>
+  <tr>
+    <td>
+      <p>Common proprietory names</p>
+    </td>
+    <td>
+      <p>Cipramil</p>
+    </td>
+    <td>
+      <p>Cipralex</p>
+    </td>
+    <td>
+      <p>Prozac</p>
+    </td>
+    <td>
+      <p>Faverin</p>
+    </td>
+    <td>
+      <p>Seroxat</p>
+    </td>
+    <td>
+      <p>Lustral</p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>
+        Depressive illness
+        <sup>
+          <a class="footnote-ref" href="#fn-2">
+            2
+          </a>
+        </sup>
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Generalised anxiety disorder</p>
+    </td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>
+      <p>Obsessive–compulsive disorder</p>
+    </td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>
+        Panic disorder with or without agoraphobia
+        <sup>
+          <a class="footnote-ref" href="#fn-3">
+            3
+          </a>
+        </sup>
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Social anxiety disorder (social phobia)</p>
+    </td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Post-traumatic stress disorder</p>
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Bulimia nervosa</p>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+      <p>
+        <img alt="Tickbox" src="../../assets/con126283.jpg" />
+      </p>
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
 </table>
 
-
-[^1] [^2] [^3]
+<div class="collected-footnotes">
+  <sup>
+    <a class="footnote-ref" href="#fn-1">
+      1
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-2">
+      2
+    </a>
+  </sup>
+  <sup>
+    <a class="footnote-ref" href="#fn-3">
+      3
+    </a>
+  </sup>
+</div>
 
 Antidepressants in other classes may also inhibit reuptake of serotonin, but only SSRIs are discussed here.
 
 Only the following SSRIs are licensed for children and adolescents:
 
-* Fluoxetine for the treatment of moderate to severe major depressive episode (in combination with psychological therapy) in children aged over eight years and adolescents
-* Fluvoxamine for the treatment of obsessive–compulsive disorder in children aged over eight years and adolescents
-* Sertraline for the treatment of obsessive–compulsive disorder in children aged over six years and adolescents.
-
+- Fluoxetine for the treatment of moderate to severe major depressive episode (in combination with psychological therapy) in children aged over eight years and adolescents
+- Fluvoxamine for the treatment of obsessive–compulsive disorder in children aged over eight years and adolescents
+- Sertraline for the treatment of obsessive–compulsive disorder in children aged over six years and adolescents.
 
 [^1]: An enantiomer is one of a pair of chemical molecules with identical molecular formula, but one enantiomer cannot be superimposed on the other because it is a mirror image of the other. Often one enantiomer exerts considerably more biological activity than the other.
-
-
 [^2]: A psychiatric disorder characterised by lowered mood, reduced energy and decreased activity. The severity of a depressive episode is divided clinically into mild, moderate and severe subtypes (the latter may or may not have psychotic features). Repeated episodes of depression, without a history of mania, are classified as recurrent depressive disorder.
-
-
 [^3]: Abnormal fear or anxiety induced by being in crowds or in open spaces—environments which seem difficult to escape from or obtain help.

--- a/learning/web/src/components/Layout/index.js
+++ b/learning/web/src/components/Layout/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
-import ReactGA from 'react-ga';
-import TagManager from 'react-gtm-module';
+import ReactGA from "react-ga"
+import TagManager from "react-gtm-module"
 
 import { rhythm } from "../../utils/typography"
 import SvgMhraLogo from "../Logos/mhra-logo"
@@ -70,6 +70,10 @@ const Content = styled.div`
 
 const LayoutStyled = styled.div`
   border-top: 4px solid rgb(15, 18, 144);
+
+  .collected-footnotes > sup + sup {
+    padding-left: 15px;
+  }
 `
 
 const Wrapper = styled.div`
@@ -132,19 +136,22 @@ class Layout extends React.Component {
   componentDidMount() {
     // If cookies are allowed and they haven't already been initialised,
     // initialise Google Analytics and Tag Manager.
-    if (window.localStorage.getItem("showCookieBanner") === "false" && !Layout.cookiesInitialized) {
+    if (
+      window.localStorage.getItem("showCookieBanner") === "false" &&
+      !Layout.cookiesInitialized
+    ) {
       if (process.env.GATSBY_GOOGLE_TAG_MANAGER_ID) {
         TagManager.initialize({
           gtmId: process.env.GATSBY_GOOGLE_TAG_MANAGER_ID,
-          dataLayerName: 'dataLayer',
-        });
+          dataLayerName: "dataLayer",
+        })
       }
 
       if (process.env.GATSBY_GOOGLE_ANALYTICS_TRACKING_ID) {
-        ReactGA.initialize(process.env.GATSBY_GOOGLE_ANALYTICS_TRACKING_ID);
+        ReactGA.initialize(process.env.GATSBY_GOOGLE_ANALYTICS_TRACKING_ID)
       }
 
-      Layout.cookiesInitialized = true;
+      Layout.cookiesInitialized = true
     }
   }
 
@@ -185,7 +192,13 @@ class Layout extends React.Component {
                 </li>
                 <li>
                   <p>
-                    <a href="https://www.gov.uk/government/publications/mhra-privacy-notice/mhra-privacy-notice" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+                    <a
+                      href="https://www.gov.uk/government/publications/mhra-privacy-notice/mhra-privacy-notice"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Privacy Policy
+                    </a>
                   </p>
                 </li>
                 <li>
@@ -202,6 +215,6 @@ class Layout extends React.Component {
   }
 }
 
-Layout.cookiesInitialized = false;
+Layout.cookiesInitialized = false
 
 export default Layout


### PR DESCRIPTION
# Space out footnote links for mobile users

Wrap collected footnotes in containing div so they can be styled specifically to give more spacing, allowing them to be clicked more easily on a mobile device.

![](https://gph.is/g/EGdkyln)

### Acceptance Criteria

- [ ] The footnotes that are collected at the bottom of tables and expanders should be spaced out

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
