### PR TITLE
Add diagnostic logging to service bus

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -124,10 +124,11 @@ module cluster {
 module service_bus {
   source = "../../modules/service-bus"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  name                = local.service_bus_name
-  resource_group_name = azurerm_resource_group.products.name
+  environment             = var.ENVIRONMENT
+  location                = var.REGION
+  name                    = local.service_bus_name
+  resource_group_name     = azurerm_resource_group.products.name
+  logs_storage_account_id = module.logs.logs_resource_group_id
 }
 
 # Key vault

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -132,12 +132,13 @@ data "azurerm_public_ip" "external" {
 module service_bus {
   source = "../../modules/service-bus"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  name                = local.service_bus_name
-  resource_group_name = azurerm_resource_group.products.name
-  redis_use_firewall  = true
-  redis_firewall_ip   = data.azurerm_public_ip.external.ip_address
+  environment             = var.ENVIRONMENT
+  location                = var.REGION
+  name                    = local.service_bus_name
+  resource_group_name     = azurerm_resource_group.products.name
+  redis_use_firewall      = true
+  redis_firewall_ip       = data.azurerm_public_ip.external.ip_address
+  logs_storage_account_id = module.logs.logs_resource_group_id
 }
 
 # Key vault

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -108,12 +108,13 @@ data "azurerm_public_ip" "external" {
 module service_bus {
   source = "../../modules/service-bus"
 
-  environment         = var.ENVIRONMENT
-  location            = var.REGION
-  name                = local.service_bus_name
-  resource_group_name = data.azurerm_resource_group.products.name
-  redis_use_firewall  = true
-  redis_firewall_ip   = data.azurerm_public_ip.external.ip_address
+  environment             = var.ENVIRONMENT
+  location                = var.REGION
+  name                    = local.service_bus_name
+  resource_group_name     = data.azurerm_resource_group.products.name
+  redis_use_firewall      = true
+  redis_firewall_ip       = data.azurerm_public_ip.external.ip_address
+  logs_storage_account_id = module.logs.logs_resource_group_id
 }
 
 # Key vault

--- a/infrastructure/modules/service-bus/diagnostics.tf
+++ b/infrastructure/modules/service-bus/diagnostics.tf
@@ -1,0 +1,27 @@
+resource "azurerm_monitor_diagnostic_setting" "service_bus" {
+  name               = "service-bus-diagnostics-${var.environment}"
+  target_resource_id = azurerm_servicebus_namespace.doc_index_updater_service_bus.id
+  storage_account_id = var.logs_storage_account_id
+
+  dynamic "log" {
+    for_each = var.diagnostic_log_types
+
+    content {
+      category = log.value
+      retention_policy {
+        enabled = true
+        days    = 0
+      }
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}

--- a/infrastructure/modules/service-bus/variables.tf
+++ b/infrastructure/modules/service-bus/variables.tf
@@ -24,3 +24,13 @@ variable "redis_firewall_ip" {
   description = "IP allowed to access Redis Cache"
   default     = ""
 }
+
+variable "logs_storage_account_id" {
+  description = "ID of the storage account to send service bus logs to"
+}
+
+variable "diagnostic_log_types" {
+  description = "Set of log types to create configuration for"
+  type        = list(string)
+  default     = ["OperationalLogs"]
+}


### PR DESCRIPTION
# Add diagnostic logging to service bus

Resolves #896 

Causes service bus to log to storage container

![](https://media.giphy.com/media/B5BfWWr1UnVrG/giphy.gif)

### Acceptance Criteria

- [ ] Logs service bus changes to storage container

### Testing information

- Execute terraform to create diagnostic setting
- Check that logs are saved to storage container

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
