### PR TITLE
Update .test.mhra urls to .non-prod.mhra

### DIFF
--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -20,7 +20,7 @@ env:
   GOOGLE_TRACKING_ID: UA-6838115-11
   GOOGLE_USE_DEBUG: true
   ROOT_URL_DOMAIN: .windows.net
-  GRAPHQL_URL: https://medicines-api.test.mhra.gov.uk/graphql
+  GRAPHQL_URL: https://medicines-api.non-prod.mhra.gov.uk/graphql
 
 jobs:
   build:

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -10,9 +10,9 @@ on:
 
 env:
   NEXT_PUBLIC_DISABLE_AUTH: false
-  PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
+  PARS_UPLOAD_URL: "https://doc-index-updater.non-prod.mhra.gov.uk/pars"
   # above is for cypress, below is for next.js
-  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.test.mhra.gov.uk/pars"
+  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.non-prod.mhra.gov.uk/pars"
   NONPROD_PARS_APP_ID: ac2b59e9-77ca-4d39-8186-b96d305c9aae
 
 jobs:

--- a/medicines/doc-index-updater/scripts/api.scala
+++ b/medicines/doc-index-updater/scripts/api.scala
@@ -35,7 +35,7 @@ class ProductsApi extends Simulation {
   }
 
   val httpProtocol = http
-    //.baseUrl("https://medicines-api.test.mhra.gov.uk/graphql") // non prod
+    //.baseUrl("https://medicines-api.non-prod.mhra.gov.uk/graphql") // non prod
     .baseUrl("https://medicines-api-dev.test.mhra.gov.uk/graphql") //dev
     //.baseUrl("http://localhost:8000/graphql") // local
     .acceptHeader("application/json")


### PR DESCRIPTION
# Update .test.mhra urls to .non-prod.mhra

There are no public DNS records for `doc-index-updater.test.mhra.gov.uk` and `medicines-api.non-prod.mhra.gov.uk` so these urls don't resolve when used by the non-prod sites. 

The `non-prod.mhra.gov.uk` versions do resolve since they are controlled by the DNS zone in Azure.

This PR updates urls in the non-prod environment accordingly.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
