### PR TITLE
Make filter checkbox style darker for accessibility best practice

### DIFF
--- a/medicines/web/src/components/disclaimer/__snapshots__/index.test.tsx.snap
+++ b/medicines/web/src/components/disclaimer/__snapshots__/index.test.tsx.snap
@@ -38,11 +38,10 @@ exports[`Disclaimer should render 1`] = `
     </p>
     <form>
       <div>
-        <input
+        <Component
           id="agree-checkbox"
           name="agree"
           onChange={[Function]}
-          type="checkbox"
         />
         <label
           htmlFor="agree-checkbox"

--- a/medicines/web/src/components/disclaimer/index.tsx
+++ b/medicines/web/src/components/disclaimer/index.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
 import {
-  black,
   mhra70,
   mhraGray,
   mhraGray10,
@@ -10,6 +9,7 @@ import {
   primaryColor,
 } from '../../styles/colors';
 import { mobileBreakpoint } from '../../styles/dimensions';
+import { Checkbox } from '../form-elements';
 
 interface IDisclaimerProps {
   onDisclaimerAgree: (event: MouseEvent<HTMLButtonElement>) => void;
@@ -55,23 +55,6 @@ const StyledDisclaimer = styled.section`
   form input,
   form label {
     cursor: pointer;
-  }
-
-  input[type='checkbox'] {
-    appearance: none;
-    border: 1px solid ${black};
-    display: block;
-    height: 1.25rem;
-    margin-right: 1.25rem;
-    width: 1.25rem;
-    min-width: 1.25rem;
-  }
-
-  input[type='checkbox']:checked {
-    background-image: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"/></svg>');
-    background-size: calc(100% - 4px) calc(100% - 4px);
-    background-position: center center;
-    background-repeat: no-repeat;
   }
 
   button[type='submit'] {
@@ -157,8 +140,7 @@ const Disclaimer: React.FC<IDisclaimerProps> = props => {
         </p>
         <form>
           <div>
-            <input
-              type="checkbox"
+            <Checkbox
               name="agree"
               id="agree-checkbox"
               onChange={handleOnCheck}

--- a/medicines/web/src/components/form-elements/index.tsx
+++ b/medicines/web/src/components/form-elements/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+import { black } from '../../styles/colors';
+
+const StyledCheckbox = styled.input`
+  appearance: none;
+  border: 1px solid ${black};
+  display: block;
+  height: 1.25rem;
+  margin-right: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+
+  &:checked {
+    background-image: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"/></svg>');
+    background-size: calc(100% - 4px) calc(100% - 4px);
+    background-position: center center;
+    background-repeat: no-repeat;
+  }
+`;
+
+export const Checkbox = props => {
+  return <StyledCheckbox type="checkbox" {...props} />;
+};

--- a/medicines/web/src/components/search-filter/index.tsx
+++ b/medicines/web/src/components/search-filter/index.tsx
@@ -17,6 +17,7 @@ const StyledSearchFilter = styled.section`
 
       input {
         flex: 1;
+        box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 1);
       }
     }
 

--- a/medicines/web/src/components/search-filter/index.tsx
+++ b/medicines/web/src/components/search-filter/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { DocType } from '../../services/azure-search';
+import { Checkbox } from '../form-elements';
 
 const StyledSearchFilter = styled.section`
   .checkbox-row {
@@ -13,12 +14,7 @@ const StyledSearchFilter = styled.section`
       flex: 0.1;
       display: flex;
       flex-direction: column;
-      padding: 0.25em;
-
-      input {
-        flex: 1;
-        box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 1);
-      }
+      padding: 0.25em 0;
     }
 
     label {
@@ -53,8 +49,7 @@ const DocTypeCheckbox: React.FC<IDocTypeCheckboxProps> = props => {
   return (
     <div className="checkbox-row">
       <div className="checkbox">
-        <input
-          type="checkbox"
+        <Checkbox
           id={id}
           name="doc"
           value={docTypeForThisCheckbox}


### PR DESCRIPTION
# Make filter checkbox style darker for accessibility best practice

Make checkbox border darker, relates to #927

![](https://media.giphy.com/media/EPf0wbRlhAO8KGeVFA/giphy.gif)

### Acceptance Criteria

- [ ] Border is clearer and more identifiable as a checkbox

### Testing information
- Go to search results page, view border of checkbox in different browsers to ensure looks ok and is visible.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [x] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
