### PR TITLE
Update doc-index-updater url for PARs release workflow

### DIFF
--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -7,9 +7,9 @@ on:
 
 env:
   NEXT_PUBLIC_DISABLE_AUTH: false
-  PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
+  PARS_UPLOAD_URL: "https://doc-index-updater.api.mhra.gov.uk/pars"
   # above is for cypress, below is for next.js
-  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.mhra.gov.uk/pars"
+  NEXT_PUBLIC_PARS_UPLOAD_URL: "https://doc-index-updater.api.mhra.gov.uk/pars"
   PROD_PARS_APP_ID: 088430d1-a1e4-444a-8769-6d0d998ba67a
 
 jobs:


### PR DESCRIPTION
# Update doc-index-updater url for PARs release workflow

Switching from `doc-index-updater.mhra.gov.uk` to `doc-index-updater.api.mhra.gov.uk` to migrate to an URL we have set up automated SSL renewal for and have DNS control over.

### Acceptance Criteria

- [ ] PARs sends docs to new public doc-index-updater url

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
