### PR TITLE
Darkened the border around the searchbar

### DIFF
--- a/medicines/web/src/components/search-wrapper/__snapshots__/index.test.tsx.snap
+++ b/medicines/web/src/components/search-wrapper/__snapshots__/index.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`SearchWrapper should render 1`] = `
                     "componentStyle": ComponentStyle {
                       "componentId": "sc-bwzfXH",
                       "isStatic": false,
-                      "lastClassName": "gkFGKz",
+                      "lastClassName": "hQeodl",
                       "rules": Array [
                         "
   box-sizing: border-box;
@@ -117,7 +117,7 @@ exports[`SearchWrapper should render 1`] = `
   input[type='search'] {
     width: 100%;
     border: solid 1px ",
-                        "rgb(154, 155, 156)",
+                        "#000",
                         ";
     margin-right: 0.5rem;
     min-width: 0;
@@ -179,7 +179,7 @@ exports[`SearchWrapper should render 1`] = `
                 forwardedRef={null}
               >
                 <section
-                  className="sc-bwzfXH gkFGKz"
+                  className="sc-bwzfXH hQeodl"
                 >
                   <form
                     aria-label="Search for medicines"

--- a/medicines/web/src/components/search/index.tsx
+++ b/medicines/web/src/components/search/index.tsx
@@ -40,7 +40,7 @@ const StyledSearch = styled.section`
 
   input[type='search'] {
     width: 100%;
-    border: solid 1px ${mhraGray};
+    border: solid 1px ${black};
     margin-right: 0.5rem;
     min-width: 0;
   }


### PR DESCRIPTION
# Change search box border for accessible colour -> 1.4.11 Non-Text Contrast (AA) - Page 79 of accessibility audit report - issue 7

Relates to #921 

![](https://media.giphy.com/media/5XvhZSJHr8wOk/giphy.gif)

### Acceptance Criteria

- [ ] Contrast fulfills AA criteria for contrast difference

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo - MHRA colour changed

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
