### PR TITLE
Clear doc-index-updater dead letter queues

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/clean_up_worker.rs
+++ b/medicines/doc-index-updater/src/create_manager/clean_up_worker.rs
@@ -1,0 +1,27 @@
+use crate::{
+    models::CreateMessage, service_bus_client::create_clean_up_factory, state_manager::StateManager,
+};
+use anyhow::anyhow;
+use std::time::Duration;
+use tokio::time::delay_for;
+
+pub async fn create_queue_clean_up_worker(
+    time_to_wait: Duration,
+    state_manager: StateManager,
+) -> Result<(), anyhow::Error> {
+    tracing::info!("Starting create queue clean up worker");
+    let mut create_clean_up_client = create_clean_up_factory()
+        .await
+        .map_err(|e| anyhow!("Couldn't create service bus client: {:?}", e))?;
+
+    loop {
+        match create_clean_up_client
+            .try_process_from_dead_letter_queue::<CreateMessage>(&state_manager)
+            .await
+        {
+            Ok(()) => {}
+            Err(e) => tracing::error!("{:?}", e),
+        }
+        delay_for(time_to_wait).await;
+    }
+}

--- a/medicines/doc-index-updater/src/create_manager/mod.rs
+++ b/medicines/doc-index-updater/src/create_manager/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     create_manager::models::BlobMetadata,
     models::{CreateMessage, JobStatus},
     service_bus_client::{
-        create_factory, ProcessMessageError, ProcessRetrievalError, RemovableMessage,
-        RetrievedMessage,
+        create_clean_up_factory, create_factory, ProcessMessageError, ProcessRetrievalError,
+        RemovableMessage, RetrievedMessage,
     },
     state_manager::{JobStatusClient, StateManager},
     storage_client::{
@@ -37,6 +37,27 @@ pub async fn create_service_worker(
     loop {
         match create_client
             .try_process_from_queue::<CreateMessage>(&state_manager)
+            .await
+        {
+            Ok(()) => {}
+            Err(e) => tracing::error!("{:?}", e),
+        }
+        delay_for(time_to_wait).await;
+    }
+}
+
+pub async fn create_queue_clean_up_worker(
+    time_to_wait: Duration,
+    state_manager: StateManager,
+) -> Result<(), anyhow::Error> {
+    tracing::info!("Starting create service worker");
+    let mut create_clean_up_client = create_clean_up_factory()
+        .await
+        .map_err(|e| anyhow!("Couldn't create service bus client: {:?}", e))?;
+
+    loop {
+        match create_clean_up_client
+            .try_process_from_dead_letter_queue::<CreateMessage>(&state_manager)
             .await
         {
             Ok(()) => {}

--- a/medicines/doc-index-updater/src/delete_manager/clean_up_worker.rs
+++ b/medicines/doc-index-updater/src/delete_manager/clean_up_worker.rs
@@ -1,22 +1,22 @@
 use crate::{
-    models::CreateMessage, service_bus_client::create_clean_up_factory, state_manager::StateManager,
+    models::DeleteMessage, service_bus_client::delete_clean_up_factory, state_manager::StateManager,
 };
 use anyhow::anyhow;
 use std::time::Duration;
 use tokio::time::delay_for;
 
-pub async fn create_queue_clean_up_worker(
+pub async fn delete_queue_clean_up_worker(
     time_to_wait: Duration,
     state_manager: StateManager,
 ) -> Result<(), anyhow::Error> {
-    tracing::info!("Starting create queue clean up worker");
-    let mut create_clean_up_client = create_clean_up_factory()
+    tracing::info!("Starting delete queue clean up worker");
+    let mut delete_clean_up_client = delete_clean_up_factory()
         .await
         .map_err(|e| anyhow!("Couldn't create service bus client: {:?}", e))?;
 
     loop {
-        match create_clean_up_client
-            .try_process_from_dead_letter_queue::<CreateMessage>(&state_manager)
+        match delete_clean_up_client
+            .try_process_from_dead_letter_queue::<DeleteMessage>(&state_manager)
             .await
         {
             Ok(found_message) => {

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -19,6 +19,8 @@ use storage_client::{AzureBlobStorage, DeleteBlob};
 use tokio::time::delay_for;
 use uuid::Uuid;
 
+pub mod clean_up_worker;
+
 pub async fn delete_service_worker(
     time_to_wait: Duration,
     state_manager: StateManager,

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -68,10 +68,12 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
             time_to_wait,
             create_state
         )),
-        tokio::spawn(create_manager::create_queue_clean_up_worker(
-            time_to_wait,
-            create_clean_up_state
-        )),
+        tokio::spawn(
+            create_manager::clean_up_worker::create_queue_clean_up_worker(
+                time_to_wait,
+                create_clean_up_state
+            )
+        ),
     );
     Ok(())
 }

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -29,11 +29,13 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     let redis_addr = create_redis_url(redis_server, redis_port, redis_key);
 
     let time_to_wait = Duration::from_secs(get_env_or_default("SECONDS_TO_WAIT", 5));
+    let clean_up_time_to_wait = time_to_wait * 10;
     let state = state_manager::StateManager::new(get_client(redis_addr.clone())?);
 
     let create_state = state.clone();
     let delete_state = state.clone();
     let create_clean_up_state = state.clone();
+    let delete_clean_up_state = state.clone();
 
     let pars_origin = get_env_or_default(
         "PARS_UPLOAD_SITE_ORIGIN",
@@ -69,8 +71,14 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
         )),
         tokio::spawn(
             create_manager::clean_up_worker::create_queue_clean_up_worker(
-                time_to_wait,
+                clean_up_time_to_wait,
                 create_clean_up_state
+            )
+        ),
+        tokio::spawn(
+            delete_manager::clean_up_worker::delete_queue_clean_up_worker(
+                clean_up_time_to_wait,
+                delete_clean_up_state
             )
         ),
     );

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -29,7 +29,6 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     let redis_addr = create_redis_url(redis_server, redis_port, redis_key);
 
     let time_to_wait = Duration::from_secs(get_env_or_default("SECONDS_TO_WAIT", 5));
-    let clean_up_time_to_wait = time_to_wait * 10;
     let state = state_manager::StateManager::new(get_client(redis_addr.clone())?);
 
     let create_state = state.clone();

--- a/medicines/doc-index-updater/src/main.rs
+++ b/medicines/doc-index-updater/src/main.rs
@@ -29,11 +29,12 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     let redis_addr = create_redis_url(redis_server, redis_port, redis_key);
 
     let time_to_wait = Duration::from_secs(get_env_or_default("SECONDS_TO_WAIT", 5));
-
+    let clean_up_time_to_wait = time_to_wait * 10;
     let state = state_manager::StateManager::new(get_client(redis_addr.clone())?);
 
     let create_state = state.clone();
     let delete_state = state.clone();
+    let create_clean_up_state = state.clone();
 
     let pars_origin = get_env_or_default(
         "PARS_UPLOAD_SITE_ORIGIN",
@@ -66,6 +67,10 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
         tokio::spawn(create_manager::create_service_worker(
             time_to_wait,
             create_state
+        )),
+        tokio::spawn(create_manager::create_queue_clean_up_worker(
+            time_to_wait,
+            create_clean_up_state
         )),
     );
     Ok(())

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -247,7 +247,6 @@ impl DocIndexUpdaterQueue {
         T: Message,
         RetrievedMessage<T>: ProcessRetrievalError + Removable,
     {
-        tracing::debug!("Checking for messages.");
         let retrieved_result: Result<RetrievedMessage<T>, RetrieveFromQueueError> =
             self.receive().await;
 
@@ -301,8 +300,7 @@ where
         .set_status(
             retrieval.message.get_id(),
             JobStatus::Error {
-                message: "Max number of retries exceeded - removed from dead letter queue"
-                    .to_string(),
+                message: "Max number of retries exceeded".to_string(),
                 code: "500".to_string(),
             },
         )

--- a/medicines/doc-index-updater/src/service_bus_client/mod.rs
+++ b/medicines/doc-index-updater/src/service_bus_client/mod.rs
@@ -255,7 +255,7 @@ impl DocIndexUpdaterQueue {
             let correlation_id = retrieval.message.get_id().to_string();
             let correlation_id = correlation_id.as_str();
 
-            process_dead_letter(correlation_id, state_manager)
+            process_dead_letter(retrieval, state_manager)
                 .instrument(tracing::info_span!(
                     "try_process_dead_letter_from_queue",
                     correlation_id
@@ -299,7 +299,7 @@ where
 {
     state_manager
         .set_status(
-            retrieval.message.job_id,
+            retrieval.message.get_id(),
             JobStatus::Error {
                 message: "Max number of retries exceeded - removed from dead letter queue"
                     .to_string(),
@@ -307,7 +307,7 @@ where
             },
         )
         .await?;
-    let _ = removable_message.remove().await?;
+    let _ = retrieval.remove().await?;
     Ok(())
 }
 

--- a/medicines/doc-index-updater/stunnel.conf
+++ b/medicines/doc-index-updater/stunnel.conf
@@ -4,4 +4,4 @@ foreground = yes
 [doc_index_updater]
 client = yes
 accept = 127.0.0.1:6379
-connect = doc-index-updater-dev.redis.cache.windows.net:6380
+connect = doc-index-updater-non-prod.redis.cache.windows.net:6380


### PR DESCRIPTION
# Clear doc-index-updater dead letter queues

Relates to #631 

Currently nothing clears up the dead letter queues and updates the job status to errored.
This PR adds 2 new workers that periodically check the DLQs (less frequently than the normal queues are checked) and removes all the messages it finds.

![](https://media.giphy.com/media/f69Ei1R9MVz2w/giphy.gif)

### Acceptance Criteria

- [ ] Clears dead letter queues
- [ ] Updates job status to errored

### Testing information

- [ ] Create a job that won't complete
- [ ] Wait until job gets on error queue
- [ ] Watch it be processed by worker

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
