### PR TITLE
Add network security group for cluster

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.8.0"
+  version = "=2.10.0"
   features {}
 }
 

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -109,6 +109,7 @@ module cluster {
   resource_group_name                   = azurerm_resource_group.products.name
   vnet_name                             = azurerm_virtual_network.cluster.name
   vnet_resource_group                   = azurerm_virtual_network.cluster.resource_group_name
+  lb_subnet_name                        = "adarz-spoke-products-dev-sn-01"
   lb_subnet_id                          = azurerm_subnet.load_balancer.id
   cluster_subnet_name                   = "adarz-spoke-products-dev-sn-02"
   cluster_subnet_cidr                   = "10.5.65.192/26"

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -102,6 +102,7 @@ module cluster {
   resource_group_name                   = azurerm_resource_group.products.name
   vnet_name                             = data.azurerm_virtual_network.cluster.name
   vnet_resource_group                   = data.azurerm_virtual_network.cluster.resource_group_name
+  lb_subnet_name                        = "adarz-spoke-products-sn-01"
   lb_subnet_id                          = azurerm_subnet.load_balancer.id
   cluster_subnet_name                   = "adarz-spoke-products-sn-02"
   cluster_subnet_cidr                   = "10.5.65.64/26"

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -112,7 +112,6 @@ module cluster {
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
   log_cluster_diagnostics               = false
   logs_storage_account_id               = module.logs.logs_resource_group_id
-  cluster_public_ip                     = "52.151.120.140"
 }
 
 # CPD

--- a/infrastructure/environments/non-prod/main.tf
+++ b/infrastructure/environments/non-prod/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.8.0"
+  version = "=2.10.0"
   features {}
 }
 
@@ -111,6 +111,7 @@ module cluster {
   support_email_addresses               = var.SUPPORT_EMAIL_ADDRESSES
   log_cluster_diagnostics               = false
   logs_storage_account_id               = module.logs.logs_resource_group_id
+  cluster_public_ip                     = "52.151.120.140"
 }
 
 # CPD

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -87,6 +87,7 @@ module cluster {
   resource_group_name                   = data.azurerm_resource_group.products.name
   vnet_name                             = data.azurerm_virtual_network.cluster.name
   vnet_resource_group                   = data.azurerm_virtual_network.cluster.resource_group_name
+  lb_subnet_name                        = "aparz-spoke-products-sn-01"
   lb_subnet_id                          = data.azurerm_subnet.load_balancer.id
   cluster_subnet_name                   = "aparz-spoke-products-sn-02"
   cluster_subnet_cidr                   = "10.5.66.64/26"

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.8.0"
+  version = "=2.10.0"
   features {}
 }
 

--- a/infrastructure/modules/cluster/network_security_group.tf
+++ b/infrastructure/modules/cluster/network_security_group.tf
@@ -1,0 +1,14 @@
+resource "azurerm_network_security_group" "cluster_subnet" {
+  name                = var.cluster_subnet_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "cluster_subnet" {
+  subnet_id                 = azurerm_subnet.cluster.id
+  network_security_group_id = azurerm_network_security_group.cluster_subnet.id
+}

--- a/infrastructure/modules/cluster/network_security_group.tf
+++ b/infrastructure/modules/cluster/network_security_group.tf
@@ -1,78 +1,3 @@
-resource "azurerm_network_security_group" "cluster_subnet" {
-  name                = var.cluster_subnet_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-
-  security_rule {
-    name                       = "port15021"
-    priority                   = 500
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "15021"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = var.cluster_public_ip
-  }
-
-  security_rule {
-    name                       = "port80"
-    priority                   = 501
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "80"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = var.cluster_public_ip
-  }
-
-  security_rule {
-    name                       = "port443"
-    priority                   = 502
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "443"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = var.cluster_public_ip
-  }
-
-  security_rule {
-    name                       = "port31400"
-    priority                   = 503
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "31400"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = var.cluster_public_ip
-  }
-
-  security_rule {
-    name                       = "port15443"
-    priority                   = 504
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "15443"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = var.cluster_public_ip
-  }
-
-  tags = {
-    environment = var.environment
-  }
-}
-
-resource "azurerm_subnet_network_security_group_association" "cluster_subnet" {
-  subnet_id                 = azurerm_subnet.cluster.id
-  network_security_group_id = azurerm_network_security_group.cluster_subnet.id
-}
-
 resource "azurerm_network_security_group" "lb_subnet" {
   name                = var.lb_subnet_name
   location            = var.location
@@ -86,4 +11,6 @@ resource "azurerm_network_security_group" "lb_subnet" {
 resource "azurerm_subnet_network_security_group_association" "lb_subnet" {
   subnet_id                 = var.lb_subnet_id
   network_security_group_id = azurerm_network_security_group.lb_subnet.id
+
+  // TODO: add security rules to allow inbound/outbound to Sentinel and to the VNET, but not the internet
 }

--- a/infrastructure/modules/cluster/network_security_group.tf
+++ b/infrastructure/modules/cluster/network_security_group.tf
@@ -72,3 +72,18 @@ resource "azurerm_subnet_network_security_group_association" "cluster_subnet" {
   subnet_id                 = azurerm_subnet.cluster.id
   network_security_group_id = azurerm_network_security_group.cluster_subnet.id
 }
+
+resource "azurerm_network_security_group" "lb_subnet" {
+  name                = var.lb_subnet_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "lb_subnet" {
+  subnet_id                 = var.lb_subnet_id
+  network_security_group_id = azurerm_network_security_group.lb_subnet.id
+}

--- a/infrastructure/modules/cluster/network_security_group.tf
+++ b/infrastructure/modules/cluster/network_security_group.tf
@@ -3,6 +3,30 @@ resource "azurerm_network_security_group" "lb_subnet" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
+  security_rule {                                                                                                                                                                                             
+     name                       = "DenyAzureLoadBalancerInBound"                                                                                                                                                                  
+     priority                   = 100                                                                                                                                                                          
+     direction                  = "Inbound"                                                                                                                                                                    
+     access                     = "Deny"                                                                                                                                                                      
+     protocol                   = "*"                                                                                                                                                                        
+     source_port_range          = "*"                                                                                                                                                                          
+     destination_port_range     = "*"                                                                                                                                                                      
+     source_address_prefix      = "AzureLoadBalancer"                                                                                                                                                                   
+     destination_address_prefix = "*"
+   }    
+
+    security_rule {                                                                                                                                                                                             
+     name                       = "DenyInternetOutBound"                                                                                                                                                                  
+     priority                   = 100                                                                                                                                                                          
+     direction                  = "Outbound"                                                                                                                                                                    
+     access                     = "Deny"                                                                                                                                                                      
+     protocol                   = "*"                                                                                                                                                                        
+     source_port_range          = "*"                                                                                                                                                                          
+     destination_port_range     = "*"                                                                                                                                                                      
+     source_address_prefix      = "*"                                                                                                                                                                   
+     destination_address_prefix = "Internet"
+   }  
+
   tags = {
     environment = var.environment
   }
@@ -11,6 +35,4 @@ resource "azurerm_network_security_group" "lb_subnet" {
 resource "azurerm_subnet_network_security_group_association" "lb_subnet" {
   subnet_id                 = var.lb_subnet_id
   network_security_group_id = azurerm_network_security_group.lb_subnet.id
-
-  // TODO: add security rules to allow inbound/outbound to Sentinel and to the VNET, but not the internet
 }

--- a/infrastructure/modules/cluster/network_security_group.tf
+++ b/infrastructure/modules/cluster/network_security_group.tf
@@ -3,6 +3,66 @@ resource "azurerm_network_security_group" "cluster_subnet" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
+  security_rule {
+    name                       = "port15021"
+    priority                   = 500
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "15021"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = var.cluster_public_ip
+  }
+
+  security_rule {
+    name                       = "port80"
+    priority                   = 501
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = var.cluster_public_ip
+  }
+
+  security_rule {
+    name                       = "port443"
+    priority                   = 502
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = var.cluster_public_ip
+  }
+
+  security_rule {
+    name                       = "port31400"
+    priority                   = 503
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "31400"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = var.cluster_public_ip
+  }
+
+  security_rule {
+    name                       = "port15443"
+    priority                   = 504
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "15443"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = var.cluster_public_ip
+  }
+
   tags = {
     environment = var.environment
   }

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -80,3 +80,7 @@ variable "logs_storage_account_id" {
   description = "ID of the immutable storage account used for logs"
   default     = ""
 }
+
+variable "cluster_public_ip" {
+  description = "IP address of the public endpoint of the cluster"
+}

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -84,7 +84,3 @@ variable "logs_storage_account_id" {
   description = "ID of the immutable storage account used for logs"
   default     = ""
 }
-
-variable "cluster_public_ip" {
-  description = "IP address of the public endpoint of the cluster"
-}

--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -18,6 +18,10 @@ variable "lb_subnet_id" {
   description = "Load Balancer Subnet id"
 }
 
+variable "lb_subnet_name" {
+  description = "Load balancer subnet name"
+}
+
 variable "cluster_subnet_name" {
   description = "Cluster Subnet name"
 }


### PR DESCRIPTION
# Add network security group for cluster

Relates to #801 

Restrict inbound and outbound traffic from cluster subnets using network security groups.

![](https://media.giphy.com/media/11fot0YzpQMA0g/giphy.gif)

### Acceptance Criteria

- [ ] Restrict inbound and outbound connections to the cluster, whilst ensuring existing required connections are allowed

### Testing information

Test hitting doc-index-updater and medicines-api endpoints and ensuring documents can still be processed and uploaded.

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
