### PR TITLE
Add service bus specific alert

### DIFF
--- a/infrastructure/modules/cluster/alerts.tf
+++ b/infrastructure/modules/cluster/alerts.tf
@@ -78,7 +78,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "doc_index_updater_errors
   | extend correlation_id = tostring(LogEntry.span.correlation_id)
   | extend message = tostring(LogEntry.fields.message)
   | extend level = tostring(LogEntry.level)
-  | where level == "ERROR"
+  | where level == "ERROR" and message !contains '500 Internal Server Error when reading queue'
   | order by TimeGenerated desc
   QUERY
   severity       = 1
@@ -87,5 +87,44 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "doc_index_updater_errors
   trigger {
     operator  = "GreaterThan"
     threshold = 10
+  }
+}
+
+# Periodic disruptions to connection to Service Bus seem common - this alert only fires when there are 5 minutes out of 10 where
+# service bus connection errors are thrown, by grouping service bus errors by minute
+resource "azurerm_monitor_scheduled_query_rules_alert" "doc_index_updater_service_bus_errors_alert" {
+  name                = "Doc Index Updater Service Bus Errors (${var.environment})"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  action {
+    action_group           = [azurerm_monitor_action_group.support.id]
+    email_subject          = "Doc Index Updater Service Bus Errors (${var.environment})"
+    custom_webhook_payload = "{}"
+  }
+  data_source_id = azurerm_log_analytics_workspace.cluster.id
+  description    = "Alert when total results cross threshold"
+  enabled        = true
+  query          = <<-QUERY
+  let clusterId = '${azurerm_kubernetes_cluster.cluster.id}';
+  let ContainerIdList = KubePodInventory
+  | where ContainerName contains 'doc-index-updater'
+  | where ClusterId =~ clusterId
+  | distinct ContainerID;
+  ContainerLog
+  | where ContainerID in (ContainerIdList)
+  | project parse_json(LogEntry), TimeGenerated, ContainerID
+  | render table
+  | extend message = tostring(LogEntry.fields.message)
+  | extend level = tostring(LogEntry.level)
+  | where level == "ERROR" and message contains '500 Internal Server Error when reading queue'
+  | summarize count() by bin(TimeGenerated, 1m)
+  QUERY
+  severity       = 1
+  frequency      = 5
+  time_window    = 10
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 5
   }
 }


### PR DESCRIPTION
# Add service bus specific alert

Service bus connectivity issues sometimes generate continuous errors for several minutes during day-to-day running of the doc index updater service. This PR excludes them from the generic error alert and introduces a new alert that requires service bus errors to be generated for 5 minutes within a 10 min period, which would be indicative of a longer term issue that should be investigated.

![](https://media.giphy.com/media/qHSS4bGQUTcY0/giphy.gif)

### Acceptance Criteria

- [ ] Alert generated when service bus errors have been generated in 5 out of any 10 min period
- [ ] Other alerts continue to be generated when there are 10 errors in any 10 min period

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
