### PR TITLE
Add cors back in to post request

### DIFF
--- a/medicines/api/src/main.rs
+++ b/medicines/api/src/main.rs
@@ -54,17 +54,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("0.0.0.0:{}", get_env_or_default("PORT", PORT.to_string()))
         .parse::<SocketAddr>()?;
 
-    let graphql_options = warp::options()
-        .map(warp::reply)
-        .with(cors.clone())
-        .with(warp::log("cors-only"));
-
     let graphql_post = async_graphql_warp::graphql(schema.0)
         .and_then(|(schema, builder): (_, QueryBuilder)| async move {
             let response = builder.execute(&schema).await;
             Ok::<_, Infallible>(GQLResponse::from(response))
         })
-        .with(cors);
+        .with(cors.clone());
+
+    let graphql_options = warp::options()
+        .map(warp::reply)
+        .with(cors)
+        .with(warp::log("cors-only"));
 
     let graphql_playground = warp::path::end().and(warp::get()).map(|| {
         Response::builder()

--- a/medicines/api/src/main.rs
+++ b/medicines/api/src/main.rs
@@ -54,17 +54,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("0.0.0.0:{}", get_env_or_default("PORT", PORT.to_string()))
         .parse::<SocketAddr>()?;
 
-    let graphql_post = async_graphql_warp::graphql(schema.0).and_then(
-        |(schema, builder): (_, QueryBuilder)| async move {
-            let response = builder.execute(&schema).await;
-            Ok::<_, Infallible>(GQLResponse::from(response))
-        },
-    );
-
     let graphql_options = warp::options()
         .map(warp::reply)
-        .with(cors)
+        .with(cors.clone())
         .with(warp::log("cors-only"));
+
+    let graphql_post = async_graphql_warp::graphql(schema.0)
+        .and_then(|(schema, builder): (_, QueryBuilder)| async move {
+            let response = builder.execute(&schema).await;
+            Ok::<_, Infallible>(GQLResponse::from(response))
+        })
+        .with(cors);
 
     let graphql_playground = warp::path::end().and(warp::get()).map(|| {
         Response::builder()


### PR DESCRIPTION
# Add cors back in to post request

Recent refactor of API to use async_graphql dropped cors response from post requests. This adds it back in.

![](https://media.giphy.com/media/i6JLRbk4f2gIU/giphy.gif)

### Acceptance Criteria

- [ ] Browser requests to API are returned with `access-control-allow-origin: <origin>`

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
