### PR TITLE
Update msal from 1.3.4 -> 1.4.0 to remove issue with blank token

### DIFF
--- a/medicines/pars-upload/package.json
+++ b/medicines/pars-upload/package.json
@@ -21,7 +21,7 @@
     "classnames": "^2.2.6",
     "core-js": "^3.4.7",
     "govuk-frontend": "^3.8.0",
-    "msal": "^1.3.4",
+    "msal": "1.4.0",
     "next": "^9.5.2",
     "next-compose-plugins": "^2.2.0",
     "next-optimized-images": "^2.6.2",

--- a/medicines/pars-upload/yarn.lock
+++ b/medicines/pars-upload/yarn.lock
@@ -7014,10 +7014,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-msal@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/msal/-/msal-1.3.4.tgz#5803c3c948bc827879a1d812bb6719839c2af8de"
-  integrity sha512-FQUillxx0/SDc7mJrii8MMx1k0cV9C5x8h7AcSvwovEZe5LBGiAGU7dv/0pg5Q64T9TT1iIg4tlHO2xWYuJfvA==
+msal@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/msal/-/msal-1.4.0.tgz#7e6e053a8cd3fd5b693e2f9504737f0c2b1219d4"
+  integrity sha512-NTxMFQh6t5g2QWMlvZTWTxL1bmcqiCv0cs2lxTHhUbWEuxWCfvaVRZfjxN8i+T0VltVVGaVIdML8QEoBnlbaSw==
   dependencies:
     tslib "^1.9.3"
 


### PR DESCRIPTION
# Update msal from v1.3.4 -> v1.4.0 to remove issue with blank token on auth object
v1.3.2 of msal returned an auth token with the `token` field populated. v1.3.4 does not, so updating to v1.4.0, which remedies the issue.

![](https://media.giphy.com/media/l2Je5m7NKZPlsW1La/giphy.gif)

### Acceptance Criteria

- [ ] Token on auth object returned by msal is populated
- [ ] Token is submitted when making requests to doc index updater

### Testing information

- Can submit PAR in nonprod

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
