### PR TITLE
Remove references to graphiql following api update

### DIFF
--- a/medicines/api/README.md
+++ b/medicines/api/README.md
@@ -2,7 +2,7 @@
 
 ![medicines-api](https://github.com/MHRA/products/workflows/medicines-api-master/badge.svg)
 
-This is where the code for the [Medicines API](https://medicines.api.mhra.gov.uk/graphiql) lives.
+This is where the code for the [Medicines API](https://medicines.api.mhra.gov.uk) lives.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ You should also have installed:
 4. Once compiled, open a browser tab and go to http://127.0.0.1:8000/healthz
 5. You should see **OK** rendered on the page
 
-To see the GraphQL explorer, go to http://127.0.0.1:8000/graphiql.
+To see the GraphQL explorer, go to http://127.0.0.1:8000.
 
 ## Running in Docker container 🐳
 
@@ -41,7 +41,7 @@ To see the GraphQL explorer, go to http://127.0.0.1:8000/graphiql.
 4. Open the browser and go to `http://localhost:8080/healthz`
 5. You should see an **Ok** and a server log in your terminal
 
-To see the GraphQL explorer, go to http://127.0.0.1:8080/graphiql.
+To see the GraphQL explorer, go to http://127.0.0.1:8080.
 
 ## Deploy API pod in Kubernetes cluster ⎈
 

--- a/medicines/docs/architecture/README.md
+++ b/medicines/docs/architecture/README.md
@@ -16,7 +16,7 @@ Metadata for the medicines (including lists of associated documents) is attached
 
 ## Medicines API
 
-The API pod contains a lightweight custom HTTP server, written in Rust. It is stateless so it can scale out easily. It allows SPC, PIL and PAR to be searched via a self-documented, read-only, [GraphQL-based API](https://medicines.api.mhra.gov.uk/graphiql).
+The API pod contains a lightweight custom HTTP server, written in Rust. It is stateless so it can scale out easily. It allows SPC, PIL and PAR to be searched via a self-documented, read-only, [GraphQL-based API](https://medicines.api.mhra.gov.uk).
 
 ## SPC/PIL/PAR document management
 


### PR DESCRIPTION
# Remove references to graphiql following api update

Following update of medicines API from juniper to async graphql, no longer need to go to `/graphiql` to see graphical interface.

Updating documentation to reflect that.

### Acceptance Criteria

- [ ] No references to `graphiql` in documentation

### Testing information

- Ctrl + f in products repository

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
