### PR TITLE
Required PARs changes following msal package update

### DIFF
--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -64,7 +64,7 @@ describe('New PARs upload', () => {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
       doseForm: 'some form',
-      substances: 'Ibuprofen',
+      substance: 'Ibuprofen',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
     let uploadPageTitle = 'New Public Assessment Report'

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -17,9 +17,20 @@ setUp()
 const parsUrl = Cypress.env('PARS_UPLOAD_URL')
 const baseUrl = Cypress.config().baseUrl
 
+const startNewParForm = () => {
+  cy.visit('/')
+
+  cy.findAllByText('What are you doing today?').should('exist')
+
+  cy.findByText('Upload a new document').click()
+
+  cy.findByText('Continue').click()
+}
+
 describe('New PARs upload', () => {
   it('can add and delete multiple substances', () => {
-    cy.visit('/new-par')
+    startNewParForm()
+
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -33,7 +44,8 @@ describe('New PARs upload', () => {
   })
 
   it('can add and delete multiple products', () => {
-    cy.visit('/new-par')
+    startNewParForm()
+
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -45,8 +57,21 @@ describe('New PARs upload', () => {
     let uploadPageTitle = 'New Public Assessment Report'
     addAndDeleteProducts(uploadData, uploadPageTitle)
   })
+  it('duplicate licence numbers are not allowed', () => {
+    startNewParForm()
+
+    let uploadData = {
+      brand: 'Ibuprofen pills',
+      strength: 'Really powerful stuff',
+      doseForm: 'some form',
+      substances: 'Ibuprofen',
+      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
+    }
+    let uploadPageTitle = 'New Public Assessment Report'
+    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
+  })
   it('upload field only accepts PDFs', () => {
-    cy.visit('/new-par')
+    startNewParForm()
 
     let uploadData = {
       brand: 'Ibuprofen pills',
@@ -68,21 +93,8 @@ describe('New PARs upload', () => {
       )
     })
   })
-  it('duplicate licence numbers are not allowed', () => {
-    cy.visit('/new-par')
-
-    let uploadData = {
-      brand: 'Ibuprofen pills',
-      strength: 'Really powerful stuff',
-      doseForm: 'some form',
-      substances: 'Ibuprofen',
-      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
-    }
-    let uploadPageTitle = 'New Public Assessment Report'
-    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
-  })
   it('review page shows the correct information', () => {
-    cy.visit('/new-par')
+    startNewParForm()
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -163,7 +175,7 @@ describe('New PARs upload', () => {
     )
   })
   it('shows the uploaded file when going back to upload file page', () => {
-    cy.visit('/new-par')
+    startNewParForm()
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -205,7 +217,7 @@ describe('New PARs upload', () => {
       mockSuccessfulSubmission(baseUrl, parsUrl)
     }
 
-    cy.visit('/new-par')
+    startNewParForm()
 
     let uploadData = {
       brand: 'Ibuprofen pills',

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -75,7 +75,7 @@ describe('New PARs upload', () => {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
       doseForm: 'some form',
-      substances: ['Ibuprofen', 'Paracetamol'],
+      substances: 'Ibuprofen',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
     let uploadPageTitle = 'New Public Assessment Report'

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -57,20 +57,6 @@ describe('New PARs upload', () => {
     let uploadPageTitle = 'New Public Assessment Report'
     addAndDeleteProducts(uploadData, uploadPageTitle)
   })
-  it('duplicate licence numbers are not allowed', () => {
-    startNewParForm()
-
-    let uploadData = {
-      brand: 'Ibuprofen pills',
-      strength: 'Really powerful stuff',
-      doseForm: 'some form',
-      substance1: 'Ibuprofen',
-      substance2: 'Paracetamol',
-      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
-    }
-    let uploadPageTitle = 'New Public Assessment Report'
-    addAndDeleteProducts(uploadData, uploadPageTitle)
-  })
   it('upload field only accepts PDFs', () => {
     startNewParForm()
 
@@ -93,6 +79,19 @@ describe('New PARs upload', () => {
         'One or more field is invalid within given file(s)'
       )
     })
+  })
+  it('duplicate licence numbers are not allowed', () => {
+    startNewParForm()
+
+    let uploadData = {
+      brand: 'Ibuprofen pills',
+      strength: 'Really powerful stuff',
+      doseForm: 'some form',
+      substance: 'Ibuprofen',
+      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
+    }
+    let uploadPageTitle = 'New Public Assessment Report'
+    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
   })
   it('review page shows the correct information', () => {
     startNewParForm()

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -52,7 +52,7 @@ describe('New PARs upload', () => {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
       doseForm: 'some form',
-      substances: ['Ibuprofen', 'Paracetamol'],
+      substance: 'Ibuprofen',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
     let uploadPageTitle = 'New Public Assessment Report'

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -64,11 +64,12 @@ describe('New PARs upload', () => {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
       doseForm: 'some form',
-      substance: 'Ibuprofen',
+      substance1: 'Ibuprofen',
+      substance2: 'Paracetamol',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
     let uploadPageTitle = 'New Public Assessment Report'
-    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
+    addAndDeleteProducts(uploadData, uploadPageTitle)
   })
   it('upload field only accepts PDFs', () => {
     startNewParForm()

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -45,19 +45,6 @@ describe('New PARs upload', () => {
     let uploadPageTitle = 'New Public Assessment Report'
     addAndDeleteProducts(uploadData, uploadPageTitle)
   })
-  it('duplicate licence numbers are not allowed', () => {
-    cy.visit('/new-par')
-
-    let uploadData = {
-      brand: 'Ibuprofen pills',
-      strength: 'Really powerful stuff',
-      doseForm: 'some form',
-      substance: 'Ibuprofen',
-      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
-    }
-    let uploadPageTitle = 'New Public Assessment Report'
-    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
-  })
   it('upload field only accepts PDFs', () => {
     cy.visit('/new-par')
 
@@ -80,6 +67,19 @@ describe('New PARs upload', () => {
         'One or more field is invalid within given file(s)'
       )
     })
+  })
+  it('duplicate licence numbers are not allowed', () => {
+    cy.visit('/new-par')
+
+    let uploadData = {
+      brand: 'Ibuprofen pills',
+      strength: 'Really powerful stuff',
+      doseForm: 'some form',
+      substances: ['Ibuprofen', 'Paracetamol'],
+      licence: { type: 'THR', part_one: '12345', part_two: '6789' },
+    }
+    let uploadPageTitle = 'New Public Assessment Report'
+    addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
   })
   it('review page shows the correct information', () => {
     cy.visit('/new-par')

--- a/medicines/pars-upload/cypress/integration/new-par.js
+++ b/medicines/pars-upload/cypress/integration/new-par.js
@@ -17,19 +17,9 @@ setUp()
 const parsUrl = Cypress.env('PARS_UPLOAD_URL')
 const baseUrl = Cypress.config().baseUrl
 
-const startNewParForm = () => {
-  cy.visit('/')
-
-  cy.findAllByText('What are you doing today?').should('exist')
-
-  cy.findByText('Upload a new document').click()
-
-  cy.findByText('Continue').click()
-}
-
 describe('New PARs upload', () => {
   it('can add and delete multiple substances', () => {
-    startNewParForm()
+    cy.visit('/new-par')
 
     let uploadData = {
       brand: 'Ibuprofen pills',
@@ -44,7 +34,7 @@ describe('New PARs upload', () => {
   })
 
   it('can add and delete multiple products', () => {
-    startNewParForm()
+    cy.visit('/new-par')
 
     let uploadData = {
       brand: 'Ibuprofen pills',
@@ -58,7 +48,7 @@ describe('New PARs upload', () => {
     addAndDeleteProducts(uploadData, uploadPageTitle)
   })
   it('upload field only accepts PDFs', () => {
-    startNewParForm()
+    cy.visit('/new-par')
 
     let uploadData = {
       brand: 'Ibuprofen pills',
@@ -81,7 +71,7 @@ describe('New PARs upload', () => {
     })
   })
   it('duplicate licence numbers are not allowed', () => {
-    startNewParForm()
+    cy.visit('/new-par')
 
     let uploadData = {
       brand: 'Ibuprofen pills',
@@ -94,7 +84,7 @@ describe('New PARs upload', () => {
     addDuplicateLicenceNumbers(uploadData, uploadPageTitle)
   })
   it('review page shows the correct information', () => {
-    startNewParForm()
+    cy.visit('/new-par')
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -175,7 +165,7 @@ describe('New PARs upload', () => {
     )
   })
   it('shows the uploaded file when going back to upload file page', () => {
-    startNewParForm()
+    cy.visit('/new-par')
     let uploadData = {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
@@ -217,7 +207,7 @@ describe('New PARs upload', () => {
       mockSuccessfulSubmission(baseUrl, parsUrl)
     }
 
-    startNewParForm()
+    cy.visit('/new-par')
 
     let uploadData = {
       brand: 'Ibuprofen pills',

--- a/medicines/pars-upload/cypress/integration/update-par.js
+++ b/medicines/pars-upload/cypress/integration/update-par.js
@@ -59,7 +59,7 @@ describe('Update PARs', () => {
       brand: 'Ibuprofen pills',
       strength: 'Really powerful stuff',
       doseForm: 'some form',
-      substances: ['Ibuprofen', 'Paracetamol'],
+      substance: 'Ibuprofen',
       licence: { type: 'THR', part_one: '12345', part_two: '6789' },
     }
     let uploadPageTitle = 'Updated Public Assessment Report'

--- a/medicines/pars-upload/cypress/support/shared.js
+++ b/medicines/pars-upload/cypress/support/shared.js
@@ -150,37 +150,44 @@ export const addAndDeleteProducts = (uploadData, expectedTitle) => {
 export const addDuplicateLicenceNumbers = (uploadData, expectedTitle) => {
   cy.findAllByText(expectedTitle).not('title').should('exist')
 
-  for (let i = 0; i < 2; i++) {
-    cy.findByLabelText('Brand/Generic name').should('have.value', '')
+  cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
-    cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
+  cy.findByLabelText('Strength').type(uploadData.strength)
 
-    cy.findByLabelText('Strength').type(uploadData.strength)
+  cy.findByLabelText('Pharmaceutical dose form').type(uploadData.doseForm)
 
-    cy.findByLabelText('Pharmaceutical dose form').type(uploadData.doseForm)
+  cy.findByLabelText('Active substance(s)').type(uploadData.substance)
 
-    cy.findByLabelText('Active substance(s)').type(uploadData.substances[0])
+  cy.findByText('Licence number')
+    .parent()
+    .parent()
+    .within(() => {
+      cy.findByLabelText('Type').select(uploadData.licence.type)
+      cy.findByLabelText('First five digits').type(uploadData.licence.part_one)
+      cy.findByLabelText('Last four digits').type(uploadData.licence.part_two)
+    })
+  cy.findByText('Add another product').click()
 
-    for (let j = 1; j < uploadData.substances.length; j++) {
-      cy.findByText('Add another active substance').click()
-      cy.findAllByLabelText('Active substance(s)')
-        .last()
-        .type(uploadData.substances[j])
-    }
+  cy.findByLabelText('Brand/Generic name').should('have.value', '')
 
-    cy.findByText('Licence number')
-      .parent()
-      .parent()
-      .within(() => {
-        cy.findByLabelText('Type').select(uploadData.licence.type)
-        cy.findByLabelText('First five digits').type(
-          uploadData.licence.part_one
-        )
-        cy.findByLabelText('Last four digits').type(uploadData.licence.part_two)
-      })
+  cy.findByLabelText('Brand/Generic name').type(uploadData.brand)
 
-    cy.findByText('Add another product').click()
-  }
+  cy.findByLabelText('Strength').type(uploadData.strength)
+
+  cy.findByLabelText('Pharmaceutical dose form').type(uploadData.doseForm)
+
+  cy.findByLabelText('Active substance(s)').type(uploadData.substance)
+
+  cy.findByText('Licence number')
+    .parent()
+    .parent()
+    .within(() => {
+      cy.findByLabelText('Type').select(uploadData.licence.type)
+      cy.findByLabelText('First five digits').type(uploadData.licence.part_one)
+      cy.findByLabelText('Last four digits').type(uploadData.licence.part_two)
+    })
+
+  cy.findByText('Add another product').click()
 
   const validationMsg = 'Duplicate licence numbers are not allowed'
 

--- a/medicines/pars-upload/src/auth/authConfig.js
+++ b/medicines/pars-upload/src/auth/authConfig.js
@@ -19,5 +19,5 @@ export const loginRequest = {
 
 // Add here scopes for access token to be used at MS Graph API endpoints.
 export const tokenRequest = {
-  scopes: ['user.read'],
+  scopes: [],
 }

--- a/medicines/pars-upload/src/auth/authConfig.js
+++ b/medicines/pars-upload/src/auth/authConfig.js
@@ -19,5 +19,5 @@ export const loginRequest = {
 
 // Add here scopes for access token to be used at MS Graph API endpoints.
 export const tokenRequest = {
-  scopes: [],
+  scopes: ['user.read'],
 }

--- a/medicines/pars-upload/src/auth/authPopup.js
+++ b/medicines/pars-upload/src/auth/authPopup.js
@@ -1,23 +1,25 @@
 import { UserAgentApplication } from 'msal'
-import { msalConfig, loginRequest } from './authConfig'
+import { msalConfig, loginRequest, tokenRequest } from './authConfig'
 
 export async function getAccount() {
   msalConfig.auth.redirectUri = getCurrentHost(window.location.href)
   const msalInstance = new UserAgentApplication(msalConfig)
   const account = msalInstance.getAccount()
 
-  if (account) {
-    const token = window.sessionStorage['msal.idtoken']
-    const username = account.userName
-
-    return {
-      account,
-      token,
-      username,
-      signOut: () => {
-        msalInstance.logout()
-      },
-    }
+  if (msalInstance && account) {
+    let auth = await msalInstance
+      .acquireTokenSilent(tokenRequest)
+      .then((response) => {
+        return {
+          account,
+          token: response.accessToken,
+          username: account.userName,
+          signOut: () => {
+            msalInstance.logout()
+          },
+        }
+      })
+    return auth
   }
 }
 

--- a/medicines/pars-upload/src/auth/authPopup.js
+++ b/medicines/pars-upload/src/auth/authPopup.js
@@ -1,25 +1,24 @@
 import { UserAgentApplication } from 'msal'
-import { msalConfig, loginRequest, tokenRequest } from './authConfig'
+import { msalConfig, loginRequest } from './authConfig'
 
 export async function getAccount() {
   msalConfig.auth.redirectUri = getCurrentHost(window.location.href)
   const msalInstance = new UserAgentApplication(msalConfig)
   const account = msalInstance.getAccount()
 
-  if (msalInstance && account) {
-    let auth = await msalInstance
-      .acquireTokenSilent(tokenRequest)
-      .then((response) => {
-        return {
-          account,
-          token: response.accessToken,
-          username: account.userName,
-          signOut: () => {
-            msalInstance.logout()
-          },
-        }
-      })
-    return auth
+  if (account) {
+    const tokenSessionStorageKey = `msal.${msalConfig.auth.clientId}.idtoken`
+    const token = window.sessionStorage[tokenSessionStorageKey]
+    const username = account.userName
+
+    return {
+      account,
+      token,
+      username,
+      signOut: () => {
+        msalInstance.logout()
+      },
+    }
   }
 }
 


### PR DESCRIPTION
# Acquire and set PARs access token separately

Package update of msal no longer seems to set the `msal.idtoken` session storage entry on login, so adding an additional step, [in line with the docs](https://www.npmjs.com/package/msal#3-get-an-access-token-to-call-an-api), to acquire the access token after logging in and using that to set the auth object so that it's passed properly when submitting to the doc index updater.

### Acceptance Criteria

- [ ] Users can log in and submit documents successfully

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
