### PR TITLE
Add two new log types to cluster diagnostic config

### DIFF
--- a/infrastructure/modules/cluster/variables.tf
+++ b/infrastructure/modules/cluster/variables.tf
@@ -57,6 +57,8 @@ variable "diagnostic_log_types" {
     "kube-audit",
     "kube-controller-manager",
     "kube-scheduler",
+    "guard",
+    "kube-audit-admin",
   "cluster-autoscaler"]
 }
 


### PR DESCRIPTION
# Add two new log types to cluster diagnostic config

Including two new diagnostic log types in the terraform configuration for the cluster diagnostics.

### Acceptance Criteria

- [ ] All metric types included in terraform configuration

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
