### PR TITLE
Release workflows should target renamed new prod overlays

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -75,7 +75,7 @@ jobs:
           kustomize: 3.4.0
           command: |
             set -eux
-            cd deployments/doc-index-updater/overlays/prod-new
+            cd deployments/doc-index-updater/overlays/prod
 
             kustomize edit set image $DIGEST
 

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -75,7 +75,7 @@ jobs:
           kustomize: 3.4.0
           command: |
             set -eux
-            cd deployments/medicines-api/overlays/prod-new
+            cd deployments/medicines-api/overlays/prod
 
             kustomize edit set image $DIGEST
 


### PR DESCRIPTION
# Release workflows should target renamed new prod overlays

Deprecating old prod overlays in deployments repository and renaming `prod-new` to `prod`. This renames the release workflow files to match.

### Acceptance Criteria

- [ ] _The first thing this PR must achieve_
- [ ] _The second thing this PR must achieve_
- [ ] _etc_

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
