### PR TITLE
Shorten lock duration and max delivery count

### DIFF
--- a/infrastructure/modules/service-bus/main.tf
+++ b/infrastructure/modules/service-bus/main.tf
@@ -25,6 +25,8 @@ resource "azurerm_servicebus_queue" "service_bus_queue" {
   count               = length(local.queue_names)
   namespace_name      = azurerm_servicebus_namespace.service_bus.name
   resource_group_name = var.resource_group_name
+  lock_duration       = "PT20S"
+  max_delivery_count  = 5
 }
 
 resource "azurerm_servicebus_queue_authorization_rule" "service_bus_queue_auth_rule" {


### PR DESCRIPTION
# Shorten lock duration and max delivery count

The vast majority of jobs fail within 20 seconds so reducing this in order to achieve a retry more quickly.
If a job is going to succeed it will usually do so within 1-2 attempts, so also reducing max retries from 10 -> 5.
There is score to reduce both of these numbers further.

### Acceptance Criteria

- [ ] _The first thing this PR must achieve_
- [ ] _The second thing this PR must achieve_
- [ ] _etc_

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
