### PR TITLE
Reorder repo digest in workflow

### DIFF
--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG
           make docker-push image=$PROD_IMAGE tag=$TAG
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 1}}' ${PROD_IMAGE}:${TAG})"
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${PROD_IMAGE}:${TAG})"
           echo ::set-env name=DIGEST::$DIGEST
 
       - name: Create Release

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG
           make docker-push image=$PROD_IMAGE tag=$TAG
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 1}}' ${PROD_IMAGE}:${TAG})"
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${PROD_IMAGE}:${TAG})"
           echo ::set-env name=DIGEST::$DIGEST
 
       - name: Create Release


### PR DESCRIPTION
# Reorder repo digest in workflow

Repo digest is accessed by index and the repos are sorted alphabetically, e.g.
```
"RepoDigests": [
            "mhraproducts4853registry.azurecr.io/products/medicines-api@sha256:255cfec5e13da35ddf84c01f840c053b3c1d455cc8e27ba3674db63f7963c803",
            "mhraproductsnonprodregistry.azurecr.io/products/medicines-api@sha256:255cfec5e13da35ddf84c01f840c053b3c1d455cc8e27ba3674db63f7963c803"
        ],
```
The new prod repo comes first in the list as `mhraproducts4853` < `mhraproductsnonprod` so updating index to `0`.

### Acceptance Criteria

- [ ] _The first thing this PR must achieve_
- [ ] _The second thing this PR must achieve_
- [ ] _etc_

### Testing information

_notes that might be helpful for testing_

### Pre-flight Checklist

- [ ] Testing aligns with [testing strategy][testing strategy]
- [ ] DUXD review approval
- [ ] Accessibility Reviewed
- [ ] Product owner demo

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
