### PR TITLE
update doc-index-updater workflow for pr merge

### DIFF
--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -3,7 +3,7 @@ name: doc-index-updater-branch
 on:
   pull_request:
     branches:
-      - "master"
+      - master
     paths:
       - rust-toolchain
       - medicines/doc-index-updater/**
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-test:
-    name: Build and Test
+    name: Build, Test and Deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/doc-index-updater-master.yaml
+++ b/.github/workflows/doc-index-updater-master.yaml
@@ -5,8 +5,10 @@ on:
     branches:
       - master
     paths:
+      - rust-toolchain
       - medicines/doc-index-updater/**
       - medicines/search-client/**
+      - manifests/doc-index-updater/**
       - .github/workflows/doc-index-updater-master.yaml
       - .github/workflows/doc-index-updater-release.yaml
 
@@ -24,24 +26,65 @@ jobs:
         with:
           path: products
 
+      - uses: dorny/paths-filter@v2.5.1
+        id: filter
+        with:
+          working-directory: products
+          filters: |
+            src:
+              - rust-toolchain
+              - medicines/doc-index-updater/**/*
+              - medicines/search-client/**/*
+
       - name: Docker login
         uses: azure/docker-login@v1
+        if: steps.filter.outputs.src == 'true'
         with:
           login-server: mhraproductsnonprodregistry.azurecr.io
           username: mhraproductsnonprodregistry
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Set .env.build
-        working-directory: ./products/medicines/doc-index-updater
-        run: echo "SCCACHE_AZURE_CONNECTION_STRING=\"$SCCACHE_AZURE_CONNECTION_STRING\"" > .env.build
-        env:
-          SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+      - name: Make toolchain version available in current directory
+        if: steps.filter.outputs.src == 'true'
+        run: cp products/rust-toolchain .
 
-      - name: Build, test and push Docker image
-        working-directory: ./products/medicines/doc-index-updater
+      - uses: actions-rs/toolchain@v1
+        if: steps.filter.outputs.src == 'true'
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        if: steps.filter.outputs.src == 'true'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            products/medicines/doc-index-updater/target
+          key: cargo-${{ hashFiles('products/medicines/doc-index-updater/Cargo.lock') }}-1
+
+      - name: Install redis
+        uses: shogo82148/actions-setup-redis@v1
+        if: steps.filter.outputs.src == 'true'
+        with:
+          auto-start: "false"
+
+      - name: Build and test doc-index-updater service
+        if: steps.filter.outputs.src == 'true'
+        working-directory: products/medicines/doc-index-updater
+        run: |
+          set -e
+          set -a && source .env.base && set +a
+          cargo clippy --release -- -D warnings
+          cargo build --release
+          cargo test --release
+
+      - name: Build and push Docker image
+        if: steps.filter.outputs.src == 'true'
+        working-directory: products/medicines/doc-index-updater
         run: |
           TAG="$(git rev-parse --short=7 ${{ github.sha }})"
-          make ci-master tag=$TAG
+          make ci-master tag=$TAG image=$IMAGE
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
           echo "TAG=$TAG" >>$GITHUB_ENV
           echo "DIGEST=$DIGEST" >>$GITHUB_ENV
@@ -58,15 +101,15 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -eux
-            SOURCE="${PWD}/products/medicines/doc-index-updater/manifests/overlays/non-prod"
+            set -ex
+            SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
 
             cd $SOURCE 
-            kustomize edit set image $DIGEST
+            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
             kustomize build . > "${DEST}/manifests.yaml"
-            
+
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"
             git config --local user.name "MHRA CI/CD"


### PR DESCRIPTION
Updates the `doc-index-updater` master workflow to build outside of docker in order to leverage caching