### PR TITLE
Timlee/new pl formats

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -167,7 +167,7 @@ pub fn create_facets_by_active_substance(
 pub fn format_product_licence(input: &str) -> String {
     lazy_static! {
         static ref RE_WHITESPACE: Regex = Regex::new(r"(\s+|/|_|-)").expect("cannot compile regex");
-        static ref RE_PL: Regex = Regex::new(r"(?i:\b|[A-Z]+)(\s+|/|_|-)*\d{5}(\s+|/|_|-)*\d{4}")
+        static ref RE_PL: Regex = Regex::new(r"(?i:[A-Z]+)(\s+|/|_|-)*\d{5}(\s+|/|_|-)*\d{4}")
             .expect("cannot compile regex");
     }
     let product_licences: Vec<String> = RE_PL
@@ -292,6 +292,7 @@ mod test {
     #[test_case("THR 12345/1234", "[\"THR123451234\"]")]
     #[test_case("NR 12345/1234", "[\"NR123451234\"]")]
     #[test_case("NEW 12345/1234", "[\"NEW123451234\"]")]
+    #[test_case("12345/1234", "[]")]
     #[test_case("NO PL", "[]")]
     fn format_product_licence_test(input: &str, output: &str) {
         assert_eq!(format_product_licence(input), output);

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -7,7 +7,7 @@ extern crate lazy_static;
 
 use crate::models::{AzureIndexChangedResults, FacetResults, IndexEntry};
 use crate::query_normalizer::{
-    escape_special_characters, escape_special_words, extract_normalized_product_licences,
+    escape_special_characters, escape_special_words, normalize_product_licences,
     prefer_exact_match_but_support_fuzzy_match,
 };
 use async_trait::async_trait;
@@ -256,7 +256,7 @@ impl Search for AzureSearchClient {
 }
 
 fn clean_up_search_term(search_term: &str) -> String {
-    let search_term = extract_normalized_product_licences(&search_term);
+    let search_term = normalize_product_licences(&search_term);
     let search_term = escape_special_characters(&search_term);
     escape_special_words(&search_term)
 }

--- a/medicines/search-client/src/query_normalizer.rs
+++ b/medicines/search-client/src/query_normalizer.rs
@@ -2,23 +2,16 @@ use regex::Captures;
 
 use regex::Regex;
 
-pub fn extract_normalized_product_licences(search_term: &str) -> String {
+pub fn normalize_product_licences(search_term: &str) -> String {
     lazy_static! {
-        static ref RE_PRODUCT_LICENCE: Regex = Regex::new(r"(?i)(?P<prefix>PL|HR|THR|\s|^)(\s+|/|_|-)*(?P<fivenumbers>\d{5})(\s+|/|_|-)*(?P<fournumbers>\d{4})").unwrap();
+        static ref RE_PRODUCT_LICENCE: Regex = Regex::new(r"(?i)(?P<prefix>PL|PLGB|PLNI|THR|NR)(\s+|/|_|-)*(?P<fivenumbers>\d{5})(\s+|/|_|-)*(?P<fournumbers>\d{4})").unwrap();
     }
 
     RE_PRODUCT_LICENCE
         .replace_all(&search_term, |caps: &Captures| {
-            let prefix = if caps[1].is_empty() {
-                String::from("PL")
-            } else if caps[1].trim().is_empty() {
-                String::from(" PL")
-            } else {
-                caps[1].to_uppercase()
-            };
             format!(
                 "{prefix}{five_numbers}{four_numbers}",
-                prefix = prefix,
+                prefix = caps[1].to_uppercase(),
                 five_numbers = &caps[3],
                 four_numbers = &caps[5]
             )
@@ -67,17 +60,19 @@ mod test {
     use test_case::test_case;
 
     #[test_case("PL 12345/1234", "PL123451234")]
-    #[test_case("HR 12345/1234", "HR123451234")]
     #[test_case("THR 12345/1234", "THR123451234")]
-    #[test_case("12345/1234", "PL123451234")]
+    #[test_case("PLGB 12345/1234", "PLGB123451234")]
+    #[test_case("PLNI 12345/1234", "PLNI123451234")]
+    #[test_case("NEW 12345/1234", "NEW 12345/1234")]
+    #[test_case("12345/1234", "12345/1234")]
     #[test_case("PRETEXT PL 12345/1234 POSTTEXT", "PRETEXT PL123451234 POSTTEXT")]
-    #[test_case("PRETEXT 12345/1234 POSTTEXT", "PRETEXT PL123451234 POSTTEXT")]
     #[test_case("PRETEXT pl 12345/1234", "PRETEXT PL123451234")]
+    #[test_case("PRETEXT plgb 12345/1234", "PRETEXT PLGB123451234")]
     #[test_case("PL/23456/1234", "PL234561234")]
     #[test_case("PL-34567-1234", "PL345671234")]
     #[test_case("PL_45678_1234", "PL456781234")]
-    fn test_extract_normalized_product_licences(input: &str, expected: &str) {
-        let result = extract_normalized_product_licences(&input);
+    fn test_normalize_product_licences(input: &str, expected: &str) {
+        let result = normalize_product_licences(&input);
         assert_eq!(result, expected);
     }
 

--- a/medicines/web/src/components/search-results/__snapshots__/index.test.tsx.snap
+++ b/medicines/web/src/components/search-results/__snapshots__/index.test.tsx.snap
@@ -29,10 +29,10 @@ exports[`SearchResults should render 1`] = `
          website.
       </p>
       <p>
-        Before a medicine can be sold in the UK, a number of licences are essential. Products with a UK marketing authorisation have a licence number in the format ‘PL 12345/0001’. The first 2 characters are always the letters ‘PL’, and this can be found on the packaging of the product.
+        Before a medicine can be sold in the UK, a number of licences are essential. Products with a UK marketing authorisation have a licence number in the format ‘PL 12345/0001’, ‘PLGB 12345/0002’ or ‘PLNI 12345/0003’. The licence number can be found on the packaging of the product and the first 2 characters are always contain the letters ‘PL’.
       </p>
       <p>
-        You can identify the product in the list below using the PL number.
+        You can identify the product in the list below using the PL, PLGB or PLNI number.
       </p>
       <p>
         The information about a medicine will be updated when new evidence becomes available. This may mean that there are differences between the information in the pack and the information here. The most up-to-date information will be available on this site.

--- a/medicines/web/src/components/search-results/index.tsx
+++ b/medicines/web/src/components/search-results/index.tsx
@@ -314,12 +314,14 @@ const SearchResults = (props: ISearchResultsProps) => {
           <p>
             Before a medicine can be sold in the UK, a number of licences are
             essential. Products with a UK marketing authorisation have a licence
-            number in the format ‘PL 12345/0001’. The first 2 characters are
-            always the letters ‘PL’, and this can be found on the packaging of
-            the product.
+            number in the format ‘PL 12345/0001’, ‘PLGB 12345/0002’ or ‘PLNI
+            12345/0003’. The licence number can be found on the packaging of the
+            product and the first 2 characters are always contain the letters
+            ‘PL’.
           </p>
           <p>
-            You can identify the product in the list below using the PL number.
+            You can identify the product in the list below using the PL, PLGB or
+            PLNI number.
           </p>
           <p>
             The information about a medicine will be updated when new evidence

--- a/medicines/web/src/components/search-wrapper/index.tsx
+++ b/medicines/web/src/components/search-wrapper/index.tsx
@@ -49,8 +49,8 @@ const whitespaceRegExp: RegExp = new RegExp('\\s+', 'g');
 
 const formatSearchTerm = (s: string): string => {
   return s
-    .replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5, p6) => {
-      return `${p1 ? p1 : ''}${p2.toUpperCase()} ${p4}/${p6}`;
+    .replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5) => {
+      return `${p1.toUpperCase()} ${p3}/${p5}`;
     })
     .replace(whitespaceRegExp, ' ')
     .trim();

--- a/medicines/web/src/components/search-wrapper/index.tsx
+++ b/medicines/web/src/components/search-wrapper/index.tsx
@@ -3,7 +3,7 @@ import React, { FormEvent, useEffect } from 'react';
 import styled from 'styled-components';
 import { accessibleBackgroundBlue } from '../../styles/colors';
 import { baseSpace, mobileBreakpoint } from '../../styles/dimensions';
-
+import { productLicenseRegExp } from '../../services/search-query-normalizer';
 import DrugIndex, { index, IndexType } from '../drug-index';
 import Search from '../search';
 import YellowCard from '../yellow-card';
@@ -45,19 +45,15 @@ const formatInitialSearchTerm = (searchTerm: string | string[]) => {
   return '';
 };
 
-const extractProductLicenseRegExp: RegExp = new RegExp(
-  '(\\b|PL)(\\s+|/|_|-)*(\\d{5})(\\s+|/|_|-)*(\\d{4})',
-  'ig',
-);
-
 const whitespaceRegExp: RegExp = new RegExp('\\s+', 'g');
 
 const formatSearchTerm = (s: string): string => {
   return s
-    .replace(extractProductLicenseRegExp, ' PL $3/$5')
+    .replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5, p6) => {
+      return `${p1 ? p1 : ''}${p2.toUpperCase()} ${p4}/${p6}`;
+    })
     .replace(whitespaceRegExp, ' ')
-    .trim()
-    .toLowerCase();
+    .trim();
 };
 
 const SearchWrapper: React.FC<ISearchWrapperProps> = (props) => {

--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -50,6 +50,7 @@ describe(normalizeProductLicenses, () => {
     ${'plgb 30464/0140'}                                       | ${'PLGB304640140'}
     ${'plni 30464/0140'}                                       | ${'PLNI304640140'}
     ${'thr 30464/0140'}                                        | ${'THR304640140'}
+    ${'nr 30464/0140'}                                         | ${'NR304640140'}
     ${'pretext 30464-0140'}                                    | ${'pretext 30464-0140'}
     ${'pretext pl 30464-0140'}                                 | ${'pretext PL304640140'}
     ${'pretext pl 30464_0140 posttext'}                        | ${'pretext PL304640140 posttext'}

--- a/medicines/web/src/services/search-query-normalizer.test.ts
+++ b/medicines/web/src/services/search-query-normalizer.test.ts
@@ -1,7 +1,7 @@
 import {
   buildFuzzyQuery,
   escapeSpecialWords,
-  extractNormalizedProductLicenses,
+  normalizeProductLicenses,
 } from './search-query-normalizer';
 
 describe(buildFuzzyQuery, () => {
@@ -39,23 +39,23 @@ describe(buildFuzzyQuery, () => {
   });
 });
 
-describe(extractNormalizedProductLicenses, () => {
+describe(normalizeProductLicenses, () => {
   it.each`
-    input                                               | expectedResult
-    ${'pl 30464/0140'}                                  | ${'PL304640140'}
-    ${'pl30464/0140'}                                   | ${'PL304640140'}
-    ${'30464/0140'}                                     | ${'PL304640140'}
-    ${'pl/30464/0140'}                                  | ${'PL304640140'}
-    ${'pl-30464-0140'}                                  | ${'PL304640140'}
-    ${'pl_30464_0140'}                                  | ${'PL304640140'}
-    ${'hr 30464/0140'}                                  | ${'hr PL304640140'}
-    ${'thr 30464/0140'}                                 | ${'thr PL304640140'}
-    ${'pretext 30464/0140'}                             | ${'pretext PL304640140'}
-    ${'pretext 30464-0140'}                             | ${'pretext PL304640140'}
-    ${'pretext 30464_0140 posttext'}                    | ${'pretext posttext PL304640140'}
-    ${'pretext 30464_0140 midtext 12345_1234 posttext'} | ${'pretext midtext posttext PL304640140 PL123451234'}
+    input                                                      | expectedResult
+    ${'pl 30464/0140'}                                         | ${'PL304640140'}
+    ${'pl30464/0140'}                                          | ${'PL304640140'}
+    ${'pl/30464/0140'}                                         | ${'PL304640140'}
+    ${'pl-30464-0140'}                                         | ${'PL304640140'}
+    ${'pl_30464_0140'}                                         | ${'PL304640140'}
+    ${'plgb 30464/0140'}                                       | ${'PLGB304640140'}
+    ${'plni 30464/0140'}                                       | ${'PLNI304640140'}
+    ${'thr 30464/0140'}                                        | ${'THR304640140'}
+    ${'pretext 30464-0140'}                                    | ${'pretext 30464-0140'}
+    ${'pretext pl 30464-0140'}                                 | ${'pretext PL304640140'}
+    ${'pretext pl 30464_0140 posttext'}                        | ${'pretext PL304640140 posttext'}
+    ${'pretext pl 30464_0140 midtext thr 12345_1234 posttext'} | ${'pretext PL304640140 midtext THR123451234 posttext'}
   `('converts $input to $expectedResult', ({ input, expectedResult }) => {
-    const result = extractNormalizedProductLicenses(input);
+    const result = normalizeProductLicenses(input);
     expect(result).toBe(expectedResult);
   });
 });

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -1,42 +1,38 @@
 const searchExactnessBoost = process.env.AZURE_SEARCH_EXACTNESS_BOOST;
 const searchWordFuzziness = process.env.AZURE_SEARCH_WORD_FUZZINESS;
 
-const extractProductLicenseRegExp: RegExp = new RegExp(
-  '(\\b|PL)(\\s+|/|_|-)*(\\d{5})(\\s+|/|_|-)*(\\d{4})',
+export const productLicenseRegExp: RegExp = new RegExp(
+  '(\\s)*(PL|PLGB|PLNI|THR|NR)(\\s+|/|_|-)*(\\d{5})(\\s+|/|_|-)*(\\d{4})',
   'ig',
 );
 
+const nonSearchableCharactersRegExp: RegExp = new RegExp(
+  /(?:[,+\-!(){}\[\]^~*?:%\/]|\s+)/,
+  'ig',
+);
+
+const specialWordsRegExp: RegExp = new RegExp(
+  /(\|\||&&|\bAND\b|\bOR\b|\bNOT\b)/,
+  'gi',
+);
+
 export const escapeSpecialWords = (word: string): string =>
-  word.replace(/(\|\||&&|\bAND\b|\bOR\b|\bNOT\b)/gi, `\\$1`);
+  word.replace(specialWordsRegExp, `\\$1`);
 
 const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
   `(${word}~${searchWordFuzziness} || ${word}^${searchExactnessBoost})`;
 
-export const extractNormalizedProductLicenses = (q: string): string => {
-  const normalizedProductLicences = q
-    .match(extractProductLicenseRegExp)
-    ?.map((match) =>
-      match.replace(extractProductLicenseRegExp, 'PL$3$5').trim(),
-    );
-
-  if (normalizedProductLicences && normalizedProductLicences.length) {
-    const normalizedProductLicencesString: string = normalizedProductLicences.join(
-      ' ',
-    );
-    const qWithoutProductLicences = q.replace(extractProductLicenseRegExp, '');
-    return `${
-      qWithoutProductLicences ? `${qWithoutProductLicences} ` : ''
-    }${normalizedProductLicencesString}`;
-  }
-
-  return `${q}`;
+export const normalizeProductLicenses = (q: string): string => {
+  return q.replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5, p6) => {
+    return `${p1 ? p1 : ''}${p2.toUpperCase()}${p4}${p6}`;
+  });
 };
 
 const splitByNonSearchableCharacters = (query: string) =>
-  query.split(/(?:[,+\-!(){}\[\]^~*?:%\/]|\s+)/gi);
+  query.split(nonSearchableCharactersRegExp);
 
 export const buildFuzzyQuery = (query: string): string => {
-  return splitByNonSearchableCharacters(extractNormalizedProductLicenses(query))
+  return splitByNonSearchableCharacters(normalizeProductLicenses(query))
     .filter((x) => x.length > 0)
     .map((word) => escapeSpecialWords(word))
     .map((word) => preferExactMatchButSupportFuzzyMatch(word))

--- a/medicines/web/src/services/search-query-normalizer.ts
+++ b/medicines/web/src/services/search-query-normalizer.ts
@@ -2,7 +2,7 @@ const searchExactnessBoost = process.env.AZURE_SEARCH_EXACTNESS_BOOST;
 const searchWordFuzziness = process.env.AZURE_SEARCH_WORD_FUZZINESS;
 
 export const productLicenseRegExp: RegExp = new RegExp(
-  '(\\s)*(PL|PLGB|PLNI|THR|NR)(\\s+|/|_|-)*(\\d{5})(\\s+|/|_|-)*(\\d{4})',
+  '(PL|PLGB|PLNI|THR|NR)(\\s+|/|_|-)*(\\d{5})(\\s+|/|_|-)*(\\d{4})',
   'ig',
 );
 
@@ -23,8 +23,8 @@ const preferExactMatchButSupportFuzzyMatch = (word: string): string =>
   `(${word}~${searchWordFuzziness} || ${word}^${searchExactnessBoost})`;
 
 export const normalizeProductLicenses = (q: string): string => {
-  return q.replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5, p6) => {
-    return `${p1 ? p1 : ''}${p2.toUpperCase()}${p4}${p6}`;
+  return q.replace(productLicenseRegExp, (match, p1, p2, p3, p4, p5) => {
+    return `${p1.toUpperCase()}${p3}${p5}`;
   });
 };
 


### PR DESCRIPTION
# Add support for new PL prefixes

Add support for new PL-type prefixes

### Acceptance Criteria

- [x] When a message is sent to the Doc Index Updater with any of the PL prefixes (PL, PLNI, PLGB, THR, NR), it is saved in normalized form in Azure (e.g. PLNI123451234)
- [x] When a user searches for a document using any of the PL prefixes (PL, PLNI, PLGB, THR, NR) and the site is using Azure, the correct documents are returned 
- [x] When a user searches for a document using any of the PL prefixes (PL, PLNI, PLGB, THR, NR) and the site is using the GraphQL API, the correct documents are returned 