### PR TITLE
Updgrade certificate manager api version for prod

### DIFF
--- a/manifests/doc-index-updater/overlays/prod/certificate.yaml
+++ b/manifests/doc-index-updater/overlays/prod/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-doc-index-updater

--- a/manifests/medicines-api/overlays/prod/certificate.yaml
+++ b/manifests/medicines-api/overlays/prod/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-medicines-api


### PR DESCRIPTION
Upgrade certificate manager version from `/v1alpha2` to `v1` for **medicines-api** and **doc-index-updater** for prod environment

This PR is aligned with the following deployments repo PR: [Cert Manager upgrade](https://github.com/MHRA/deployments/pull/61)

This PR is a mirror of #1072 for prod env


![](https://media.giphy.com/media/uBQNLeszLtiNO/giphy.gif)

### Pre-flight Checklist

~Testing aligns with [testing strategy][testing strategy]~
~DUXD review approval~
~Accessibility Reviewed~
~Product owner demo~

### Pre-merge Checklist

- [ ] Branch test approved

[testing strategy]: https://github.com/MHRA/products/blob/master/docs/principles/testing.md "MHRA/products testing strategy"
