### PR TITLE
Release workflow no image

### DIFF
--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -79,14 +79,18 @@ jobs:
           cargo build --release
           cargo test --release
 
+      - name: Create Docker tag
+        working-directory: products/medicines/doc-index-updater
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Build and push Docker image
         if: steps.filter.outputs.src == 'true'
         working-directory: products/medicines/doc-index-updater
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make ci-master tag=$TAG image=$IMAGE
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
-          echo "TAG=$TAG" >>$GITHUB_ENV
           echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo

--- a/.github/workflows/doc-index-updater-master.yaml
+++ b/.github/workflows/doc-index-updater-master.yaml
@@ -79,14 +79,18 @@ jobs:
           cargo build --release
           cargo test --release
 
+      - name: Create Docker tag
+        working-directory: products/medicines/doc-index-updater
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Build and push Docker image
         if: steps.filter.outputs.src == 'true'
         working-directory: products/medicines/doc-index-updater
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make ci-master tag=$TAG image=$IMAGE
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
-          echo "TAG=$TAG" >>$GITHUB_ENV
           echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -28,6 +28,8 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Fetch image for tagged commit
+        id: fetch-image
+        continue-on-error: true
         working-directory: ./products/medicines/doc-index-updater
         run: |
           TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
@@ -36,12 +38,14 @@ jobs:
 
       - name: Docker login to prod
         uses: azure/docker-login@v1
+        if: steps.fetch-image.outcome == 'success'
         with:
           login-server: mhraproducts4853registry.azurecr.io
           username: mhraproducts4853registry
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
 
       - name: Push image for tagged commit
+        if: steps.fetch-image.outcome == 'success'
         working-directory: ./products/medicines/doc-index-updater
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG
@@ -79,7 +83,7 @@ jobs:
             DEST="${PWD}/deployments/doc-index-updater/prod"
 
             cd $SOURCE 
-            kustomize edit set image $DIGEST
+            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
             kustomize build . > "${DEST}/manifests.yaml"
 

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -27,14 +27,18 @@ jobs:
           username: mhraproductsnonprodregistry
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Create Docker tag
+        working-directory: ./products/medicines/doc-index-updater
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Fetch image for tagged commit
         id: fetch-image
         continue-on-error: true
         working-directory: ./products/medicines/doc-index-updater
         run: |
-          TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
           make docker-pull image=$NONPROD_IMAGE tag=$TAG
-          echo "TAG=$TAG" >>$GITHUB_ENV
 
       - name: Docker login to prod
         uses: azure/docker-login@v1

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -72,14 +72,18 @@ jobs:
           cargo build --release
           cargo test --release
 
+      - name: Create Docker tag
+        working-directory: products/medicines/api
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Build and push Docker image
         if: steps.filter.outputs.src == 'true'
         working-directory: products/medicines/api
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make ci-master tag=$TAG image=$IMAGE
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
-          echo "TAG=$TAG" >>$GITHUB_ENV
           echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo

--- a/.github/workflows/medicines-api-master.yaml
+++ b/.github/workflows/medicines-api-master.yaml
@@ -72,14 +72,18 @@ jobs:
           cargo build --release
           cargo test --release
 
+      - name: Create Docker tag
+        working-directory: products/medicines/api
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Build and push Docker image
         if: steps.filter.outputs.src == 'true'
         working-directory: products/medicines/api
         run: |
-          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make ci-master tag=$TAG image=$IMAGE
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE}:${TAG})"
-          echo "TAG=$TAG" >>$GITHUB_ENV
           echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -27,14 +27,18 @@ jobs:
           username: mhraproductsnonprodregistry
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Create Docker tag
+        working-directory: ./products/medicines/api
+        run: |
+          TAG="$(git rev-parse --short=7 ${{ github.sha }})"
+          echo "TAG=$TAG" >>$GITHUB_ENV
+
       - name: Fetch image for tagged commit
         id: fetch-image
         continue-on-error: true
         working-directory: ./products/medicines/api
         run: |
-          TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
           make docker-pull image=$NONPROD_IMAGE tag=$TAG
-          echo "TAG=$TAG" >>$GITHUB_ENV
 
       - name: Docker login to prod
         uses: azure/docker-login@v1

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -28,20 +28,23 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Fetch image for tagged commit
+        id: fetch-image
         working-directory: ./products/medicines/api
         run: |
           TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
-          make docker-pull image=$NONPROD_IMAGE tag=$TAG
+          make docker-pull image=$NONPROD_IMAGE tag=$TAG | echo ""::set-output name=IMAGE_ERROR::$!"
           echo "TAG=$TAG" >>$GITHUB_ENV
 
       - name: Docker login to prod
         uses: azure/docker-login@v1
+        if: steps.fetch-image.outputs.IMAGE_ERROR == '0'
         with:
           login-server: mhraproducts4853registry.azurecr.io
           username: mhraproducts4853registry
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
 
       - name: Push image for tagged commit
+        if: steps.fetch-image.outputs.IMAGE_ERROR == '0'
         working-directory: ./products/medicines/api
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG
@@ -79,7 +82,7 @@ jobs:
             DEST="${PWD}/deployments/medicines-api/prod"
 
             cd $SOURCE
-            kustomize edit set image $DIGEST
+            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
             kustomize build . > "${DEST}/manifests.yaml"
 

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -29,22 +29,23 @@ jobs:
 
       - name: Fetch image for tagged commit
         id: fetch-image
+        continue-on-error: true
         working-directory: ./products/medicines/api
         run: |
           TAG="$(git rev-parse --short=7 $GITHUB_SHA)"
-          make docker-pull image=$NONPROD_IMAGE tag=$TAG | echo ""::set-output name=IMAGE_ERROR::$!"
+          make docker-pull image=$NONPROD_IMAGE tag=$TAG
           echo "TAG=$TAG" >>$GITHUB_ENV
 
       - name: Docker login to prod
         uses: azure/docker-login@v1
-        if: steps.fetch-image.outputs.IMAGE_ERROR == '0'
+        if: steps.fetch-image.outcome == 'success'
         with:
           login-server: mhraproducts4853registry.azurecr.io
           username: mhraproducts4853registry
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
 
       - name: Push image for tagged commit
-        if: steps.fetch-image.outputs.IMAGE_ERROR == '0'
+        if: steps.fetch-image.outcome == 'success'
         working-directory: ./products/medicines/api
         run: |
           make docker-retag image=$NONPROD_IMAGE new_image=$PROD_IMAGE tag=$TAG


### PR DESCRIPTION
# Release workflow no image

The current release workflows for `doc-index-updater` and `medicines-api` work from a tagged commit. Currently the workflow will fail if there was no image generated for that commit - this happens when only the manifests have been  updated. This makes it currently impossible to release changes only to the manifests in production.

This PR adds some conditions to continue with the workflow when the image does not exist (i.e. when the `Fetch image for tagged commit` step fails).