### PR TITLE
git action failed on master, there is a comment stating this was know…

### DIFF
--- a/.github/workflows/medicines-web-master.yaml
+++ b/.github/workflows/medicines-web-master.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Deploy products web to static site in azure storage
         # master causes this step to fail so pointing to last working commit until fixed
-        uses: lauchacarro/Azure-Storage-Action@9225056
+        uses: lauchacarro/Azure-Storage-Action@92250565adefe3844ab7e135cb570ca354f0ac18
         with:
           enabled-static-website: true
           folder: medicines/web/dist


### PR DESCRIPTION
Git action on master did not work and git itself suggested the following fix:

Error: Unable to resolve action lauchacarro/Azure-Storage-Action@9225056, the provided ref 9225056 is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA 92250565adefe3844ab7e135cb570ca354f0ac18 instead.