### PR TITLE
Fetch existing digest

### DIFF
--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -110,11 +110,20 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
-
+            DEST_MANIFESTS="${DEST}/manifests.yml"
+            
             cd $SOURCE 
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
-            kustomize build . > "${DEST}/manifests.yaml"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+            set -u
+
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   IMAGE: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater
-  DEPLOY_TO_NONPROD: false
+  DEPLOY_TO_NONPROD: true
 
 jobs:
   build-and-test:
@@ -110,7 +110,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
             
             cd $SOURCE 
             mkdir -p "${DEST}"

--- a/.github/workflows/doc-index-updater-branch.yaml
+++ b/.github/workflows/doc-index-updater-branch.yaml
@@ -107,7 +107,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"

--- a/.github/workflows/doc-index-updater-master.yaml
+++ b/.github/workflows/doc-index-updater-master.yaml
@@ -105,7 +105,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"

--- a/.github/workflows/doc-index-updater-master.yaml
+++ b/.github/workflows/doc-index-updater-master.yaml
@@ -108,7 +108,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
 
             cd $SOURCE 
             mkdir -p "${DEST}"

--- a/.github/workflows/doc-index-updater-master.yaml
+++ b/.github/workflows/doc-index-updater-master.yaml
@@ -108,11 +108,19 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/non-prod"
             DEST="${PWD}/deployments/doc-index-updater/non-prod"
+            DEST_MANIFESTS="${DEST}/manifests.yml"
 
             cd $SOURCE 
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
-            kustomize build . > "${DEST}/manifests.yaml"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -82,16 +82,22 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -eux
+            set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/prod"
             DEST="${PWD}/deployments/doc-index-updater/prod"
+            DEST_MANIFESTS="${DEST}/manifests.yml"
 
             cd $SOURCE 
-            set +u
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
-            set -u
             mkdir -p "${DEST}"
-            kustomize build . > "${DEST}/manifests.yaml"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+            
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -85,7 +85,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/prod"
             DEST="${PWD}/deployments/doc-index-updater/prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
 
             cd $SOURCE 
             mkdir -p "${DEST}"

--- a/.github/workflows/doc-index-updater-release.yaml
+++ b/.github/workflows/doc-index-updater-release.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/doc-index-updater/overlays/prod"
             DEST="${PWD}/deployments/doc-index-updater/prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -100,7 +100,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -103,10 +103,19 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
+            DEST_MANIFESTS="${DEST}/manifests.yml"
 
             cd $SOURCE 
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+            set -u
+
             kustomize build . > "${DEST}/manifests.yaml"
 
             cd $DEST

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -116,7 +116,7 @@ jobs:
             fi
             set -u
 
-            kustomize build . > "${DEST}/manifests.yaml"
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/medicines-api-branch.yaml
+++ b/.github/workflows/medicines-api-branch.yaml
@@ -103,7 +103,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
 
             cd $SOURCE 
             mkdir -p "${DEST}"

--- a/.github/workflows/medicines-api-master.yaml
+++ b/.github/workflows/medicines-api-master.yaml
@@ -101,11 +101,20 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
+            DEST_MANIFESTS="${DEST}/manifests.yml"
 
             cd $SOURCE 
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
             mkdir -p "${DEST}"
-            kustomize build . > "${DEST}/manifests.yaml"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+            set -u
+            
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/medicines-api-master.yaml
+++ b/.github/workflows/medicines-api-master.yaml
@@ -101,7 +101,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
 
             cd $SOURCE 
             mkdir -p "${DEST}"

--- a/.github/workflows/medicines-api-master.yaml
+++ b/.github/workflows/medicines-api-master.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/non-prod"
             DEST="${PWD}/deployments/medicines-api/non-prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -47,7 +47,7 @@ jobs:
           login-server: mhraproducts4853registry.azurecr.io
           username: mhraproducts4853registry
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
-
+      
       - name: Push image for tagged commit
         if: steps.fetch-image.outcome == 'success'
         working-directory: ./products/medicines/api
@@ -82,16 +82,23 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -eux
+            set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/prod"
             DEST="${PWD}/deployments/medicines-api/prod"
+            DEST_MANIFESTS="${DEST}/manifests.yml"
 
             cd $SOURCE
-            set +u
-            [[ ! -z "${DIGEST}" ]] && kustomize edit set image $DIGEST
-            set -u
             mkdir -p "${DEST}"
-            kustomize build . > "${DEST}/manifests.yaml"
+
+            set +u
+            if [[ -n "${DIGEST}" ]]; then 
+              kustomize edit set image $DIGEST
+            else
+              cat "${DEST_MANIFESTS}" | awk '/image:/ {print}' | sed 's/image://' | xargs kustomize edit set image
+            fi
+            set -u
+
+            kustomize build . > "${DEST_MANIFESTS}"
 
             cd $DEST
             git config --local user.email "CD.no.reply@mhra.gov.uk"

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -47,7 +47,7 @@ jobs:
           login-server: mhraproducts4853registry.azurecr.io
           username: mhraproducts4853registry
           password: ${{ secrets.PROD_REGISTRY_PASSWORD }}
-      
+
       - name: Push image for tagged commit
         if: steps.fetch-image.outcome == 'success'
         working-directory: ./products/medicines/api

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -85,7 +85,7 @@ jobs:
             set -ex
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/prod"
             DEST="${PWD}/deployments/medicines-api/prod"
-            DEST_MANIFESTS="${DEST}/manifests.yml"
+            DEST_MANIFESTS="${DEST}/manifests.yaml"
 
             cd $SOURCE
             mkdir -p "${DEST}"

--- a/.github/workflows/medicines-api-release.yaml
+++ b/.github/workflows/medicines-api-release.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           kustomize: 3.4.0
           command: |
-            set -ex
+            set -eux
             SOURCE="${PWD}/products/manifests/medicines-api/overlays/prod"
             DEST="${PWD}/deployments/medicines-api/prod"
             DEST_MANIFESTS="${DEST}/manifests.yaml"


### PR DESCRIPTION
# Fetch existing digest if not being updated

If no Docker image is generated/found for the commit in the workflows (because there are no changes to the app code), take the image digest that is already in the deployment manifests.

This fixes a bug where the digest in the Deployments repository would otherwise be overwritten with the old digest from the manifests in this (Products) repository.