### PR TITLE
add full SHA to pars-upload yaml files

### DIFF
--- a/.github/workflows/pars-upload-branch.yaml
+++ b/.github/workflows/pars-upload-branch.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - name: DEV - Deploy pars upload website to static site in azure storage
         # master causes this step to fail so pointing to last working commit until fixed
-        uses: lauchacarro/Azure-Storage-Action@9225056
+        uses: lauchacarro/Azure-Storage-Action@92250565adefe3844ab7e135cb570ca354f0ac18
         with:
           enabled-static-website: true
           folder: medicines/pars-upload/out

--- a/.github/workflows/pars-upload-master.yaml
+++ b/.github/workflows/pars-upload-master.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - name: NON-PROD - Deploy pars upload website to static site in azure storage
         # master causes this step to fail so pointing to last working commit until fixed
-        uses: lauchacarro/Azure-Storage-Action@9225056
+        uses: lauchacarro/Azure-Storage-Action@92250565adefe3844ab7e135cb570ca354f0ac18
         with:
           enabled-static-website: true
           folder: medicines/pars-upload/out

--- a/.github/workflows/pars-upload-release.yaml
+++ b/.github/workflows/pars-upload-release.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: PRODUCTION - Deploy pars upload website to static site in azure storage
         # master causes this step to fail so pointing to last working commit until fixed
-        uses: lauchacarro/Azure-Storage-Action@9225056
+        uses: lauchacarro/Azure-Storage-Action@92250565adefe3844ab7e135cb570ca354f0ac18
         with:
           enabled-static-website: true
           folder: medicines/pars-upload/out


### PR DESCRIPTION
Update the pars-upload yaml files to have full SHA as the GIT action fails without this.