### PR TITLE
Added PLGB and PLNI options to drop down pars upload dropdown

### DIFF
--- a/medicines/pars-upload/src/products_form.js
+++ b/medicines/pars-upload/src/products_form.js
@@ -259,6 +259,8 @@ const LicenceNumber = ({ formData, checkLicenceNumberIsNotDuplicate }) => (
         <option value="PL">PL</option>
         <option value="PLPI">HR</option>
         <option value="THR">THR</option>
+        <option value="PLGB">PLGB</option>
+        <option value="PLNI">PLNI</option>
       </select>{' '}
       <Field
         className="govuk-input--width-5"

--- a/medicines/pars-upload/src/update_products_form.js
+++ b/medicines/pars-upload/src/update_products_form.js
@@ -288,6 +288,8 @@ const LicenceNumber = ({ formData, checkLicenceNumberIsNotDuplicate }) => (
         <option value="PL">PL</option>
         <option value="PLPI">HR</option>
         <option value="THR">THR</option>
+        <option value="PLGB">PLGB</option>
+        <option value="PLNI">PLNI</option>
       </select>{' '}
       <Field
         className="govuk-input--width-5"


### PR DESCRIPTION
Added PLGB and PLNI options to drop down. 
Two files needed to be updated it looks like:
products_form.js
update_products_form.js 

Will test using https://mhraparsnonprod.azureedge.net/ and give to UAT team to test. 


	Acceptance criteria:
1.	I can upload a PAR with a licence number that has a PLNI prefix
2.	I can upload a PAR with a licence number that has a PLGB prefix
3.	I can update a PAR to have a licence number that has a PLNI prefix
4.	I can update a PAR to have a licence number that has a PLGB prefix
5.	The external user sees the correct licence number prefix assigned to the PAR
