### PR TITLE
Add frontend UI for territory filtering

### DIFF
--- a/medicines/web/src/components/form-elements/index.tsx
+++ b/medicines/web/src/components/form-elements/index.tsx
@@ -19,7 +19,7 @@ const StyledCheckbox = styled.input`
   }
 `;
 
-export const Checkbox = props => {
+export const Checkbox = (props) => {
   return <StyledCheckbox type="checkbox" {...props} />;
 };
 

--- a/medicines/web/src/components/search-filter/__snapshots__/index.test.tsx.snap
+++ b/medicines/web/src/components/search-filter/__snapshots__/index.test.tsx.snap
@@ -3,16 +3,17 @@
 exports[`SearchFilter should render search filter 1`] = `
 <SearchFilter
   currentlyEnabledDocTypes={Array []}
+  currentlyEnabledTerritoryTypes={Array []}
   rerouteType={0}
-  updateDocTypes={[Function]}
+  updatePageFilters={[Function]}
 >
   <styled.section>
     <section
-      className="sc-dlfnbm gCBqhY"
+      className="sc-dlfnbm ledHbp"
     >
       <styled.h3>
         <h3
-          className="sc-gKsewC icRsCX"
+          className="sc-iBPRYJ jueRyf"
         >
           Documents filter
         </h3>
@@ -23,16 +24,24 @@ exports[`SearchFilter should render search filter 1`] = `
         >
           <styled.legend>
             <legend
-              className="sc-jSgupP bHokth"
+              className="sc-jSgupP ifTOsT"
             >
               Filter documents by
             </legend>
           </styled.legend>
-          <DocTypeCheckbox
-            currentlyEnabledDocTypes={Array []}
-            docTypeForThisCheckbox="Spc"
-            name="Summary of Product Characteristics"
-            toggleDocType={[Function]}
+          <styled.legend>
+            <legend
+              className="sc-gKsewC kEXlwV"
+            >
+              Type of document
+            </legend>
+          </styled.legend>
+          <FilterCheckbox
+            checked={false}
+            label="Summary of Product Characteristics"
+            query="doc"
+            toggleFilter={[Function]}
+            value="Spc"
           >
             <div
               className="checkbox-row"
@@ -76,12 +85,13 @@ exports[`SearchFilter should render search filter 1`] = `
                 )
               </label>
             </div>
-          </DocTypeCheckbox>
-          <DocTypeCheckbox
-            currentlyEnabledDocTypes={Array []}
-            docTypeForThisCheckbox="Pil"
-            name="Patient Information Leaflet"
-            toggleDocType={[Function]}
+          </FilterCheckbox>
+          <FilterCheckbox
+            checked={false}
+            label="Patient Information Leaflet"
+            query="doc"
+            toggleFilter={[Function]}
+            value="Pil"
           >
             <div
               className="checkbox-row"
@@ -125,12 +135,13 @@ exports[`SearchFilter should render search filter 1`] = `
                 )
               </label>
             </div>
-          </DocTypeCheckbox>
-          <DocTypeCheckbox
-            currentlyEnabledDocTypes={Array []}
-            docTypeForThisCheckbox="Par"
-            name="Public Assessment Reports"
-            toggleDocType={[Function]}
+          </FilterCheckbox>
+          <FilterCheckbox
+            checked={false}
+            label="Public Assessment Reports"
+            query="doc"
+            toggleFilter={[Function]}
+            value="Par"
           >
             <div
               className="checkbox-row"
@@ -174,10 +185,167 @@ exports[`SearchFilter should render search filter 1`] = `
                 )
               </label>
             </div>
-          </DocTypeCheckbox>
+          </FilterCheckbox>
+          <styled.legend>
+            <legend
+              className="sc-gKsewC kEXlwV"
+            >
+              Applicable to territory
+            </legend>
+          </styled.legend>
+          <FilterCheckbox
+            checked={false}
+            label="United Kingdom"
+            query="ter"
+            toggleFilter={[Function]}
+            value="UK"
+          >
+            <div
+              className="checkbox-row"
+            >
+              <div
+                className="checkbox"
+              >
+                <Checkbox
+                  checked={false}
+                  id="filter-uk"
+                  name="ter"
+                  onChange={[Function]}
+                  value="UK"
+                >
+                  <styled.input
+                    checked={false}
+                    id="filter-uk"
+                    name="ter"
+                    onChange={[Function]}
+                    type="checkbox"
+                    value="UK"
+                  >
+                    <input
+                      checked={false}
+                      className="sc-bdfBwQ bHPfdB"
+                      id="filter-uk"
+                      name="ter"
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="UK"
+                    />
+                  </styled.input>
+                </Checkbox>
+              </div>
+              <label
+                htmlFor="filter-uk"
+              >
+                United Kingdom
+                 (
+                UK
+                )
+              </label>
+            </div>
+          </FilterCheckbox>
+          <FilterCheckbox
+            checked={false}
+            label="Northern Ireland"
+            query="ter"
+            toggleFilter={[Function]}
+            value="NI"
+          >
+            <div
+              className="checkbox-row"
+            >
+              <div
+                className="checkbox"
+              >
+                <Checkbox
+                  checked={false}
+                  id="filter-ni"
+                  name="ter"
+                  onChange={[Function]}
+                  value="NI"
+                >
+                  <styled.input
+                    checked={false}
+                    id="filter-ni"
+                    name="ter"
+                    onChange={[Function]}
+                    type="checkbox"
+                    value="NI"
+                  >
+                    <input
+                      checked={false}
+                      className="sc-bdfBwQ bHPfdB"
+                      id="filter-ni"
+                      name="ter"
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="NI"
+                    />
+                  </styled.input>
+                </Checkbox>
+              </div>
+              <label
+                htmlFor="filter-ni"
+              >
+                Northern Ireland
+                 (
+                NI
+                )
+              </label>
+            </div>
+          </FilterCheckbox>
+          <FilterCheckbox
+            checked={false}
+            label="Great Britain"
+            query="ter"
+            toggleFilter={[Function]}
+            value="GB"
+          >
+            <div
+              className="checkbox-row"
+            >
+              <div
+                className="checkbox"
+              >
+                <Checkbox
+                  checked={false}
+                  id="filter-gb"
+                  name="ter"
+                  onChange={[Function]}
+                  value="GB"
+                >
+                  <styled.input
+                    checked={false}
+                    id="filter-gb"
+                    name="ter"
+                    onChange={[Function]}
+                    type="checkbox"
+                    value="GB"
+                  >
+                    <input
+                      checked={false}
+                      className="sc-bdfBwQ bHPfdB"
+                      id="filter-gb"
+                      name="ter"
+                      onChange={[Function]}
+                      type="checkbox"
+                      value="GB"
+                    />
+                  </styled.input>
+                </Checkbox>
+              </div>
+              <label
+                htmlFor="filter-gb"
+              >
+                Great Britain
+                 (
+                GB
+                )
+              </label>
+            </div>
+          </FilterCheckbox>
           <styled.div>
             <div
-              className="sc-hKgILt htIFRi"
+              className="sc-hKgILt emQRkz"
             >
               <styled.input
                 onClick={[Function]}

--- a/medicines/web/src/components/search-filter/index.test.tsx
+++ b/medicines/web/src/components/search-filter/index.test.tsx
@@ -1,18 +1,19 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { RerouteType } from '../../model/rerouteType';
-import { DocType } from '../../services/azure-search';
+import { DocType, TerritoryType } from '../../services/azure-search';
 import SearchFilter from './index';
 
 describe(SearchFilter, () => {
   it('should render search filter', () => {
-    const updateDocTypesFunction = (d: DocType[]) => {
+    const updatePageFiltersFunction = (d: DocType[], t: TerritoryType[]) => {
       return null;
     };
     const component = mount(
       <SearchFilter
         currentlyEnabledDocTypes={[]}
-        updateDocTypes={updateDocTypesFunction}
+        currentlyEnabledTerritoryTypes={[]}
+        updatePageFilters={updatePageFiltersFunction}
         rerouteType={RerouteType.CheckboxSelected}
       />,
     );

--- a/medicines/web/src/components/search-results/__snapshots__/index.test.tsx.snap
+++ b/medicines/web/src/components/search-results/__snapshots__/index.test.tsx.snap
@@ -46,8 +46,9 @@ exports[`SearchResults should render 1`] = `
       >
         <SearchFilter
           currentlyEnabledDocTypes={Array []}
+          currentlyEnabledTerritoryTypes={Array []}
           rerouteType={0}
-          updateDocTypes={[Function]}
+          updatePageFilters={[Function]}
         />
       </div>
       <section

--- a/medicines/web/src/components/search-results/index.test.tsx
+++ b/medicines/web/src/components/search-results/index.test.tsx
@@ -42,7 +42,8 @@ describe(SearchResults, () => {
         showingResultsForTerm={'Tea'}
         disclaimerAgree
         docTypes={[]}
-        updateDocTypes={updateDocType}
+        territoryTypes={[]}
+        updatePageFilters={updateDocType}
         rerouteType={RerouteType.CheckboxSelected}
         handlePageChange={noFeedback}
         isLoading={false}
@@ -62,8 +63,9 @@ describe(SearchResults, () => {
         showingResultsForTerm={'Tea'}
         disclaimerAgree
         docTypes={[]}
+        territoryTypes={[]}
         rerouteType={RerouteType.Other}
-        updateDocTypes={noFeedback}
+        updatePageFilters={noFeedback}
         handlePageChange={noFeedback}
         isLoading
       />,
@@ -82,8 +84,9 @@ describe(SearchResults, () => {
         showingResultsForTerm={'Tea'}
         disclaimerAgree
         docTypes={[]}
+        territoryTypes={[]}
         rerouteType={RerouteType.Other}
-        updateDocTypes={noFeedback}
+        updatePageFilters={noFeedback}
         handlePageChange={noFeedback}
         isLoading
         errorFetchingResults

--- a/medicines/web/src/components/search-results/index.tsx
+++ b/medicines/web/src/components/search-results/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useLocalStorage, useSessionStorage } from '../../hooks';
 import { RerouteType } from '../../model/rerouteType';
 import { IDocument } from '../../model/document';
-import { DocType } from '../../services/azure-search';
+import { DocType, TerritoryType } from '../../services/azure-search';
 import { errorRed, mhraBlue80, mhraGray10, white } from '../../styles/colors';
 import {
   baseSpace,
@@ -220,7 +220,8 @@ interface ISearchResultsProps {
   showingResultsForTerm: string;
   disclaimerAgree: boolean;
   docTypes: DocType[];
-  updateDocTypes: (d: DocType[]) => void;
+  territoryTypes: TerritoryType[];
+  updatePageFilters: (d: DocType[], t: TerritoryType[]) => void;
   handlePageChange: (num: number) => void;
   isLoading: boolean;
   rerouteType: RerouteType;
@@ -253,7 +254,8 @@ const SearchResults = (props: ISearchResultsProps) => {
     searchTerm,
     showingResultsForTerm,
     docTypes,
-    updateDocTypes,
+    territoryTypes,
+    updatePageFilters,
     rerouteType,
   } = props;
 
@@ -340,7 +342,8 @@ const SearchResults = (props: ISearchResultsProps) => {
             <div className="column filter">
               <SearchFilter
                 currentlyEnabledDocTypes={docTypes}
-                updateDocTypes={updateDocTypes}
+                currentlyEnabledTerritoryTypes={territoryTypes}
+                updatePageFilters={updatePageFilters}
                 rerouteType={rerouteType}
               />
             </div>

--- a/medicines/web/src/pages/search/index.tsx
+++ b/medicines/web/src/pages/search/index.tsx
@@ -8,13 +8,13 @@ import SearchWrapper from '../../components/search-wrapper';
 import { useLocalStorage } from '../../hooks';
 import { RerouteType } from '../../model/rerouteType';
 import { IDocument } from '../../model/document';
-import { DocType } from '../../services/azure-search';
+import { DocType, TerritoryType } from '../../services/azure-search';
 import Events from '../../services/events';
 import {
   docTypesFromQueryString,
   parseDisclaimerAgree,
   parsePage,
-  queryStringFromDocTypes,
+  queryStringFromTypes,
 } from '../../services/querystring-interpreter';
 import { getLoader } from '../../services/loaders/products/search-results-loader';
 
@@ -31,6 +31,9 @@ const App: NextPage = (props) => {
   const [count, setCount] = React.useState(0);
   const [pageNumber, setPageNumber] = React.useState(1);
   const [docTypes, setDocTypes] = React.useState<DocType[]>([]);
+  const [territoryTypes, setTerritoryTypes] = React.useState<TerritoryType[]>(
+    [],
+  );
   const [disclaimerAgree, setDisclaimerAgree] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
   const [rerouteType, setRerouteType] = React.useState(RerouteType.Other);
@@ -59,6 +62,7 @@ const App: NextPage = (props) => {
     setQuery(query);
     setPageNumber(page);
     setDocTypes(docTypes);
+    setTerritoryTypes(territoryTypes);
     setDisclaimerAgree(parseDisclaimerAgree(disclaimerQS));
 
     setDocuments([]);
@@ -77,7 +81,7 @@ const App: NextPage = (props) => {
     Events.searchForProductsMatchingKeywords({
       searchTerm: query,
       pageNo: page,
-      docTypes: queryStringFromDocTypes(docTypes),
+      docTypes: queryStringFromTypes(docTypes),
     });
   }, [queryQS, pageQS, disclaimerQS, docQS]);
 
@@ -104,7 +108,7 @@ const App: NextPage = (props) => {
     };
     if (docTypes.length > 0) {
       const docKey = 'doc';
-      query[docKey] = queryStringFromDocTypes(docTypes);
+      query[docKey] = queryStringFromTypes(docTypes);
     }
     if (rerouteType != null) {
       const rerouteTypeKey = 'rerouteType';
@@ -142,6 +146,7 @@ const App: NextPage = (props) => {
           searchTerm={query}
           disclaimerAgree={disclaimerAgree}
           docTypes={docTypes}
+          territoryTypes={territoryTypes}
           updatePageFilters={updatePageFilters}
           handlePageChange={handlePageChange}
           isLoading={isLoading}

--- a/medicines/web/src/pages/search/index.tsx
+++ b/medicines/web/src/pages/search/index.tsx
@@ -8,10 +8,15 @@ import SearchWrapper from '../../components/search-wrapper';
 import { useLocalStorage } from '../../hooks';
 import { RerouteType } from '../../model/rerouteType';
 import { IDocument } from '../../model/document';
-import { DocType, TerritoryType } from '../../services/azure-search';
+import {
+  DocType,
+  TerritoryType,
+  SearchType,
+} from '../../services/azure-search';
 import Events from '../../services/events';
 import {
   docTypesFromQueryString,
+  territoryTypesFromQueryString,
   parseDisclaimerAgree,
   parsePage,
   queryStringFromTypes,
@@ -47,6 +52,7 @@ const App: NextPage = (props) => {
       page: pageQS,
       disclaimer: disclaimerQS,
       doc: docQS,
+      ter: territoryQS,
       rerouteType: rerouteTypeQS,
     },
   } = router;
@@ -59,6 +65,7 @@ const App: NextPage = (props) => {
     const query = queryQS.toString();
     const page = pageQS ? parsePage(pageQS) : 1;
     const docTypes = docTypesFromQueryString(docQS);
+    const territoryTypes = territoryTypesFromQueryString(territoryQS);
     setQuery(query);
     setPageNumber(page);
     setDocTypes(docTypes);
@@ -100,6 +107,7 @@ const App: NextPage = (props) => {
     searchTerm: string,
     page: number,
     docTypes: DocType[],
+    territoryTypes: TerritoryType[],
     rerouteType?: RerouteType,
   ) => {
     const query = {
@@ -107,8 +115,10 @@ const App: NextPage = (props) => {
       page,
     };
     if (docTypes.length > 0) {
-      const docKey = 'doc';
-      query[docKey] = queryStringFromTypes(docTypes);
+      query[SearchType.Doc] = queryStringFromTypes(docTypes);
+    }
+    if (territoryTypes.length > 0) {
+      query[SearchType.Territory] = queryStringFromTypes(territoryTypes);
     }
     if (rerouteType != null) {
       const rerouteTypeKey = 'rerouteType';
@@ -120,13 +130,28 @@ const App: NextPage = (props) => {
     });
   };
 
-  const updatePageFilters = (updatedDocTypes: DocType[]) => {
-    if (docTypes === updatedDocTypes) return;
-    reroutePage(query, 1, updatedDocTypes, RerouteType.CheckboxSelected);
+  const updatePageFilters = (
+    updatedDocTypes: DocType[],
+    updatedTerritoryTypes: TerritoryType[],
+  ) => {
+    if (
+      docTypes === updatedDocTypes &&
+      territoryTypes === updatedTerritoryTypes
+    ) {
+      return;
+    }
+
+    reroutePage(
+      query,
+      1,
+      updatedDocTypes,
+      updatedTerritoryTypes,
+      RerouteType.CheckboxSelected,
+    );
   };
 
   const handlePageChange = async (page: number) => {
-    reroutePage(query, page, docTypes);
+    reroutePage(query, page, docTypes, territoryTypes);
   };
 
   return (

--- a/medicines/web/src/pages/search/index.tsx
+++ b/medicines/web/src/pages/search/index.tsx
@@ -116,7 +116,7 @@ const App: NextPage = (props) => {
     });
   };
 
-  const updateDocTypes = (updatedDocTypes: DocType[]) => {
+  const updatePageFilters = (updatedDocTypes: DocType[]) => {
     if (docTypes === updatedDocTypes) return;
     reroutePage(query, 1, updatedDocTypes, RerouteType.CheckboxSelected);
   };
@@ -142,7 +142,7 @@ const App: NextPage = (props) => {
           searchTerm={query}
           disclaimerAgree={disclaimerAgree}
           docTypes={docTypes}
-          updateDocTypes={updateDocTypes}
+          updatePageFilters={updatePageFilters}
           handlePageChange={handlePageChange}
           isLoading={isLoading}
           rerouteType={rerouteType}

--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -16,6 +16,17 @@ export enum DocType {
   Spc = 'Spc',
 }
 
+export enum TerritoryType {
+  UK = 'UK',
+  NI = 'NI',
+  GB = 'GB',
+}
+
+export enum SearchType {
+  Doc = 'doc',
+  Territory = 'ter',
+}
+
 export interface ISearchResult {
   '@search.highlights': { content: string[] };
   '@search.score': number;

--- a/medicines/web/src/services/querysting-interpreter.test.ts
+++ b/medicines/web/src/services/querysting-interpreter.test.ts
@@ -2,7 +2,7 @@ import { DocType } from './azure-search';
 import {
   docTypesFromQueryString,
   parsePage,
-  queryStringFromDocTypes,
+  queryStringFromTypes,
 } from './querystring-interpreter';
 
 describe(parsePage, () => {
@@ -28,14 +28,14 @@ describe(docTypesFromQueryString, () => {
   });
 });
 
-describe(queryStringFromDocTypes, () => {
+describe(queryStringFromTypes, () => {
   it('can join by pipe', () => {
-    expect(queryStringFromDocTypes([DocType.Par, DocType.Pil])).toStrictEqual(
+    expect(queryStringFromTypes([DocType.Par, DocType.Pil])).toStrictEqual(
       'Par|Pil',
     );
   });
 
   it('gives empty string for empty filters', () => {
-    expect(queryStringFromDocTypes([])).toStrictEqual('');
+    expect(queryStringFromTypes([])).toStrictEqual('');
   });
 });

--- a/medicines/web/src/services/querystring-interpreter.ts
+++ b/medicines/web/src/services/querystring-interpreter.ts
@@ -1,4 +1,4 @@
-import { DocType } from './azure-search';
+import { DocType, TerritoryType } from './azure-search';
 
 export const parsePage = (page: string | string[]) => {
   let parsedPage = Number(page);
@@ -8,7 +8,7 @@ export const parsePage = (page: string | string[]) => {
   return parsedPage;
 };
 
-const docTypeQueryStringSeparator = '|';
+const typeQueryStringSeparator = '|';
 
 const formatDocTypeFilters = (s: string): DocType[] => {
   if (s.length <= 0) {
@@ -16,14 +16,9 @@ const formatDocTypeFilters = (s: string): DocType[] => {
   }
 
   return s
-    .split(docTypeQueryStringSeparator)
-    .map(d => DocType[d as keyof typeof DocType]);
+    .split(typeQueryStringSeparator)
+    .map((d) => DocType[d as keyof typeof DocType]);
 };
-
-export const queryStringFromDocTypes = (enabledDocTypes: DocType[]): string =>
-  enabledDocTypes.length > 0
-    ? enabledDocTypes.join(docTypeQueryStringSeparator)
-    : '';
 
 export const docTypesFromQueryString = (
   queryDocFilter: string | string[],
@@ -32,6 +27,30 @@ export const docTypesFromQueryString = (
     ? formatDocTypeFilters(queryDocFilter)
     : [];
 };
+
+const formatTerritoryTypeFilters = (s: string): TerritoryType[] => {
+  if (s.length <= 0) {
+    return [];
+  }
+
+  return s
+    .split(typeQueryStringSeparator)
+    .map((d) => TerritoryType[d as keyof typeof TerritoryType]);
+};
+
+export const territoryTypesFromQueryString = (
+  queryTerritoryFilter: string | string[],
+): TerritoryType[] => {
+  return typeof queryTerritoryFilter === 'string' &&
+    queryTerritoryFilter.length > 0
+    ? formatTerritoryTypeFilters(queryTerritoryFilter)
+    : [];
+};
+
+export const queryStringFromTypes = (
+  enabledTypes: DocType[] | TerritoryType[],
+): string =>
+  enabledTypes.length > 0 ? enabledTypes.join(typeQueryStringSeparator) : '';
 
 export const parseDisclaimerAgree = (
   queryDisclaimerAgree: string | string[],


### PR DESCRIPTION
We want to be able to filter products by the territories they're 
approved in.

The method we're using to filter territories is similar to how we're
currently filtering documents.

We've added the filter checkboxes to the left hand side of the page,
and when each filter is selected it is appended to a query string in the
page's URL.

The implementation of this territory filtering has been mostly
generalising the current implementation of filtering documents. We're
then able to re-use most of the existing functionality by passing in the
existing `DocType` or new `TerritoryType`.

Closes #1123.

For the snapshot fixes I ran `yarn jest -u` to allow jest to update the
snapshots for us, Otherwise the querystring-interpreter tests just
needed to modify a failing import.