### PR TITLE
Link territory changes from UI to GraphQL backend

### DIFF
--- a/medicines/api/src/query_objects/products/product.rs
+++ b/medicines/api/src/query_objects/products/product.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use async_graphql::{Context, FieldResult, Object};
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Product {
@@ -42,6 +42,7 @@ impl Product {
         first: Option<i32>,
         offset: Option<i32>,
         document_types: Option<Vec<DocumentType>>,
+        territory_types: Option<Vec<TerritoryType>>,
     ) -> FieldResult<document::Documents> {
         let context = context.data::<AzureContext>()?;
 
@@ -55,6 +56,14 @@ impl Product {
                 Some(document_types) => docs
                     .into_iter()
                     .filter(|x| document_types.iter().any(|&f| x.is_doc_type(f)))
+                    .collect(),
+                None => docs,
+            };
+
+            let docs = match territory_types {
+                Some(territory_types) => docs
+                    .into_iter()
+                    .filter(|x| territory_types.iter().any(|&f| x.is_territory_type(f)))
                     .collect(),
                 None => docs,
             };
@@ -78,6 +87,7 @@ impl Product {
                 first,
                 offset,
                 document_types,
+                territory_types,
                 Some(&self.name),
             )
             .await
@@ -123,12 +133,12 @@ mod test {
         let result = IndexResult {
             product_name,
             doc_type: DocumentType::Spc,
+            territory: Some(TerritoryType::UK),
             created: Some("yes".to_string()),
             facets: Vec::new(),
             file_name: "README.markdown".to_string(),
             highlights: None,
             keywords: None,
-            territory: Some("UK".to_string()),
             metadata_storage_name: "dummy".to_string(),
             metadata_storage_path: "/".to_string(),
             metadata_storage_size: 0,

--- a/medicines/api/src/query_objects/products/query_root.rs
+++ b/medicines/api/src/query_objects/products/query_root.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use async_graphql::{Context, FieldResult, Object};
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 
 pub struct Products {}
 
@@ -79,6 +79,7 @@ impl Products {
             })
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[field(desc = "SPC, PIL and PAR Documents related to products")]
     async fn documents(
         &self,
@@ -88,6 +89,7 @@ impl Products {
         skip: Option<i32>,
         after: Option<String>,
         document_types: Option<Vec<DocumentType>>,
+        territory_types: Option<Vec<TerritoryType>>,
     ) -> FieldResult<Documents> {
         let context = context.data::<AzureContext>()?;
         let offset = get_offset_or_default(skip, after, 0);
@@ -98,6 +100,7 @@ impl Products {
             first,
             offset,
             document_types,
+            territory_types,
             None,
         )
         .await

--- a/medicines/api/src/schema.rs
+++ b/medicines/api/src/schema.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use async_graphql::{Context, EmptyMutation, EmptySubscription, FieldResult, Object, Schema};
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 
 pub struct QueryRoot;
 
@@ -79,6 +79,7 @@ impl QueryRoot {
             })
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[field(deprecation = "Please use `products::documents` instead")]
     async fn documents(
         &self,
@@ -88,6 +89,7 @@ impl QueryRoot {
         skip: Option<i32>,
         after: Option<String>,
         document_types: Option<Vec<DocumentType>>,
+        territory_types: Option<Vec<TerritoryType>>,
     ) -> FieldResult<Documents> {
         let context = context.data::<AzureContext>()?;
         let offset = get_offset_or_default(skip, after, 0);
@@ -98,6 +100,7 @@ impl QueryRoot {
             first,
             offset,
             document_types,
+            territory_types,
             None,
         )
         .await

--- a/medicines/doc-index-updater/src/audit_logger/mod.rs
+++ b/medicines/doc-index-updater/src/audit_logger/mod.rs
@@ -111,7 +111,7 @@ mod test {
                 "PL 12345/6789".to_string(),
             ]),
             pl_number: "PL 12345/6789".to_string(),
-            territory: TerritoryType::UK,
+            territory: Some(TerritoryType::UK),
             active_substances: vec!["Paracetamol".to_string(), "Caffeine".to_string()],
             file_path: "location/on/disk".to_string(),
             file_source: FileSource::TemporaryAzureBlobStorage,
@@ -142,7 +142,7 @@ mod test {
             DateTime::parse_from_rfc3339("1996-12-19T16:39:57-00:00").unwrap(),
         );
         let message = get_create_message();
-        let expected = "1kdlkjd1229ui09askjsadkl12da,1996-12-19 16:39:57,CreateMessage { job_id: 739b7840-a1e9-42eb-8013-0120cdf066bc, document: Document { id: \"CON123456\", name: \"Paracetamol Plus PL 12345/6789\", document_type: Spc, author: \"JRR Tolkien\", products: [\"Effective product 1\", \"Effective product 2\"], keywords: Some([\"Very good for you\", \"Cures headaches\", \"PL 12345/6789\"]), pl_number: \"PL 12345/6789\", territory: UK, active_substances: [\"Paracetamol\", \"Caffeine\"], file_source: TemporaryAzureBlobStorage, file_path: \"location/on/disk\" }, initiator_email: Some(\"example@email.com\") }\n".to_string();
+        let expected = "1kdlkjd1229ui09askjsadkl12da,1996-12-19 16:39:57,CreateMessage { job_id: 739b7840-a1e9-42eb-8013-0120cdf066bc, document: Document { id: \"CON123456\", name: \"Paracetamol Plus PL 12345/6789\", document_type: Spc, author: \"JRR Tolkien\", products: [\"Effective product 1\", \"Effective product 2\"], keywords: Some([\"Very good for you\", \"Cures headaches\", \"PL 12345/6789\"]), pl_number: \"PL 12345/6789\", territory: Some(UK), active_substances: [\"Paracetamol\", \"Caffeine\"], file_source: TemporaryAzureBlobStorage, file_path: \"location/on/disk\" }, initiator_email: Some(\"example@email.com\") }\n".to_string();
 
         let actual = get_log_body(&blob_name, message, &date);
 

--- a/medicines/doc-index-updater/src/audit_logger/mod.rs
+++ b/medicines/doc-index-updater/src/audit_logger/mod.rs
@@ -82,7 +82,7 @@ fn get_log_file_name(date: &DateTime<Utc>) -> String {
 mod test {
     use super::*;
     use crate::models::{CreateMessage, DeleteMessage, Document, FileSource};
-    use search_client::models::DocumentType;
+    use search_client::models::{DocumentType, TerritoryType};
     use uuid::Uuid;
 
     #[test]
@@ -111,7 +111,7 @@ mod test {
                 "PL 12345/6789".to_string(),
             ]),
             pl_number: "PL 12345/6789".to_string(),
-            territory: "UK".to_string(),
+            territory: TerritoryType::UK,
             active_substances: vec!["Paracetamol".to_string(), "Caffeine".to_string()],
             file_path: "location/on/disk".to_string(),
             file_source: FileSource::TemporaryAzureBlobStorage,
@@ -142,7 +142,7 @@ mod test {
             DateTime::parse_from_rfc3339("1996-12-19T16:39:57-00:00").unwrap(),
         );
         let message = get_create_message();
-        let expected = "1kdlkjd1229ui09askjsadkl12da,1996-12-19 16:39:57,CreateMessage { job_id: 739b7840-a1e9-42eb-8013-0120cdf066bc, document: Document { id: \"CON123456\", name: \"Paracetamol Plus PL 12345/6789\", document_type: Spc, author: \"JRR Tolkien\", products: [\"Effective product 1\", \"Effective product 2\"], keywords: Some([\"Very good for you\", \"Cures headaches\", \"PL 12345/6789\"]), pl_number: \"PL 12345/6789\", territory: \"UK\", active_substances: [\"Paracetamol\", \"Caffeine\"], file_source: TemporaryAzureBlobStorage, file_path: \"location/on/disk\" }, initiator_email: Some(\"example@email.com\") }\n".to_string();
+        let expected = "1kdlkjd1229ui09askjsadkl12da,1996-12-19 16:39:57,CreateMessage { job_id: 739b7840-a1e9-42eb-8013-0120cdf066bc, document: Document { id: \"CON123456\", name: \"Paracetamol Plus PL 12345/6789\", document_type: Spc, author: \"JRR Tolkien\", products: [\"Effective product 1\", \"Effective product 2\"], keywords: Some([\"Very good for you\", \"Cures headaches\", \"PL 12345/6789\"]), pl_number: \"PL 12345/6789\", territory: UK, active_substances: [\"Paracetamol\", \"Caffeine\"], file_source: TemporaryAzureBlobStorage, file_path: \"location/on/disk\" }, initiator_email: Some(\"example@email.com\") }\n".to_string();
 
         let actual = get_log_body(&blob_name, message, &date);
 

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -11,7 +11,7 @@ pub struct BlobMetadata {
     pub doc_type: DocumentType,
     pub title: SanitisedString,
     pub pl_number: String,
-    pub territory: TerritoryType,
+    pub territory: Option<TerritoryType>,
     pub product_names: VecSanitisedString,
     pub active_substances: VecSanitisedString,
     pub author: SanitisedString,
@@ -25,7 +25,7 @@ impl BlobMetadata {
         doc_type: DocumentType,
         title: String,
         pl_number: String,
-        territory: TerritoryType,
+        territory: Option<TerritoryType>,
         product_names: Vec<String>,
         active_substances: Vec<String>,
         author: String,
@@ -100,7 +100,9 @@ impl Into<HashMap<String, String>> for BlobMetadata {
             metadata.insert("keywords".to_string(), keywords.join(" "));
         }
         metadata.insert("pl_number".to_string(), self.pl_number.clone());
-        metadata.insert("territory".to_string(), self.territory.to_string());
+        if let Some(territory) = self.territory {
+            metadata.insert("territory".to_string(), territory.to_string());
+        }
         metadata.insert("author".to_string(), self.author.to_string());
 
         metadata
@@ -212,7 +214,7 @@ mod test {
                 "PL 12345/6789".to_string(),
             ]),
             pl_number: "PL 12345/6789".to_string(),
-            territory: TerritoryType::UK,
+            territory: Some(TerritoryType::UK),
             active_substances: vec!["Paracetamol".to_string(), "Caffeine".to_string()],
             file_path: "location/on/disk".to_string(),
             file_source: FileSource::Sentinel,
@@ -320,7 +322,7 @@ mod test {
             ],
             keywords: None,
             pl_number: "PL 12345/0010-0001".to_string(),
-            territory: TerritoryType::UK,
+            territory: Some(TerritoryType::UK),
             active_substances: vec!["paracetamol".to_string()],
             file_source: FileSource::Sentinel,
             file_path: "/home/sentinel/something.pdf".to_string(),
@@ -335,7 +337,7 @@ mod test {
                 doc_type: DocumentType::Spc,
                 title: SanitisedString::from("Some SPC".to_string()),
                 pl_number: "[\"PL123450010\"]".to_string(),
-                territory: TerritoryType::UK,
+                territory: Some(TerritoryType::UK),
                 product_names: VecSanitisedString::from(vec![
                     "GENERIC PARACETAMOL".to_string(),
                     "SPECIAL PARACETAMOL".to_string()

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -36,7 +36,7 @@ impl BlobMetadata {
             doc_type,
             title: title.into(),
             pl_number,
-            territory: territory,
+            territory,
             product_names: product_names.into(),
             active_substances: active_substances.into(),
             author: author.into(),

--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -2,7 +2,7 @@ use super::sanitiser::{SanitisedString, VecSanitisedString};
 use crate::{create_manager::Blob, models::Document};
 use chrono::{SecondsFormat, Utc};
 use regex::Regex;
-use search_client::models::{DocumentType, IndexEntry};
+use search_client::models::{DocumentType, IndexEntry, TerritoryType};
 use std::{collections::HashMap, str};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -11,7 +11,7 @@ pub struct BlobMetadata {
     pub doc_type: DocumentType,
     pub title: SanitisedString,
     pub pl_number: String,
-    pub territory: SanitisedString,
+    pub territory: TerritoryType,
     pub product_names: VecSanitisedString,
     pub active_substances: VecSanitisedString,
     pub author: SanitisedString,
@@ -25,7 +25,7 @@ impl BlobMetadata {
         doc_type: DocumentType,
         title: String,
         pl_number: String,
-        territory: String,
+        territory: TerritoryType,
         product_names: Vec<String>,
         active_substances: Vec<String>,
         author: String,
@@ -36,7 +36,7 @@ impl BlobMetadata {
             doc_type,
             title: title.into(),
             pl_number,
-            territory: territory.into(),
+            territory: territory,
             product_names: product_names.into(),
             active_substances: active_substances.into(),
             author: author.into(),
@@ -61,7 +61,7 @@ impl Into<BlobMetadata> for Document {
             doc_type: self.document_type,
             title,
             pl_number,
-            territory: SanitisedString::from(&self.territory),
+            territory: self.territory,
             product_names: VecSanitisedString::from(
                 self.products
                     .iter()
@@ -123,7 +123,7 @@ impl From<Blob> for IndexEntry {
                 .join(", "),
             title: blob.metadata.title.to_string(),
             pl_number: vec![blob.metadata.pl_number.to_string()],
-            territory: blob.metadata.territory.to_string(),
+            territory: blob.metadata.territory,
             file_name: blob.metadata.file_name.to_string(),
             doc_type: blob.metadata.doc_type,
             suggestions: vec![],
@@ -212,7 +212,7 @@ mod test {
                 "PL 12345/6789".to_string(),
             ]),
             pl_number: "PL 12345/6789".to_string(),
-            territory: "UK".to_string(),
+            territory: TerritoryType::UK,
             active_substances: vec!["Paracetamol".to_string(), "Caffeine".to_string()],
             file_path: "location/on/disk".to_string(),
             file_source: FileSource::Sentinel,
@@ -320,7 +320,7 @@ mod test {
             ],
             keywords: None,
             pl_number: "PL 12345/0010-0001".to_string(),
-            territory: "UK".to_string(),
+            territory: TerritoryType::UK,
             active_substances: vec!["paracetamol".to_string()],
             file_source: FileSource::Sentinel,
             file_path: "/home/sentinel/something.pdf".to_string(),
@@ -335,7 +335,7 @@ mod test {
                 doc_type: DocumentType::Spc,
                 title: SanitisedString::from("Some SPC".to_string()),
                 pl_number: "[\"PL123450010\"]".to_string(),
-                territory: SanitisedString::from("UK".to_string()),
+                territory: TerritoryType::UK,
                 product_names: VecSanitisedString::from(vec![
                     "GENERIC PARACETAMOL".to_string(),
                     "SPECIAL PARACETAMOL".to_string()

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -528,7 +528,7 @@ mod test {
             metadata_storage_path: "test/path".to_string(),
             product_name: Some("product".to_string()),
             substance_name: vec!["substance".to_string()],
-            territory: TerritoryType::UK,
+            territory: Some(TerritoryType::UK),
             title: "title".to_string(),
             created: None,
             facets: vec!["facet".to_string()],

--- a/medicines/doc-index-updater/src/delete_manager/mod.rs
+++ b/medicines/doc-index-updater/src/delete_manager/mod.rs
@@ -222,6 +222,7 @@ mod test {
     };
     use search_client::models::{
         AzureIndexChangedResult, AzureIndexChangedResults, DocumentType, IndexResult, IndexResults,
+        TerritoryType,
     };
 
     use std::env;
@@ -527,7 +528,7 @@ mod test {
             metadata_storage_path: "test/path".to_string(),
             product_name: Some("product".to_string()),
             substance_name: vec!["substance".to_string()],
-            territory: Some("territory".to_string()),
+            territory: TerritoryType::UK,
             title: "title".to_string(),
             created: None,
             facets: vec!["facet".to_string()],

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -72,7 +72,7 @@ pub struct Document {
     pub products: Vec<String>,
     pub keywords: Option<Vec<String>>,
     pub pl_number: String,
-    pub territory: TerritoryType,
+    pub territory: Option<TerritoryType>,
     pub active_substances: Vec<String>,
     pub file_source: FileSource,
     pub file_path: String,
@@ -134,7 +134,7 @@ pub struct XMLDocument {
     pub products: Products,
     pub keywords: Option<Keywords>,
     pub pl_number: String,
-    pub territory: TerritoryType,
+    pub territory: Option<TerritoryType>,
     pub active_substances: ActiveSubstances,
     pub file_source: FileSource,
     pub file_path: String,
@@ -287,7 +287,7 @@ pub mod test {
             products: vec!["products".to_string()],
             keywords: Some(vec!["keywords".to_string()]),
             pl_number: "pl_number".to_string(),
-            territory: TerritoryType::UK,
+            territory: Some(TerritoryType::UK),
             active_substances: vec!["active_substances".to_string()],
             file_source: FileSource::Sentinel,
             file_path: "file_path".to_string(),
@@ -352,7 +352,7 @@ pub mod test {
         assert_eq!(doc.products.product[0], "This is a product");
         assert_eq!(doc.products.product[1], "This is another product");
         assert_eq!(doc.pl_number, "PL 12345/0010-0001");
-        assert_eq!(doc.territory, TerritoryType::UK);
+        assert_eq!(doc.territory, Some(TerritoryType::UK));
         if let Some(keywords) = doc.keywords {
             assert_eq!(keywords.keyword[0], "Test");
             assert_eq!(keywords.keyword[1], "Test 2");
@@ -404,7 +404,7 @@ pub mod test {
         assert_eq!(doc.products[0], "This is a product");
         assert_eq!(doc.products[1], "This is another product");
         assert_eq!(doc.pl_number, "PL 12345/0010-0001");
-        assert_eq!(doc.territory, TerritoryType::UK);
+        assert_eq!(doc.territory, Some(TerritoryType::UK));
         if let Some(keywords) = doc.keywords {
             assert_eq!(keywords[0], "Test");
             assert_eq!(keywords[1], "Test 2");

--- a/medicines/doc-index-updater/src/models.rs
+++ b/medicines/doc-index-updater/src/models.rs
@@ -2,7 +2,7 @@ use crate::service_bus_client::ProcessMessageError;
 use async_trait::async_trait;
 use regex::Regex;
 use search_client::{
-    models::{DocumentType, IndexResults},
+    models::{DocumentType, IndexResults, TerritoryType},
     AzureSearchClient, Search,
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -72,7 +72,7 @@ pub struct Document {
     pub products: Vec<String>,
     pub keywords: Option<Vec<String>>,
     pub pl_number: String,
-    pub territory: String,
+    pub territory: TerritoryType,
     pub active_substances: Vec<String>,
     pub file_source: FileSource,
     pub file_path: String,
@@ -134,7 +134,7 @@ pub struct XMLDocument {
     pub products: Products,
     pub keywords: Option<Keywords>,
     pub pl_number: String,
-    pub territory: String,
+    pub territory: TerritoryType,
     pub active_substances: ActiveSubstances,
     pub file_source: FileSource,
     pub file_path: String,
@@ -287,7 +287,7 @@ pub mod test {
             products: vec!["products".to_string()],
             keywords: Some(vec!["keywords".to_string()]),
             pl_number: "pl_number".to_string(),
-            territory: "territory".to_string(),
+            territory: TerritoryType::UK,
             active_substances: vec!["active_substances".to_string()],
             file_source: FileSource::Sentinel,
             file_path: "file_path".to_string(),
@@ -352,7 +352,7 @@ pub mod test {
         assert_eq!(doc.products.product[0], "This is a product");
         assert_eq!(doc.products.product[1], "This is another product");
         assert_eq!(doc.pl_number, "PL 12345/0010-0001");
-        assert_eq!(doc.territory, "UK");
+        assert_eq!(doc.territory, TerritoryType::UK);
         if let Some(keywords) = doc.keywords {
             assert_eq!(keywords.keyword[0], "Test");
             assert_eq!(keywords.keyword[1], "Test 2");
@@ -404,7 +404,7 @@ pub mod test {
         assert_eq!(doc.products[0], "This is a product");
         assert_eq!(doc.products[1], "This is another product");
         assert_eq!(doc.pl_number, "PL 12345/0010-0001");
-        assert_eq!(doc.territory, "UK");
+        assert_eq!(doc.territory, TerritoryType::UK);
         if let Some(keywords) = doc.keywords {
             assert_eq!(keywords[0], "Test");
             assert_eq!(keywords[1], "Test 2");

--- a/medicines/doc-index-updater/src/pars_upload.rs
+++ b/medicines/doc-index-updater/src/pars_upload.rs
@@ -6,7 +6,7 @@ use crate::{
     state_manager::{with_state, JobStatusClient, StateManager},
     storage_client::{models::StorageFile, AzureBlobStorage, StorageClient},
 };
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -86,7 +86,7 @@ fn document_from_form_data(storage_file: StorageFile, metadata: BlobMetadata) ->
             None => None,
         },
         pl_number: metadata.pl_number,
-        territory: metadata.territory.to_string(),
+        territory: metadata.territory,
         active_substances: metadata.active_substances.to_vec_string(),
         file_source: FileSource::TemporaryAzureBlobStorage,
         file_path: storage_file.name,
@@ -256,7 +256,6 @@ fn product_form_data_to_blob_metadata(
 
     let title = get_field_as_uppercase_string(&fields, "title")?;
     let pl_number = get_field_as_uppercase_string(&fields, "licence_number")?;
-    let territory = get_field_as_uppercase_string(&fields, "territory")?;
 
     let active_substances = fields
         .iter()
@@ -272,7 +271,7 @@ fn product_form_data_to_blob_metadata(
         DocumentType::Par,
         title,
         pl_number,
-        territory,
+        TerritoryType::UK,
         product_names,
         active_substances,
         author,
@@ -355,7 +354,7 @@ mod tests {
                 doc_type: DocumentType::Par,
                 title: "FEEL GOOD PILLS REALLY STRONG HIGH DOSE THR 12345/1234".into(),
                 pl_number: "THR 12345/1234".into(),
-                territory: "UK".into(),
+                territory: TerritoryType::UK,
                 product_names: vec!["FEEL GOOD PILLS".into()].into(),
                 active_substances: vec!["IBUPROFEN".into(), "TEMAZEPAM".into()].into(),
                 author: "".into(),

--- a/medicines/doc-index-updater/tests/support/document_api.rs
+++ b/medicines/doc-index-updater/tests/support/document_api.rs
@@ -5,7 +5,7 @@ use doc_index_updater::{
     models::{Document, FileSource, JobStatus, JobStatusResponse},
 };
 use reqwest::Error;
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 use uuid::Uuid;
 
 pub fn delete_document(document_id: String) -> Result<JobStatusResponse, Error> {
@@ -35,7 +35,7 @@ pub fn create_document(document_id: String, file_path: String) -> Result<JobStat
         author: "author".to_string(),
         products: vec!["products".to_string()],
         pl_number: "pl_number".to_string(),
-        territory: "territory".to_string(),
+        territory: TerritoryType::UK,
         active_substances: vec!["active_substances".to_string()],
         file_path,
         file_source: FileSource::Sentinel,

--- a/medicines/doc-index-updater/tests/support/document_api.rs
+++ b/medicines/doc-index-updater/tests/support/document_api.rs
@@ -35,7 +35,7 @@ pub fn create_document(document_id: String, file_path: String) -> Result<JobStat
         author: "author".to_string(),
         products: vec!["products".to_string()],
         pl_number: "pl_number".to_string(),
-        territory: TerritoryType::UK,
+        territory: Some(TerritoryType::UK),
         active_substances: vec!["active_substances".to_string()],
         file_path,
         file_source: FileSource::Sentinel,

--- a/medicines/doc-index-updater/tests/support/mod.rs
+++ b/medicines/doc-index-updater/tests/support/mod.rs
@@ -5,7 +5,7 @@ use doc_index_updater::{
     service_bus_client::{DocIndexUpdaterQueue, RetrieveFromQueueError, RetrievedMessage},
 };
 use redis::{self, Value};
-use search_client::models::DocumentType;
+use search_client::models::{DocumentType, TerritoryType};
 use std::{fs, io, process, thread::sleep, time::Duration};
 use tokio_test::block_on;
 use uuid::Uuid;
@@ -188,7 +188,7 @@ pub fn get_test_document() -> Document {
         products: vec!["products".to_string()],
         keywords: Some(vec!["keywords".to_string()]),
         pl_number: "pl_number".to_string(),
-        territory: "territory".to_string(),
+        territory: TerritoryType::UK,
         active_substances: vec!["active_substances".to_string()],
         file_source: FileSource::Sentinel,
         file_path: "file_path".to_string(),

--- a/medicines/doc-index-updater/tests/support/mod.rs
+++ b/medicines/doc-index-updater/tests/support/mod.rs
@@ -188,7 +188,7 @@ pub fn get_test_document() -> Document {
         products: vec!["products".to_string()],
         keywords: Some(vec!["keywords".to_string()]),
         pl_number: "pl_number".to_string(),
-        territory: TerritoryType::UK,
+        territory: Some(TerritoryType::UK),
         active_substances: vec!["active_substances".to_string()],
         file_source: FileSource::Sentinel,
         file_path: "file_path".to_string(),

--- a/medicines/search-client/src/document_type.rs
+++ b/medicines/search-client/src/document_type.rs
@@ -55,59 +55,6 @@ impl Display for DocumentType {
     }
 }
 
-#[cfg_attr(
-    feature = "graphql",
-    async_graphql::Enum(desc = "Territory type (UK/GB/NI)"),
-    derive(Serialize, Deserialize, Debug, Ord, PartialOrd)
-)]
-#[cfg_attr(
-    not(feature = "graphql"),
-    derive(
-        Serialize,
-        Deserialize,
-        Debug,
-        Copy,
-        Clone,
-        Eq,
-        PartialEq,
-        Ord,
-        PartialOrd
-    )
-)]
-pub enum TerritoryType {
-    #[serde(alias = "Uk")]
-    UK,
-    #[serde(alias = "Gb")]
-    GB,
-    #[serde(alias = "Ni")]
-    NI,
-}
-
-impl FromStr for TerritoryType {
-    type Err = TerritoryTypeParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_uppercase().as_str() {
-            "UK" => Ok(Self::UK),
-            "GB" => Ok(Self::GB),
-            "NI" => Ok(Self::NI),
-            _ => Err(TerritoryTypeParseError {
-                source: s.to_string(),
-            }),
-        }
-    }
-}
-
-impl Display for TerritoryType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TerritoryType::UK => write!(f, "UK"),
-            TerritoryType::GB => write!(f, "GB"),
-            TerritoryType::NI => write!(f, "NI"),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct DocTypeParseError {
     source: String,
@@ -124,23 +71,6 @@ impl Display for DocTypeParseError {
 }
 
 impl std::error::Error for DocTypeParseError {}
-
-#[derive(Debug, Clone)]
-pub struct TerritoryTypeParseError {
-    source: String,
-}
-
-impl Display for TerritoryTypeParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Could not parse TerritoryType from string: {}",
-            self.source
-        )
-    }
-}
-
-impl std::error::Error for TerritoryTypeParseError {}
 
 #[cfg(test)]
 mod tests {
@@ -170,33 +100,6 @@ mod tests {
         use pretty_assertions::assert_eq;
 
         let from_str: DocumentType = serde_json::from_str(input).unwrap();
-
-        assert_eq!(from_str, expected);
-    }
-
-    #[test_case("UK")]
-    #[test_case("GB")]
-    #[test_case("NI")]
-    fn parses_territory_and_formats_to_a_string(territory_type: &str) {
-        use pretty_assertions::assert_eq;
-
-        let from_str: TerritoryType = territory_type.parse().unwrap();
-
-        let as_str = from_str.to_string();
-
-        assert_eq!(territory_type, as_str);
-    }
-
-    #[test_case("\"UK\"", TerritoryType::UK; "uk uppercase")]
-    #[test_case("\"Uk\"", TerritoryType::UK; "uk titlecase")]
-    #[test_case("\"GB\"", TerritoryType::GB; "gb uppercase")]
-    #[test_case("\"Gb\"", TerritoryType::GB; "gb titlecase")]
-    #[test_case("\"NI\"", TerritoryType::NI; "ni uppercase")]
-    #[test_case("\"Ni\"", TerritoryType::NI; "ni titlecase")]
-    fn deserializes_territory_cases_insensitively(input: &str, expected: TerritoryType) {
-        use pretty_assertions::assert_eq;
-
-        let from_str: TerritoryType = serde_json::from_str(input).unwrap();
 
         assert_eq!(from_str, expected);
     }

--- a/medicines/search-client/src/document_type.rs
+++ b/medicines/search-client/src/document_type.rs
@@ -55,6 +55,59 @@ impl Display for DocumentType {
     }
 }
 
+#[cfg_attr(
+    feature = "graphql",
+    async_graphql::Enum(desc = "Territory type (UK/GB/NI)"),
+    derive(Serialize, Deserialize, Debug, Ord, PartialOrd)
+)]
+#[cfg_attr(
+    not(feature = "graphql"),
+    derive(
+        Serialize,
+        Deserialize,
+        Debug,
+        Copy,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd
+    )
+)]
+pub enum TerritoryType {
+    #[serde(alias = "Uk")]
+    UK,
+    #[serde(alias = "Gb")]
+    GB,
+    #[serde(alias = "Ni")]
+    NI,
+}
+
+impl FromStr for TerritoryType {
+    type Err = TerritoryTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "UK" => Ok(Self::UK),
+            "GB" => Ok(Self::GB),
+            "NI" => Ok(Self::NI),
+            _ => Err(TerritoryTypeParseError {
+                source: s.to_string(),
+            }),
+        }
+    }
+}
+
+impl Display for TerritoryType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TerritoryType::UK => write!(f, "UK"),
+            TerritoryType::GB => write!(f, "GB"),
+            TerritoryType::NI => write!(f, "NI"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DocTypeParseError {
     source: String,
@@ -72,6 +125,23 @@ impl Display for DocTypeParseError {
 
 impl std::error::Error for DocTypeParseError {}
 
+#[derive(Debug, Clone)]
+pub struct TerritoryTypeParseError {
+    source: String,
+}
+
+impl Display for TerritoryTypeParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Could not parse TerritoryType from string: {}",
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for TerritoryTypeParseError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,7 +150,7 @@ mod tests {
     #[test_case("Spc")]
     #[test_case("Pil")]
     #[test_case("Par")]
-    fn parses_and_formats_to_a_string(doc_type: &str) {
+    fn parses_document_and_formats_to_a_string(doc_type: &str) {
         use pretty_assertions::assert_eq;
 
         let from_str: DocumentType = doc_type.parse().unwrap();
@@ -96,10 +166,37 @@ mod tests {
     #[test_case("\"Pil\"", DocumentType::Pil; "pil titlecase")]
     #[test_case("\"PAR\"", DocumentType::Par; "par uppercase")]
     #[test_case("\"Par\"", DocumentType::Par; "par titlecase")]
-    fn deserializes_cases_insensitively(input: &str, expected: DocumentType) {
+    fn deserializes_document_cases_insensitively(input: &str, expected: DocumentType) {
         use pretty_assertions::assert_eq;
 
         let from_str: DocumentType = serde_json::from_str(input).unwrap();
+
+        assert_eq!(from_str, expected);
+    }
+
+    #[test_case("UK")]
+    #[test_case("GB")]
+    #[test_case("NI")]
+    fn parses_territory_and_formats_to_a_string(territory_type: &str) {
+        use pretty_assertions::assert_eq;
+
+        let from_str: TerritoryType = territory_type.parse().unwrap();
+
+        let as_str = from_str.to_string();
+
+        assert_eq!(territory_type, as_str);
+    }
+
+    #[test_case("\"UK\"", TerritoryType::UK; "uk uppercase")]
+    #[test_case("\"Uk\"", TerritoryType::UK; "uk titlecase")]
+    #[test_case("\"GB\"", TerritoryType::GB; "gb uppercase")]
+    #[test_case("\"Gb\"", TerritoryType::GB; "gb titlecase")]
+    #[test_case("\"NI\"", TerritoryType::NI; "ni uppercase")]
+    #[test_case("\"Ni\"", TerritoryType::NI; "ni titlecase")]
+    fn deserializes_territory_cases_insensitively(input: &str, expected: TerritoryType) {
+        use pretty_assertions::assert_eq;
+
+        let from_str: TerritoryType = serde_json::from_str(input).unwrap();
 
         assert_eq!(from_str, expected);
     }

--- a/medicines/search-client/src/lib.rs
+++ b/medicines/search-client/src/lib.rs
@@ -1,6 +1,7 @@
 mod document_type;
 pub mod models;
 mod query_normalizer;
+mod territory_type;
 
 #[macro_use]
 extern crate lazy_static;

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -1,4 +1,6 @@
-pub use crate::document_type::{DocTypeParseError, DocumentType};
+pub use crate::document_type::{
+    DocTypeParseError, DocumentType, TerritoryType, TerritoryTypeParseError,
+};
 use chrono::{SecondsFormat, Utc};
 use core::fmt::Debug;
 use serde_derive::{Deserialize, Serialize};
@@ -12,6 +14,7 @@ pub struct AzureHighlight {
 #[derive(Clone, Debug, Deserialize)]
 pub struct IndexResult {
     pub doc_type: DocumentType,
+    pub territory: Option<TerritoryType>,
     pub file_name: String,
     pub metadata_storage_name: String,
     pub metadata_storage_path: String,
@@ -29,7 +32,6 @@ pub struct IndexResult {
     pub score: f32,
     #[serde(rename = "@search.highlights")]
     pub highlights: Option<AzureHighlight>,
-    pub territory: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,7 +134,7 @@ pub struct IndexEntry {
     pub keywords: String,
     pub title: String,
     pub pl_number: Vec<String>,
-    pub territory: String,
+    pub territory: TerritoryType,
     pub file_name: String,
     pub metadata_storage_content_type: String,
     pub metadata_storage_size: usize,
@@ -171,14 +173,14 @@ impl From<IndexResult> for IndexEntry {
                 Some(k) => k,
                 None => "".to_owned(),
             },
-            territory: match res.territory {
-                Some(t) => t,
-                None => "".to_owned(),
-            },
             title: res.title,
             pl_number: vec![],
             file_name: res.file_name,
             doc_type: res.doc_type,
+            territory: match res.territory {
+                Some(t) => t,
+                None => TerritoryType::UK,
+            },
             suggestions: res.suggestions,
             substance_name: res.substance_name,
             facets: res.facets,

--- a/medicines/search-client/src/models.rs
+++ b/medicines/search-client/src/models.rs
@@ -1,6 +1,5 @@
-pub use crate::document_type::{
-    DocTypeParseError, DocumentType, TerritoryType, TerritoryTypeParseError,
-};
+pub use crate::document_type::{DocTypeParseError, DocumentType};
+pub use crate::territory_type::{TerritoryType, TerritoryTypeParseError};
 use chrono::{SecondsFormat, Utc};
 use core::fmt::Debug;
 use serde_derive::{Deserialize, Serialize};
@@ -134,7 +133,7 @@ pub struct IndexEntry {
     pub keywords: String,
     pub title: String,
     pub pl_number: Vec<String>,
-    pub territory: TerritoryType,
+    pub territory: Option<TerritoryType>,
     pub file_name: String,
     pub metadata_storage_content_type: String,
     pub metadata_storage_size: usize,
@@ -177,10 +176,7 @@ impl From<IndexResult> for IndexEntry {
             pl_number: vec![],
             file_name: res.file_name,
             doc_type: res.doc_type,
-            territory: match res.territory {
-                Some(t) => t,
-                None => TerritoryType::UK,
-            },
+            territory: res.territory,
             suggestions: res.suggestions,
             substance_name: res.substance_name,
             facets: res.facets,

--- a/medicines/search-client/src/territory_type.rs
+++ b/medicines/search-client/src/territory_type.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+#[cfg_attr(
+    feature = "graphql",
+    async_graphql::Enum(desc = "Territory type (UK/GB/NI)"),
+    derive(Serialize, Deserialize, Debug, Ord, PartialOrd)
+)]
+#[cfg_attr(
+    not(feature = "graphql"),
+    derive(
+        Serialize,
+        Deserialize,
+        Debug,
+        Copy,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd
+    )
+)]
+pub enum TerritoryType {
+    #[serde(alias = "Uk", alias = "uk")]
+    UK,
+    #[serde(alias = "Gb", alias = "gb")]
+    GB,
+    #[serde(alias = "Ni", alias = "ni")]
+    NI,
+}
+
+impl FromStr for TerritoryType {
+    type Err = TerritoryTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "UK" => Ok(Self::UK),
+            "GB" => Ok(Self::GB),
+            "NI" => Ok(Self::NI),
+            _ => Err(TerritoryTypeParseError {
+                source: s.to_string(),
+            }),
+        }
+    }
+}
+
+impl Display for TerritoryType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TerritoryType::UK => write!(f, "UK"),
+            TerritoryType::GB => write!(f, "GB"),
+            TerritoryType::NI => write!(f, "NI"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TerritoryTypeParseError {
+    source: String,
+}
+
+impl Display for TerritoryTypeParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Could not parse TerritoryType from string: {}",
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for TerritoryTypeParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("UK")]
+    #[test_case("GB")]
+    #[test_case("NI")]
+    fn parses_territory_and_formats_to_a_string(territory_type: &str) {
+        use pretty_assertions::assert_eq;
+
+        let from_str: TerritoryType = territory_type.parse().unwrap();
+
+        let as_str = from_str.to_string();
+
+        assert_eq!(territory_type, as_str);
+    }
+
+    #[test_case("\"UK\"", TerritoryType::UK; "uk uppercase")]
+    #[test_case("\"Uk\"", TerritoryType::UK; "uk titlecase")]
+    #[test_case("\"uk\"", TerritoryType::UK; "uk lowercase")]
+    #[test_case("\"GB\"", TerritoryType::GB; "gb uppercase")]
+    #[test_case("\"Gb\"", TerritoryType::GB; "gb titlecase")]
+    #[test_case("\"gb\"", TerritoryType::GB; "gb lowercase")]
+    #[test_case("\"NI\"", TerritoryType::NI; "ni uppercase")]
+    #[test_case("\"Ni\"", TerritoryType::NI; "ni titlecase")]
+    #[test_case("\"ni\"", TerritoryType::NI; "ni lowercase")]
+    fn deserializes_territory_cases_insensitively(input: &str, expected: TerritoryType) {
+        use pretty_assertions::assert_eq;
+
+        let from_str: TerritoryType = serde_json::from_str(input).unwrap();
+
+        assert_eq!(from_str, expected);
+    }
+}

--- a/medicines/web/src/pages/product/index.tsx
+++ b/medicines/web/src/pages/product/index.tsx
@@ -78,7 +78,7 @@ const App: NextPage = () => {
     setErrorFetchingResults(false);
 
     getLoader(useGraphQl)
-      .load({ name: product, page, pageSize, docTypes })
+      .load({ name: product, page, pageSize, docTypes, territoryTypes })
       .then(({ documents, count }) => {
         setDocuments(documents);
         setCount(count);
@@ -91,7 +91,7 @@ const App: NextPage = () => {
       pageNo: page,
       docTypes: queryStringFromTypes(docTypes),
     });
-  }, [queryQS, pageQS, disclaimerQS, docQS]);
+  }, [queryQS, pageQS, disclaimerQS, docQS, territoryQS]);
 
   useEffect(() => {
     if (window) {

--- a/medicines/web/src/pages/search/index.tsx
+++ b/medicines/web/src/pages/search/index.tsx
@@ -77,7 +77,7 @@ const App: NextPage = (props) => {
     setErrorFetchingResults(false);
 
     getLoader(useGraphQl)
-      .load({ searchTerm: query, page, pageSize, docTypes })
+      .load({ searchTerm: query, page, pageSize, docTypes, territoryTypes })
       .then(({ documents, count }) => {
         setDocuments(documents);
         setCount(count);
@@ -90,7 +90,7 @@ const App: NextPage = (props) => {
       pageNo: page,
       docTypes: queryStringFromTypes(docTypes),
     });
-  }, [queryQS, pageQS, disclaimerQS, docQS]);
+  }, [queryQS, pageQS, disclaimerQS, docQS, territoryQS]);
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/medicines/web/src/services/loaders/products/product-loader.ts
+++ b/medicines/web/src/services/loaders/products/product-loader.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 import { IDocument, IDocuments } from '../../../model/document';
-import { DocType, docSearch } from '../../azure-search';
+import { DocType, TerritoryType, docSearch } from '../../azure-search';
 import { graphqlRequest } from '../../graphql';
 import { convertResults } from '../../azure-results-converter';
 
@@ -59,11 +59,11 @@ interface IDocumentResponse {
 }
 
 const query = `
-query ($productName: String!, $first: Int, $skip: Int, $docTypes: [DocumentType!]) {
+query ($productName: String!, $first: Int, $skip: Int, $docTypes: [DocumentType!], $territoryTypes: [TerritoryType!]) {
   products {
     product(name: $productName) {
       name
-      documents(first: $first, offset: $skip, documentTypes: $docTypes) {
+      documents(first: $first, offset: $skip, documentTypes: $docTypes, territoryTypes: $territoryTypes) {
         count: totalCount
         edges {
           node {
@@ -125,12 +125,14 @@ const getDocumentsForProduct = async ({
   page,
   pageSize,
   docTypes,
+  territoryTypes,
 }: IProductInfo) => {
   const variables = {
     productName: name,
     first: pageSize,
     skip: calculatePageStartRecord(page, pageSize),
     docTypes: docTypes.map((s) => s.toUpperCase()),
+    territoryTypes: territoryTypes.map((t) => t.toUpperCase()),
   };
 
   return graphqlRequest<IProductResponse, typeof variables>({
@@ -144,6 +146,7 @@ interface IProductInfo {
   page: number;
   pageSize: number;
   docTypes: DocType[];
+  territoryTypes: TerritoryType[];
 }
 
 const calculatePageStartRecord = (page: number, pageSize: number): number =>

--- a/medicines/web/src/services/loaders/products/search-results-loader.ts
+++ b/medicines/web/src/services/loaders/products/search-results-loader.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 import { IDocument, IDocuments } from '../../../model/document';
-import { DocType, docSearch } from '../../azure-search';
+import { DocType, TerritoryType, docSearch } from '../../azure-search';
 import { graphqlRequest } from '../../graphql';
 import { convertResults } from '../../azure-results-converter';
 
@@ -38,6 +38,7 @@ interface ISearchInfo {
   page: number;
   pageSize: number;
   docTypes: DocType[];
+  territoryTypes: TerritoryType[];
 }
 
 interface IEdge {
@@ -62,9 +63,9 @@ interface IDocumentResponse {
 }
 
 const query = `
-query($searchTerm: String, $first: Int, $after: String, $documentTypes: [DocumentType!]) {
+query($searchTerm: String, $first: Int, $after: String, $documentTypes: [DocumentType!], $territoryTypes: [TerritoryType!]) {
   products {
-    documents(search: $searchTerm, first: $first, after: $after, documentTypes: $documentTypes) {
+    documents(search: $searchTerm, first: $first, after: $after, documentTypes: $documentTypes, territoryTypes: $territoryTypes) {
       count: totalCount
       edges {
         cursor
@@ -116,12 +117,14 @@ const getDocumentsForSearch = async ({
   page,
   pageSize,
   docTypes,
+  territoryTypes,
 }: ISearchInfo) => {
   const variables = {
     searchTerm,
     first: pageSize,
     after: makeCursor(page, pageSize),
     documentTypes: docTypes.map((s) => s.toUpperCase()),
+    territoryTypes: territoryTypes.map((t) => t.toUpperCase()),
   };
   const { data } = await graphqlRequest<ISearchResponse, typeof variables>({
     query,


### PR DESCRIPTION
This PR links together the prior changes from #1124 and #1125 so that we can now filter territories in the UI, have the backend parse our new GraphQL query, then query and filter in our Azure search service on our newly uploaded territory field.

Below is a short summary of what each commit does in this PR.

---

### Read territory as TerritoryType not String

I originally modified `doc-index-updater` with the `territory` field as
a String, much like `pl_number`.

After working through the project more, I've found that the `territory`
field is more suited to being an Enum, like `doc_type`. This gives us
both the safety that we're only parsing certain values within this
field, as well as allowing de/serialisation restrictions when indexing.

### Read and parse territoryType in graphql query 

This commit adds the functionality to filter by territoryType when
receiving this filter over graphql.

We're currently only filtering by territory, not by pl_number prefix.

### Connect territory filtering from UI to backend

This commit sends the territory filters to the backend when using the
graphql query mode. This allows us to filter by the territory field in
the metadata.

### Change territory to be read as TerritoryType 
This commit also adds better error handling when receiving an index
update. We now error on incorrect TerritoryTypes the same way we error
on incorrect DocumentTypes.
