### PR TITLE
Derive territory on import

### DIFF
--- a/medicines/doc-index-updater/src/create_manager/models.rs
+++ b/medicines/doc-index-updater/src/create_manager/models.rs
@@ -28,6 +28,7 @@ fn derive_territory(pl_number: &str, territory: Option<TerritoryType>) -> Option
             .as_ref()
         {
             "PL" => Some(TerritoryType::UK),
+            "PLPI" => Some(TerritoryType::UK),
             "PLNI" => Some(TerritoryType::NI),
             "PLGB" => Some(TerritoryType::GB),
             _ => None,
@@ -371,10 +372,12 @@ mod test {
     }
 
     #[test_case(None, "PL123456", Some(TerritoryType::UK))]
+    #[test_case(None, "PLPI123456", Some(TerritoryType::UK))]
     #[test_case(None, "PLNI123456", Some(TerritoryType::NI))]
     #[test_case(None, "PLGB123456", Some(TerritoryType::GB))]
     #[test_case(Some(TerritoryType::UK), "PLNI123456", Some(TerritoryType::UK))]
     #[test_case(Some(TerritoryType::NI), "PL123456", Some(TerritoryType::NI))]
+    #[test_case(Some(TerritoryType::NI), "PLPI123456", Some(TerritoryType::NI))]
     #[test_case(Some(TerritoryType::GB), "PLNI123456", Some(TerritoryType::GB))]
     fn test_derive_territory(
         territory: Option<TerritoryType>,

--- a/medicines/search/src/main.rs
+++ b/medicines/search/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
         ("delete_datasource", Some(_m)) => datasource::delete_datasource()
             .await
             .expect("Failed to delete datasource"),
-        ("create_index", Some(m)) => {
+        ("create_or_update_index", Some(m)) => {
             let index_definition = m.value_of("index").unwrap_or("default");
             index::create_or_update_index(index_definition)
                 .await


### PR DESCRIPTION
Azure's search doesn't allow us to prefix search the `pl_number` field.
Therefore in order to search for a territory through the `pl_number`
prefix, we derive the `territory` from the `pl_number` during import,
but only if a `territory` is not already given.

The basic rules are:

    If territory is present in document:
      return territory
    Else:
      If pl_number prefix for known territory type:
        return matching territory type
      Else:
        return None