### PR TITLE
Add territory filtering with Azure search in UI

### DIFF
--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -228,7 +228,13 @@ const createFilter = (filters: ISearchFilters) => {
   if (filters.territoryType && filters.territoryType.length > 0) {
     const territoryTypeFilters = [];
     for (const territoryType of filters.territoryType) {
-      territoryTypeFilters.push(`territory eq '${territoryType}'`);
+      if (territoryType === TerritoryType.UK) {
+        territoryTypeFilters.push(
+          `territory eq '${territoryType}' or territory eq null`,
+        );
+      } else {
+        territoryTypeFilters.push(`territory eq '${territoryType}'`);
+      }
     }
     filterParams.push('(' + territoryTypeFilters.join(' or ') + ')');
   }

--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -153,6 +153,7 @@ const getJson = async (url: string): Promise<any> => {
 
 export interface ISearchFilters {
   docType?: DocType[];
+  territoryType?: TerritoryType[];
   substanceName?: string;
   productName?: string;
   sortOrder: string;
@@ -223,6 +224,13 @@ const createFilter = (filters: ISearchFilters) => {
       docTypeFilters.push(`doc_type eq '${docType}'`);
     }
     filterParams.push('(' + docTypeFilters.join(' or ') + ')');
+  }
+  if (filters.territoryType && filters.territoryType.length > 0) {
+    const territoryTypeFilters = [];
+    for (const territoryType of filters.territoryType) {
+      territoryTypeFilters.push(`territory eq '${territoryType}'`);
+    }
+    filterParams.push('(' + territoryTypeFilters.join(' or ') + ')');
   }
   if (filters.substanceName) {
     filterParams.push(

--- a/medicines/web/src/services/loaders/products/product-loader.ts
+++ b/medicines/web/src/services/loaders/products/product-loader.ts
@@ -20,6 +20,7 @@ export const azureProductsLoader = new DataLoader<IProductInfo, IDocuments>(
           pageSize: searchParameters.pageSize,
           filters: {
             docType: searchParameters.docTypes,
+            territoryType: searchParameters.territoryTypes,
             sortOrder: 'a-z',
             productName: searchParameters.name,
           },

--- a/medicines/web/src/services/loaders/products/search-results-loader.ts
+++ b/medicines/web/src/services/loaders/products/search-results-loader.ts
@@ -20,6 +20,7 @@ export const azureSearchLoader = new DataLoader<ISearchInfo, IDocuments>(
           pageSize: searchParameters.pageSize,
           filters: {
             docType: searchParameters.docTypes,
+            territoryType: searchParameters.territoryTypes,
             sortOrder: 'a-z',
           },
         });


### PR DESCRIPTION
The Next.js frontend can toggle search between an intermediary graphQL
server and directly querying the Azure search service.

This commit adds the capability for territory filters to be applied when
using the Azure search service.