### PR TITLE
Include territory=null in UK filter

### DIFF
--- a/medicines/api/src/query_objects/products/document.rs
+++ b/medicines/api/src/query_objects/products/document.rs
@@ -191,7 +191,14 @@ fn build_territory_types_filter(territory_types: Vec<TerritoryType>) -> Option<S
         "({})",
         territory_types
             .into_iter()
-            .map(|territory_type| format!("territory eq '{}'", territory_type))
+            .map(|territory_type| {
+                match territory_type {
+                    TerritoryType::UK => {
+                        format!("territory eq '{}' or territory eq null", territory_type)
+                    }
+                    _ => format!("territory eq '{}'", territory_type),
+                }
+            })
             .collect::<Vec<_>>()
             .join(" or ")
     ))
@@ -323,13 +330,13 @@ mod test {
         Some(vec![DocumentType::Spc, DocumentType::Pil,DocumentType::Par,]),
         Some(vec![TerritoryType::UK, TerritoryType::GB, TerritoryType::NI,]),
         Some("IBUPROFEN 100MG CAPLETS"),
-        Some("((product_name eq 'IBUPROFEN 100MG CAPLETS') and (doc_type eq 'Spc' or doc_type eq 'Pil' or doc_type eq 'Par') and (territory eq 'UK' or territory eq 'GB' or territory eq 'NI'))")
+        Some("((product_name eq 'IBUPROFEN 100MG CAPLETS') and (doc_type eq 'Spc' or doc_type eq 'Pil' or doc_type eq 'Par') and (territory eq 'UK' or territory eq null or territory eq 'GB' or territory eq 'NI'))")
     )]
     #[test_case(
         Some(vec![DocumentType::Spc,  DocumentType::Pil,DocumentType::Par,]),
         Some(vec![TerritoryType::UK, TerritoryType::GB, TerritoryType::NI,]),
         None,
-        Some("((doc_type eq 'Spc' or doc_type eq 'Pil' or doc_type eq 'Par') and (territory eq 'UK' or territory eq 'GB' or territory eq 'NI'))")
+        Some("((doc_type eq 'Spc' or doc_type eq 'Pil' or doc_type eq 'Par') and (territory eq 'UK' or territory eq null or territory eq 'GB' or territory eq 'NI'))")
     )]
     #[test_case(
         None,


### PR DESCRIPTION
We want to include items which have a territory as null in the UK
filter. This is so that we don't have to re-import any non PLGB/PLNI
records.