### PR TITLE
Fix GB & NI territory filtering

### DIFF
--- a/medicines/web/src/services/azure-search.ts
+++ b/medicines/web/src/services/azure-search.ts
@@ -228,14 +228,13 @@ const createFilter = (filters: ISearchFilters) => {
   if (filters.territoryType && filters.territoryType.length > 0) {
     const territoryTypeFilters = [];
     for (const territoryType of filters.territoryType) {
-      if (territoryType === TerritoryType.UK) {
-        territoryTypeFilters.push(
-          `territory eq '${territoryType}' or territory eq null`,
-        );
-      } else {
+      if ([TerritoryType.GB, TerritoryType.NI].includes(territoryType)) {
         territoryTypeFilters.push(`territory eq '${territoryType}'`);
       }
     }
+    territoryTypeFilters.push("territory eq 'UK'");
+    territoryTypeFilters.push('territory eq null');
+
     filterParams.push('(' + territoryTypeFilters.join(' or ') + ')');
   }
   if (filters.substanceName) {


### PR DESCRIPTION
For GB and NI territories we were filtering so that it would only return
GB and NI territory results respectively. This has now been changed so
that for GB we were return GB AND UK results, and for NI we return NI
AND UK results.

This commit updates these queries in both the graphQL API, as well a
the direct Azure search.