### PR TITLE
Fix docker-push command in Makefiles

### DIFF
--- a/medicines/api/Makefile
+++ b/medicines/api/Makefile
@@ -60,7 +60,6 @@ docker-pull: ## Pull Docker image
 
 .PHONY: docker-push
 docker-push: ## Push Docker image
-	docker push $(image)
 	docker push $(image):$(tag)
 
 .PHONY: docker-retag

--- a/medicines/doc-index-updater/Makefile
+++ b/medicines/doc-index-updater/Makefile
@@ -84,7 +84,6 @@ docker-pull: ## Pull Docker image
 
 .PHONY: docker-push
 docker-push: ## Push Docker image
-	docker push $(image)
 	docker push $(image):$(tag)
 
 .PHONY: docker-retag


### PR DESCRIPTION
The default `docker push` behaviour pushes with a tag of latest. We want
to push explicitly with our specified tag only.